### PR TITLE
Fix Discriminant on 32-bit platforms

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -28,6 +28,9 @@ jobs:
         with:
           tinygo-version: '0.30.0'
 
+      - name: Set up Wasmtime
+        uses: bytecodealliance/actions/wasmtime/setup@v1
+
       - name: Vet Go code
         run: go vet ./...
 
@@ -41,6 +44,9 @@ jobs:
 
       - name: Test with TinyGo
         run: tinygo test -v ./...
+
+      - name: Test with TinyGo + WASI
+        run: tinygo test -v -target=wasi -stack-size=128KB ./...
 
       - name: Verify repo is unchanged
         run: git diff --exit-code HEAD

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -29,7 +29,7 @@ jobs:
           tinygo-version: '0.30.0'
 
       - name: Set up Wasmtime
-        uses: bytecodealliance/actions/wasmtime/setup@v1
+        uses: bytecodealliance/actions/wasmtime/setup@v0.0.1
 
       - name: Vet Go code
         run: go vet ./...

--- a/wit/abi.go
+++ b/wit/abi.go
@@ -7,8 +7,11 @@ func Align(ptr, align uintptr) uintptr {
 	return ((ptr + align - 1) / align) * align
 }
 
-// Discriminant returns the smallest integer type that can represent 0...n.
-func Discriminant(n int) Type {
+// Discriminant returns the smallest WIT integer type that can represent 0...n.
+// Used by the [Canonical ABI] for [Variant] types.
+//
+// Canonical ABI: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#alignment
+func Discriminant(n uint32) Type {
 	switch {
 	case n <= 1<<8:
 		return U8{}

--- a/wit/abi_test.go
+++ b/wit/abi_test.go
@@ -37,7 +37,7 @@ func TestAlign(t *testing.T) {
 
 func TestDiscriminant(t *testing.T) {
 	tests := []struct {
-		n    int
+		n    uint32
 		want Type
 	}{
 		{0, U8{}}, {1, U8{}}, {5, U8{}}, {8, U8{}}, {255, U8{}}, {256, U8{}},

--- a/wit/resolve.go
+++ b/wit/resolve.go
@@ -327,7 +327,7 @@ type Variant struct {
 //
 // [ABI byte size]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#size
 func (v *Variant) Size() uintptr {
-	s := Discriminant(len(v.Cases)).Size()
+	s := Discriminant(uint32(len(v.Cases))).Size()
 	s = Align(s, v.maxCaseAlign())
 	s += v.maxCaseSize()
 	return Align(s, v.Align())
@@ -337,7 +337,7 @@ func (v *Variant) Size() uintptr {
 //
 // [ABI byte alignment]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#alignment
 func (v *Variant) Align() uintptr {
-	return max(Discriminant(len(v.Cases)).Align(), v.maxCaseAlign())
+	return max(Discriminant(uint32(len(v.Cases))).Align(), v.maxCaseAlign())
 }
 
 func (v *Variant) maxCaseSize() uintptr {


### PR DESCRIPTION
Fixes u32 overflow in test:

```sh
$ tinygo test -target=wasi ./...
go: downloading github.com/cpuguy83/go-md2man/v2 v2.0.3
go: downloading github.com/mattn/go-isatty v0.0.20
?   	github.com/ydnar/wasm-tools-go/cmd/wit-bindgen-go	[no test files]
?   	github.com/ydnar/wasm-tools-go/cmd/wit-bindgen-go/cmd/print	[no test files]
?   	github.com/ydnar/wasm-tools-go/cmd/wit-bindgen-go/cmd/syntax	[no test files]
?   	github.com/ydnar/wasm-tools-go/internal/callerfs	[no test files]
?   	github.com/ydnar/wasm-tools-go/internal/codec	[no test files]
?   	github.com/ydnar/wasm-tools-go/internal/codec/json	[no test files]
?   	github.com/ydnar/wasm-tools-go/internal/witcli	[no test files]
FAIL	github.com/ydnar/wasm-tools-go/wit	0.000s
# github.com/ydnar/wasm-tools-go/wit
wit/abi_test.go:45:62: cannot use math.MaxUint32 (untyped int constant 4294967295) as int value in struct literal (overflows)
```