### PR TITLE
WIT resource support

### DIFF
--- a/testdata/examples/resource-in-world.wit
+++ b/testdata/examples/resource-in-world.wit
@@ -8,5 +8,5 @@ interface types {
 }
 
 world imports {
-    import types
+    import types;
 }

--- a/testdata/examples/resource-in-world.wit
+++ b/testdata/examples/resource-in-world.wit
@@ -1,0 +1,12 @@
+package examples:resources-in-world
+
+interface types {
+    resource foo {
+        foo: func();
+        bar: func(arg: u32);
+    }
+}
+
+world imports {
+    import types
+}

--- a/testdata/examples/resource-in-world.wit.json
+++ b/testdata/examples/resource-in-world.wit.json
@@ -1,0 +1,84 @@
+{
+  "worlds": [
+    {
+      "name": "imports",
+      "imports": {
+        "interface-0": {
+          "interface": 0
+        }
+      },
+      "exports": {},
+      "package": 0
+    }
+  ],
+  "interfaces": [
+    {
+      "name": "types",
+      "types": {
+        "foo": 0
+      },
+      "functions": {
+        "[method]foo.foo": {
+          "name": "[method]foo.foo",
+          "kind": {
+            "method": 0
+          },
+          "params": [
+            {
+              "name": "self",
+              "type": 1
+            }
+          ],
+          "results": []
+        },
+        "[method]foo.bar": {
+          "name": "[method]foo.bar",
+          "kind": {
+            "method": 0
+          },
+          "params": [
+            {
+              "name": "self",
+              "type": 1
+            },
+            {
+              "name": "arg",
+              "type": "u32"
+            }
+          ],
+          "results": []
+        }
+      },
+      "package": 0
+    }
+  ],
+  "types": [
+    {
+      "name": "foo",
+      "kind": "resource",
+      "owner": {
+        "interface": 0
+      }
+    },
+    {
+      "name": null,
+      "kind": {
+        "handle": {
+          "borrow": 0
+        }
+      },
+      "owner": null
+    }
+  ],
+  "packages": [
+    {
+      "name": "examples:resources-in-world",
+      "interfaces": {
+        "types": 0
+      },
+      "worlds": {
+        "imports": 0
+      }
+    }
+  ]
+}

--- a/testdata/examples/resource-in-world.wit.json.golden
+++ b/testdata/examples/resource-in-world.wit.json.golden
@@ -1,0 +1,319 @@
+&wit.Resolve{
+    Worlds: {
+        &wit.World{
+            Name:    "imports",
+            Imports: {
+                "interface-0": &wit.Interface{
+                    Name:     &"types",
+                    TypeDefs: {
+                        "foo": &wit.TypeDef{
+                            Name:       &"foo",
+                            Kind:       &wit.Resource{},
+                            Owner:      &wit.Interface{(CYCLIC REFERENCE)},
+                            Docs:       wit.Docs{},
+                            _worldItem: wit._worldItem{},
+                            _type:      wit._type{},
+                        },
+                    },
+                    Functions: {
+                        "[method]foo.bar": &wit.Function{
+                            Name: "[method]foo.bar",
+                            Kind: &wit.Method{
+                                Type:          &wit.TypeDef{(CYCLIC REFERENCE)},
+                                _functionKind: wit._functionKind{},
+                            },
+                            Params: {
+                                {
+                                    Name: "self",
+                                    Type: &wit.TypeDef{
+                                        Name: (*string)(nil),
+                                        Kind: &wit.BorrowedHandle{
+                                            Type:    &wit.TypeDef{(CYCLIC REFERENCE)},
+                                            _handle: wit._handle{},
+                                        },
+                                        Owner:      nil,
+                                        Docs:       wit.Docs{},
+                                        _worldItem: wit._worldItem{},
+                                        _type:      wit._type{},
+                                    },
+                                },
+                                {
+                                    Name: "arg",
+                                    Type: wit.U32{},
+                                },
+                            },
+                            Results:    nil,
+                            Docs:       wit.Docs{},
+                            _worldItem: wit._worldItem{},
+                        },
+                        "[method]foo.foo": &wit.Function{
+                            Name: "[method]foo.foo",
+                            Kind: &wit.Method{
+                                Type:          &wit.TypeDef{(CYCLIC REFERENCE)},
+                                _functionKind: wit._functionKind{},
+                            },
+                            Params: {
+                                {
+                                    Name: "self",
+                                    Type: &wit.TypeDef{
+                                        Name: (*string)(nil),
+                                        Kind: &wit.BorrowedHandle{
+                                            Type:    &wit.TypeDef{(CYCLIC REFERENCE)},
+                                            _handle: wit._handle{},
+                                        },
+                                        Owner:      nil,
+                                        Docs:       wit.Docs{},
+                                        _worldItem: wit._worldItem{},
+                                        _type:      wit._type{},
+                                    },
+                                },
+                            },
+                            Results:    nil,
+                            Docs:       wit.Docs{},
+                            _worldItem: wit._worldItem{},
+                        },
+                    },
+                    Package: &wit.Package{
+                        Name: wit.PackageName{
+                            Namespace: "examples",
+                            Name:      "resources-in-world",
+                            Version:   (*semver.Version)(nil),
+                            _node:     wit._node{},
+                        },
+                        Interfaces: {
+                            "types": &wit.Interface{(CYCLIC REFERENCE)},
+                        },
+                        Worlds: {
+                            "imports": &wit.World{(CYCLIC REFERENCE)},
+                        },
+                        Docs: wit.Docs{},
+                    },
+                    Docs:       wit.Docs{},
+                    _typeOwner: wit._typeOwner{},
+                    _worldItem: wit._worldItem{},
+                },
+            },
+            Exports: {},
+            Package: &wit.Package{
+                Name: wit.PackageName{
+                    Namespace: "examples",
+                    Name:      "resources-in-world",
+                    Version:   (*semver.Version)(nil),
+                    _node:     wit._node{},
+                },
+                Interfaces: {
+                    "types": &wit.Interface{
+                        Name:     &"types",
+                        TypeDefs: {
+                            "foo": &wit.TypeDef{
+                                Name:       &"foo",
+                                Kind:       &wit.Resource{},
+                                Owner:      &wit.Interface{(CYCLIC REFERENCE)},
+                                Docs:       wit.Docs{},
+                                _worldItem: wit._worldItem{},
+                                _type:      wit._type{},
+                            },
+                        },
+                        Functions: {
+                            "[method]foo.bar": &wit.Function{
+                                Name: "[method]foo.bar",
+                                Kind: &wit.Method{
+                                    Type:          &wit.TypeDef{(CYCLIC REFERENCE)},
+                                    _functionKind: wit._functionKind{},
+                                },
+                                Params: {
+                                    {
+                                        Name: "self",
+                                        Type: &wit.TypeDef{
+                                            Name: (*string)(nil),
+                                            Kind: &wit.BorrowedHandle{
+                                                Type:    &wit.TypeDef{(CYCLIC REFERENCE)},
+                                                _handle: wit._handle{},
+                                            },
+                                            Owner:      nil,
+                                            Docs:       wit.Docs{},
+                                            _worldItem: wit._worldItem{},
+                                            _type:      wit._type{},
+                                        },
+                                    },
+                                    {
+                                        Name: "arg",
+                                        Type: wit.U32{},
+                                    },
+                                },
+                                Results:    nil,
+                                Docs:       wit.Docs{},
+                                _worldItem: wit._worldItem{},
+                            },
+                            "[method]foo.foo": &wit.Function{
+                                Name: "[method]foo.foo",
+                                Kind: &wit.Method{
+                                    Type:          &wit.TypeDef{(CYCLIC REFERENCE)},
+                                    _functionKind: wit._functionKind{},
+                                },
+                                Params: {
+                                    {
+                                        Name: "self",
+                                        Type: &wit.TypeDef{
+                                            Name: (*string)(nil),
+                                            Kind: &wit.BorrowedHandle{
+                                                Type:    &wit.TypeDef{(CYCLIC REFERENCE)},
+                                                _handle: wit._handle{},
+                                            },
+                                            Owner:      nil,
+                                            Docs:       wit.Docs{},
+                                            _worldItem: wit._worldItem{},
+                                            _type:      wit._type{},
+                                        },
+                                    },
+                                },
+                                Results:    nil,
+                                Docs:       wit.Docs{},
+                                _worldItem: wit._worldItem{},
+                            },
+                        },
+                        Package:    &wit.Package{(CYCLIC REFERENCE)},
+                        Docs:       wit.Docs{},
+                        _typeOwner: wit._typeOwner{},
+                        _worldItem: wit._worldItem{},
+                    },
+                },
+                Worlds: {
+                    "imports": &wit.World{(CYCLIC REFERENCE)},
+                },
+                Docs: wit.Docs{},
+            },
+            Docs:       wit.Docs{},
+            _typeOwner: wit._typeOwner{},
+        },
+    },
+    Interfaces: {
+        &wit.Interface{
+            Name:     &"types",
+            TypeDefs: {
+                "foo": &wit.TypeDef{
+                    Name:       &"foo",
+                    Kind:       &wit.Resource{},
+                    Owner:      &wit.Interface{(CYCLIC REFERENCE)},
+                    Docs:       wit.Docs{},
+                    _worldItem: wit._worldItem{},
+                    _type:      wit._type{},
+                },
+            },
+            Functions: {
+                "[method]foo.bar": &wit.Function{
+                    Name: "[method]foo.bar",
+                    Kind: &wit.Method{
+                        Type:          &wit.TypeDef{(CYCLIC REFERENCE)},
+                        _functionKind: wit._functionKind{},
+                    },
+                    Params: {
+                        {
+                            Name: "self",
+                            Type: &wit.TypeDef{
+                                Name: (*string)(nil),
+                                Kind: &wit.BorrowedHandle{
+                                    Type:    &wit.TypeDef{(CYCLIC REFERENCE)},
+                                    _handle: wit._handle{},
+                                },
+                                Owner:      nil,
+                                Docs:       wit.Docs{},
+                                _worldItem: wit._worldItem{},
+                                _type:      wit._type{},
+                            },
+                        },
+                        {
+                            Name: "arg",
+                            Type: wit.U32{},
+                        },
+                    },
+                    Results:    nil,
+                    Docs:       wit.Docs{},
+                    _worldItem: wit._worldItem{},
+                },
+                "[method]foo.foo": &wit.Function{
+                    Name: "[method]foo.foo",
+                    Kind: &wit.Method{
+                        Type:          &wit.TypeDef{(CYCLIC REFERENCE)},
+                        _functionKind: wit._functionKind{},
+                    },
+                    Params: {
+                        {
+                            Name: "self",
+                            Type: &wit.TypeDef{
+                                Name: (*string)(nil),
+                                Kind: &wit.BorrowedHandle{
+                                    Type:    &wit.TypeDef{(CYCLIC REFERENCE)},
+                                    _handle: wit._handle{},
+                                },
+                                Owner:      nil,
+                                Docs:       wit.Docs{},
+                                _worldItem: wit._worldItem{},
+                                _type:      wit._type{},
+                            },
+                        },
+                    },
+                    Results:    nil,
+                    Docs:       wit.Docs{},
+                    _worldItem: wit._worldItem{},
+                },
+            },
+            Package: &wit.Package{
+                Name: wit.PackageName{
+                    Namespace: "examples",
+                    Name:      "resources-in-world",
+                    Version:   (*semver.Version)(nil),
+                    _node:     wit._node{},
+                },
+                Interfaces: {
+                    "types": &wit.Interface{(CYCLIC REFERENCE)},
+                },
+                Worlds: {
+                    "imports": &wit.World{(CYCLIC REFERENCE)},
+                },
+                Docs: wit.Docs{},
+            },
+            Docs:       wit.Docs{},
+            _typeOwner: wit._typeOwner{},
+            _worldItem: wit._worldItem{},
+        },
+    },
+    TypeDefs: {
+        &wit.TypeDef{
+            Name:       &"foo",
+            Kind:       &wit.Resource{},
+            Owner:      &wit.Interface{(CYCLIC REFERENCE)},
+            Docs:       wit.Docs{},
+            _worldItem: wit._worldItem{},
+            _type:      wit._type{},
+        },
+        &wit.TypeDef{
+            Name: (*string)(nil),
+            Kind: &wit.BorrowedHandle{
+                Type:    &wit.TypeDef{(CYCLIC REFERENCE)},
+                _handle: wit._handle{},
+            },
+            Owner:      nil,
+            Docs:       wit.Docs{},
+            _worldItem: wit._worldItem{},
+            _type:      wit._type{},
+        },
+    },
+    Packages: {
+        &wit.Package{
+            Name: wit.PackageName{
+                Namespace: "examples",
+                Name:      "resources-in-world",
+                Version:   (*semver.Version)(nil),
+                _node:     wit._node{},
+            },
+            Interfaces: {
+                "types": &wit.Interface{(CYCLIC REFERENCE)},
+            },
+            Worlds: {
+                "imports": &wit.World{(CYCLIC REFERENCE)},
+            },
+            Docs: wit.Docs{},
+        },
+    },
+}

--- a/testdata/examples/resource-in-world.wit.json.golden.wit
+++ b/testdata/examples/resource-in-world.wit.json.golden.wit
@@ -1,0 +1,9 @@
+package examples:resources-in-world;
+
+interface types {
+    resource foo {} // TODO: constructor, methods, and static functions;
+}
+
+world imports {
+    import types;
+}

--- a/testdata/examples/resource-in-world.wit.json.golden.wit
+++ b/testdata/examples/resource-in-world.wit.json.golden.wit
@@ -2,8 +2,8 @@ package examples:resources-in-world;
 
 interface types {
     resource foo {
-        constructor: func(self: borrow<foo>, arg: u32);
-        constructor: func(self: borrow<foo>);
+        bar: func(self: borrow<foo>, arg: u32);
+        foo: func(self: borrow<foo>);
     };
 }
 

--- a/testdata/examples/resource-in-world.wit.json.golden.wit
+++ b/testdata/examples/resource-in-world.wit.json.golden.wit
@@ -1,7 +1,10 @@
 package examples:resources-in-world;
 
 interface types {
-    resource foo {} // TODO: constructor, methods, and static functions;
+    resource foo {
+        constructor: func(self: borrow<foo>, arg: u32);
+        constructor: func(self: borrow<foo>);
+    };
 }
 
 world imports {

--- a/testdata/wasi/clocks.wit.json.golden.wit
+++ b/testdata/wasi/clocks.wit.json.golden.wit
@@ -1,14 +1,32 @@
 package wasi:io;
 
 interface poll {
-    resource pollable {} // TODO: constructor, methods, and static functions;
+    resource pollable;
     poll-list: func(in: list<borrow<pollable>>) -> list<u32>;
     poll-one: func(in: borrow<pollable>);
 }
 
 interface streams {
-    resource input-stream {} // TODO: constructor, methods, and static functions;
-    resource output-stream {} // TODO: constructor, methods, and static functions;
+    resource input-stream {
+        constructor: func(self: borrow<input-stream>, len: u64) -> result<tuple<list<u8>, stream-status>, _>;
+        constructor: func(self: borrow<input-stream>, len: u64) -> result<tuple<u64, stream-status>, _>;
+        constructor: func(self: borrow<input-stream>, len: u64) -> result<tuple<list<u8>, stream-status>, _>;
+        constructor: func(self: borrow<input-stream>, len: u64) -> result<tuple<u64, stream-status>, _>;
+        constructor: func(self: borrow<input-stream>) -> own<pollable>;
+    };
+    resource output-stream {
+        constructor: func(self: borrow<output-stream>) -> result<_, write-error>;
+        constructor: func(self: borrow<output-stream>, src: own<input-stream>, len: u64) -> result<tuple<u64, stream-status>, _>;
+        constructor: func(self: borrow<output-stream>, contents: list<u8>) -> result<_, write-error>;
+        constructor: func(self: borrow<output-stream>, len: u64) -> result<_, write-error>;
+        constructor: func(self: borrow<output-stream>) -> result<u64, write-error>;
+        constructor: func(self: borrow<output-stream>) -> result<_, write-error>;
+        constructor: func(self: borrow<output-stream>, src: own<input-stream>) -> result<tuple<u64, stream-status>, _>;
+        constructor: func(self: borrow<output-stream>, src: own<input-stream>, len: u64) -> result<tuple<u64, stream-status>, _>;
+        constructor: func(self: borrow<output-stream>) -> own<pollable>;
+        constructor: func(self: borrow<output-stream>, contents: list<u8>) -> result<_, write-error>;
+        constructor: func(self: borrow<output-stream>, len: u64) -> result<_, write-error>;
+    };
     use poll.{pollable};
     enum stream-status { open, ended };
     enum write-error {

--- a/testdata/wasi/clocks.wit.json.golden.wit
+++ b/testdata/wasi/clocks.wit.json.golden.wit
@@ -8,21 +8,21 @@ interface poll {
 
 interface streams {
     resource input-stream {
-        blocking-read: func(self: borrow<input-stream>, len: u64) -> result<tuple<list<u8>, stream-status>, _>;
-        blocking-skip: func(self: borrow<input-stream>, len: u64) -> result<tuple<u64, stream-status>, _>;
-        read: func(self: borrow<input-stream>, len: u64) -> result<tuple<list<u8>, stream-status>, _>;
-        skip: func(self: borrow<input-stream>, len: u64) -> result<tuple<u64, stream-status>, _>;
+        blocking-read: func(self: borrow<input-stream>, len: u64) -> result<tuple<list<u8>, stream-status>>;
+        blocking-skip: func(self: borrow<input-stream>, len: u64) -> result<tuple<u64, stream-status>>;
+        read: func(self: borrow<input-stream>, len: u64) -> result<tuple<list<u8>, stream-status>>;
+        skip: func(self: borrow<input-stream>, len: u64) -> result<tuple<u64, stream-status>>;
         subscribe: func(self: borrow<input-stream>) -> own<pollable>;
     };
     resource output-stream {
         blocking-flush: func(self: borrow<output-stream>) -> result<_, write-error>;
-        blocking-splice: func(self: borrow<output-stream>, src: own<input-stream>, len: u64) -> result<tuple<u64, stream-status>, _>;
+        blocking-splice: func(self: borrow<output-stream>, src: own<input-stream>, len: u64) -> result<tuple<u64, stream-status>>;
         blocking-write-and-flush: func(self: borrow<output-stream>, contents: list<u8>) -> result<_, write-error>;
         blocking-write-zeroes-and-flush: func(self: borrow<output-stream>, len: u64) -> result<_, write-error>;
         check-write: func(self: borrow<output-stream>) -> result<u64, write-error>;
         flush: func(self: borrow<output-stream>) -> result<_, write-error>;
-        forward: func(self: borrow<output-stream>, src: own<input-stream>) -> result<tuple<u64, stream-status>, _>;
-        splice: func(self: borrow<output-stream>, src: own<input-stream>, len: u64) -> result<tuple<u64, stream-status>, _>;
+        forward: func(self: borrow<output-stream>, src: own<input-stream>) -> result<tuple<u64, stream-status>>;
+        splice: func(self: borrow<output-stream>, src: own<input-stream>, len: u64) -> result<tuple<u64, stream-status>>;
         subscribe: func(self: borrow<output-stream>) -> own<pollable>;
         write: func(self: borrow<output-stream>, contents: list<u8>) -> result<_, write-error>;
         write-zeroes: func(self: borrow<output-stream>, len: u64) -> result<_, write-error>;

--- a/testdata/wasi/clocks.wit.json.golden.wit
+++ b/testdata/wasi/clocks.wit.json.golden.wit
@@ -8,24 +8,24 @@ interface poll {
 
 interface streams {
     resource input-stream {
-        constructor: func(self: borrow<input-stream>, len: u64) -> result<tuple<list<u8>, stream-status>, _>;
-        constructor: func(self: borrow<input-stream>, len: u64) -> result<tuple<u64, stream-status>, _>;
-        constructor: func(self: borrow<input-stream>, len: u64) -> result<tuple<list<u8>, stream-status>, _>;
-        constructor: func(self: borrow<input-stream>, len: u64) -> result<tuple<u64, stream-status>, _>;
-        constructor: func(self: borrow<input-stream>) -> own<pollable>;
+        blocking-read: func(self: borrow<input-stream>, len: u64) -> result<tuple<list<u8>, stream-status>, _>;
+        blocking-skip: func(self: borrow<input-stream>, len: u64) -> result<tuple<u64, stream-status>, _>;
+        read: func(self: borrow<input-stream>, len: u64) -> result<tuple<list<u8>, stream-status>, _>;
+        skip: func(self: borrow<input-stream>, len: u64) -> result<tuple<u64, stream-status>, _>;
+        subscribe: func(self: borrow<input-stream>) -> own<pollable>;
     };
     resource output-stream {
-        constructor: func(self: borrow<output-stream>) -> result<_, write-error>;
-        constructor: func(self: borrow<output-stream>, src: own<input-stream>, len: u64) -> result<tuple<u64, stream-status>, _>;
-        constructor: func(self: borrow<output-stream>, contents: list<u8>) -> result<_, write-error>;
-        constructor: func(self: borrow<output-stream>, len: u64) -> result<_, write-error>;
-        constructor: func(self: borrow<output-stream>) -> result<u64, write-error>;
-        constructor: func(self: borrow<output-stream>) -> result<_, write-error>;
-        constructor: func(self: borrow<output-stream>, src: own<input-stream>) -> result<tuple<u64, stream-status>, _>;
-        constructor: func(self: borrow<output-stream>, src: own<input-stream>, len: u64) -> result<tuple<u64, stream-status>, _>;
-        constructor: func(self: borrow<output-stream>) -> own<pollable>;
-        constructor: func(self: borrow<output-stream>, contents: list<u8>) -> result<_, write-error>;
-        constructor: func(self: borrow<output-stream>, len: u64) -> result<_, write-error>;
+        blocking-flush: func(self: borrow<output-stream>) -> result<_, write-error>;
+        blocking-splice: func(self: borrow<output-stream>, src: own<input-stream>, len: u64) -> result<tuple<u64, stream-status>, _>;
+        blocking-write-and-flush: func(self: borrow<output-stream>, contents: list<u8>) -> result<_, write-error>;
+        blocking-write-zeroes-and-flush: func(self: borrow<output-stream>, len: u64) -> result<_, write-error>;
+        check-write: func(self: borrow<output-stream>) -> result<u64, write-error>;
+        flush: func(self: borrow<output-stream>) -> result<_, write-error>;
+        forward: func(self: borrow<output-stream>, src: own<input-stream>) -> result<tuple<u64, stream-status>, _>;
+        splice: func(self: borrow<output-stream>, src: own<input-stream>, len: u64) -> result<tuple<u64, stream-status>, _>;
+        subscribe: func(self: borrow<output-stream>) -> own<pollable>;
+        write: func(self: borrow<output-stream>, contents: list<u8>) -> result<_, write-error>;
+        write-zeroes: func(self: borrow<output-stream>, len: u64) -> result<_, write-error>;
     };
     use poll.{pollable};
     enum stream-status { open, ended };

--- a/testdata/wasi/clocks.wit.json.golden.wit
+++ b/testdata/wasi/clocks.wit.json.golden.wit
@@ -15,22 +15,6 @@ interface streams {
         last-operation-failed,
         closed
     };
-    [method]input-stream.blocking-read: func(self: borrow<input-stream>, len: u64) -> result<tuple<list<u8>, stream-status>, _>;
-    [method]input-stream.blocking-skip: func(self: borrow<input-stream>, len: u64) -> result<tuple<u64, stream-status>, _>;
-    [method]input-stream.read: func(self: borrow<input-stream>, len: u64) -> result<tuple<list<u8>, stream-status>, _>;
-    [method]input-stream.skip: func(self: borrow<input-stream>, len: u64) -> result<tuple<u64, stream-status>, _>;
-    [method]input-stream.subscribe: func(self: borrow<input-stream>) -> own<pollable>;
-    [method]output-stream.blocking-flush: func(self: borrow<output-stream>) -> result<_, write-error>;
-    [method]output-stream.blocking-splice: func(self: borrow<output-stream>, src: own<input-stream>, len: u64) -> result<tuple<u64, stream-status>, _>;
-    [method]output-stream.blocking-write-and-flush: func(self: borrow<output-stream>, contents: list<u8>) -> result<_, write-error>;
-    [method]output-stream.blocking-write-zeroes-and-flush: func(self: borrow<output-stream>, len: u64) -> result<_, write-error>;
-    [method]output-stream.check-write: func(self: borrow<output-stream>) -> result<u64, write-error>;
-    [method]output-stream.flush: func(self: borrow<output-stream>) -> result<_, write-error>;
-    [method]output-stream.forward: func(self: borrow<output-stream>, src: own<input-stream>) -> result<tuple<u64, stream-status>, _>;
-    [method]output-stream.splice: func(self: borrow<output-stream>, src: own<input-stream>, len: u64) -> result<tuple<u64, stream-status>, _>;
-    [method]output-stream.subscribe: func(self: borrow<output-stream>) -> own<pollable>;
-    [method]output-stream.write: func(self: borrow<output-stream>, contents: list<u8>) -> result<_, write-error>;
-    [method]output-stream.write-zeroes: func(self: borrow<output-stream>, len: u64) -> result<_, write-error>;
 }
 
 world imports {

--- a/testdata/wit-parser/cross-package-resource.wit.json.golden.wit
+++ b/testdata/wit-parser/cross-package-resource.wit.json.golden.wit
@@ -1,7 +1,7 @@
 package some:dep;
 
 interface foo {
-    resource r {} // TODO: constructor, methods, and static functions;
+    resource r;
 }
 
 

--- a/testdata/wit-parser/name-both-resource-and-type.wit.json.golden.wit
+++ b/testdata/wit-parser/name-both-resource-and-type.wit.json.golden.wit
@@ -1,7 +1,7 @@
 package some:dep;
 
 interface foo {
-    resource a {} // TODO: constructor, methods, and static functions;
+    resource a;
 }
 
 

--- a/testdata/wit-parser/resources-empty.wit.json.golden.wit
+++ b/testdata/wit-parser/resources-empty.wit.json.golden.wit
@@ -1,7 +1,7 @@
 package foo:resources-empty;
 
 interface resources-empty {
-    resource r1 {} // TODO: constructor, methods, and static functions;
+    resource r1;
     t1: func(a: own<r1>);
     t2: func(a: borrow<r1>);
 }

--- a/testdata/wit-parser/resources-multiple-returns-borrow.wit.json.golden.wit
+++ b/testdata/wit-parser/resources-multiple-returns-borrow.wit.json.golden.wit
@@ -1,6 +1,8 @@
 package foo:resources1;
 
 interface resources1 {
-    resource r1 {} // TODO: constructor, methods, and static functions;
+    resource r1 {
+        constructor: func(self: borrow<r1>) -> a: s32, handle: borrow<r1>;
+    };
     t1: func(a: borrow<r1>);
 }

--- a/testdata/wit-parser/resources-multiple-returns-borrow.wit.json.golden.wit
+++ b/testdata/wit-parser/resources-multiple-returns-borrow.wit.json.golden.wit
@@ -2,6 +2,5 @@ package foo:resources1;
 
 interface resources1 {
     resource r1 {} // TODO: constructor, methods, and static functions;
-    [method]r1.f1: func(self: borrow<r1>) -> a: s32, handle: borrow<r1>;
     t1: func(a: borrow<r1>);
 }

--- a/testdata/wit-parser/resources-multiple-returns-borrow.wit.json.golden.wit
+++ b/testdata/wit-parser/resources-multiple-returns-borrow.wit.json.golden.wit
@@ -2,7 +2,7 @@ package foo:resources1;
 
 interface resources1 {
     resource r1 {
-        constructor: func(self: borrow<r1>) -> a: s32, handle: borrow<r1>;
+        f1: func(self: borrow<r1>) -> a: s32, handle: borrow<r1>;
     };
     t1: func(a: borrow<r1>);
 }

--- a/testdata/wit-parser/resources-multiple-returns-own.wit.json.golden.wit
+++ b/testdata/wit-parser/resources-multiple-returns-own.wit.json.golden.wit
@@ -2,7 +2,7 @@ package foo:resources1;
 
 interface resources1 {
     resource r1 {
-        constructor: func(self: borrow<r1>) -> a: s32, handle: own<r1>;
+        f1: func(self: borrow<r1>) -> a: s32, handle: own<r1>;
     };
     t1: func(a: own<r1>);
 }

--- a/testdata/wit-parser/resources-multiple-returns-own.wit.json.golden.wit
+++ b/testdata/wit-parser/resources-multiple-returns-own.wit.json.golden.wit
@@ -1,6 +1,8 @@
 package foo:resources1;
 
 interface resources1 {
-    resource r1 {} // TODO: constructor, methods, and static functions;
+    resource r1 {
+        constructor: func(self: borrow<r1>) -> a: s32, handle: own<r1>;
+    };
     t1: func(a: own<r1>);
 }

--- a/testdata/wit-parser/resources-multiple-returns-own.wit.json.golden.wit
+++ b/testdata/wit-parser/resources-multiple-returns-own.wit.json.golden.wit
@@ -2,6 +2,5 @@ package foo:resources1;
 
 interface resources1 {
     resource r1 {} // TODO: constructor, methods, and static functions;
-    [method]r1.f1: func(self: borrow<r1>) -> a: s32, handle: own<r1>;
     t1: func(a: own<r1>);
 }

--- a/testdata/wit-parser/resources-multiple.wit.json.golden.wit
+++ b/testdata/wit-parser/resources-multiple.wit.json.golden.wit
@@ -2,16 +2,16 @@ package foo:resources-multiple;
 
 interface resources-multiple {
     resource r1 {
-        constructor: func(self: borrow<r1>);
-        constructor: func(self: borrow<r1>) -> u: u32;
-        constructor: func(self: borrow<r1>);
-        constructor: func(self: borrow<r1>, a: u32);
-        constructor: func(self: borrow<r1>, a: u32);
-        constructor: func(self: borrow<r1>) -> u32;
-        constructor: func(self: borrow<r1>) -> tuple<u32, u32>;
-        constructor: func(self: borrow<r1>, a: float32, b: float32) -> tuple<u32, u32>;
-        constructor: func(self: borrow<r1>, a: option<u32>) -> result<u32, float32>;
-        constructor: func(self: borrow<r1>) -> u: u32, f: float32;
+        f1: func(self: borrow<r1>);
+        f10: func(self: borrow<r1>) -> u: u32;
+        f11: func(self: borrow<r1>);
+        f2: func(self: borrow<r1>, a: u32);
+        f3: func(self: borrow<r1>, a: u32);
+        f4: func(self: borrow<r1>) -> u32;
+        f6: func(self: borrow<r1>) -> tuple<u32, u32>;
+        f7: func(self: borrow<r1>, a: float32, b: float32) -> tuple<u32, u32>;
+        f8: func(self: borrow<r1>, a: option<u32>) -> result<u32, float32>;
+        f9: func(self: borrow<r1>) -> u: u32, f: float32;
     };
     t1: func(a: borrow<r1>);
     t2: func(a: own<r1>);

--- a/testdata/wit-parser/resources-multiple.wit.json.golden.wit
+++ b/testdata/wit-parser/resources-multiple.wit.json.golden.wit
@@ -1,7 +1,18 @@
 package foo:resources-multiple;
 
 interface resources-multiple {
-    resource r1 {} // TODO: constructor, methods, and static functions;
+    resource r1 {
+        constructor: func(self: borrow<r1>);
+        constructor: func(self: borrow<r1>) -> u: u32;
+        constructor: func(self: borrow<r1>);
+        constructor: func(self: borrow<r1>, a: u32);
+        constructor: func(self: borrow<r1>, a: u32);
+        constructor: func(self: borrow<r1>) -> u32;
+        constructor: func(self: borrow<r1>) -> tuple<u32, u32>;
+        constructor: func(self: borrow<r1>, a: float32, b: float32) -> tuple<u32, u32>;
+        constructor: func(self: borrow<r1>, a: option<u32>) -> result<u32, float32>;
+        constructor: func(self: borrow<r1>) -> u: u32, f: float32;
+    };
     t1: func(a: borrow<r1>);
     t2: func(a: own<r1>);
 }

--- a/testdata/wit-parser/resources-multiple.wit.json.golden.wit
+++ b/testdata/wit-parser/resources-multiple.wit.json.golden.wit
@@ -2,16 +2,6 @@ package foo:resources-multiple;
 
 interface resources-multiple {
     resource r1 {} // TODO: constructor, methods, and static functions;
-    [method]r1.f1: func(self: borrow<r1>);
-    [method]r1.f10: func(self: borrow<r1>) -> u: u32;
-    [method]r1.f11: func(self: borrow<r1>);
-    [method]r1.f2: func(self: borrow<r1>, a: u32);
-    [method]r1.f3: func(self: borrow<r1>, a: u32);
-    [method]r1.f4: func(self: borrow<r1>) -> u32;
-    [method]r1.f6: func(self: borrow<r1>) -> tuple<u32, u32>;
-    [method]r1.f7: func(self: borrow<r1>, a: float32, b: float32) -> tuple<u32, u32>;
-    [method]r1.f8: func(self: borrow<r1>, a: option<u32>) -> result<u32, float32>;
-    [method]r1.f9: func(self: borrow<r1>) -> u: u32, f: float32;
     t1: func(a: borrow<r1>);
     t2: func(a: own<r1>);
 }

--- a/testdata/wit-parser/resources-return-borrow.wit.json.golden.wit
+++ b/testdata/wit-parser/resources-return-borrow.wit.json.golden.wit
@@ -2,7 +2,7 @@ package foo:resources1;
 
 interface resources1 {
     resource r1 {
-        constructor: func(self: borrow<r1>) -> borrow<r1>;
+        f1: func(self: borrow<r1>) -> borrow<r1>;
     };
     t1: func(a: borrow<r1>);
 }

--- a/testdata/wit-parser/resources-return-borrow.wit.json.golden.wit
+++ b/testdata/wit-parser/resources-return-borrow.wit.json.golden.wit
@@ -2,6 +2,5 @@ package foo:resources1;
 
 interface resources1 {
     resource r1 {} // TODO: constructor, methods, and static functions;
-    [method]r1.f1: func(self: borrow<r1>) -> borrow<r1>;
     t1: func(a: borrow<r1>);
 }

--- a/testdata/wit-parser/resources-return-borrow.wit.json.golden.wit
+++ b/testdata/wit-parser/resources-return-borrow.wit.json.golden.wit
@@ -1,6 +1,8 @@
 package foo:resources1;
 
 interface resources1 {
-    resource r1 {} // TODO: constructor, methods, and static functions;
+    resource r1 {
+        constructor: func(self: borrow<r1>) -> borrow<r1>;
+    };
     t1: func(a: borrow<r1>);
 }

--- a/testdata/wit-parser/resources-return-own.wit.json.golden.wit
+++ b/testdata/wit-parser/resources-return-own.wit.json.golden.wit
@@ -1,6 +1,8 @@
 package foo:resources1;
 
 interface resources1 {
-    resource r1 {} // TODO: constructor, methods, and static functions;
+    resource r1 {
+        constructor: func(self: borrow<r1>) -> own<r1>;
+    };
     t1: func(a: own<r1>);
 }

--- a/testdata/wit-parser/resources-return-own.wit.json.golden.wit
+++ b/testdata/wit-parser/resources-return-own.wit.json.golden.wit
@@ -2,7 +2,7 @@ package foo:resources1;
 
 interface resources1 {
     resource r1 {
-        constructor: func(self: borrow<r1>) -> own<r1>;
+        f1: func(self: borrow<r1>) -> own<r1>;
     };
     t1: func(a: own<r1>);
 }

--- a/testdata/wit-parser/resources-return-own.wit.json.golden.wit
+++ b/testdata/wit-parser/resources-return-own.wit.json.golden.wit
@@ -2,6 +2,5 @@ package foo:resources1;
 
 interface resources1 {
     resource r1 {} // TODO: constructor, methods, and static functions;
-    [method]r1.f1: func(self: borrow<r1>) -> own<r1>;
     t1: func(a: own<r1>);
 }

--- a/testdata/wit-parser/resources.wit.json.golden.wit
+++ b/testdata/wit-parser/resources.wit.json.golden.wit
@@ -1,15 +1,26 @@
 package foo:bar;
 
 interface foo {
-    resource a {} // TODO: constructor, methods, and static functions;
-    resource b {} // TODO: constructor, methods, and static functions;
-    resource c {} // TODO: constructor, methods, and static functions;
-    resource d {} // TODO: constructor, methods, and static functions;
-    resource e {} // TODO: constructor, methods, and static functions;
+    resource a;
+    resource b {
+        [constructor]b: func() -> own<b>;
+    };
+    resource c {
+        [constructor]c: func(x: u32) -> own<c>;
+    };
+    resource d {
+        [constructor]d: func(x: u32) -> own<d>;
+        constructor: func(self: borrow<d>);
+        b: func();
+    };
+    resource e {
+        [constructor]e: func(other: own<e>, other2: borrow<e>) -> own<e>;
+        constructor: func(self: borrow<e>, thing: own<e>, thing2: borrow<e>);
+    };
 }
 
 interface i {
-    resource a {} // TODO: constructor, methods, and static functions;
+    resource a;
     type t1 = a;
     type t2 = borrow<a>;
     type t3 = borrow<t1>;
@@ -17,7 +28,9 @@ interface i {
 
 world w {
     import [constructor]c: func() -> own<c>;
-    resource a {} // TODO: constructor, methods, and static functions;
-    resource b {} // TODO: constructor, methods, and static functions;
-    resource c {} // TODO: constructor, methods, and static functions;
+    resource a;
+    resource b;
+    resource c {
+        [constructor]c: func() -> own<c>;
+    };
 }

--- a/testdata/wit-parser/resources.wit.json.golden.wit
+++ b/testdata/wit-parser/resources.wit.json.golden.wit
@@ -6,13 +6,6 @@ interface foo {
     resource c {} // TODO: constructor, methods, and static functions;
     resource d {} // TODO: constructor, methods, and static functions;
     resource e {} // TODO: constructor, methods, and static functions;
-    [constructor]b: func() -> own<b>;
-    [constructor]c: func(x: u32) -> own<c>;
-    [constructor]d: func(x: u32) -> own<d>;
-    [constructor]e: func(other: own<e>, other2: borrow<e>) -> own<e>;
-    [method]d.a: func(self: borrow<d>);
-    [method]e.method: func(self: borrow<e>, thing: own<e>, thing2: borrow<e>);
-    [static]d.b: func();
 }
 
 interface i {

--- a/testdata/wit-parser/resources.wit.json.golden.wit
+++ b/testdata/wit-parser/resources.wit.json.golden.wit
@@ -3,19 +3,19 @@ package foo:bar;
 interface foo {
     resource a;
     resource b {
-        [constructor]b: func() -> own<b>;
+        constructor: func() -> own<b>;
     };
     resource c {
-        [constructor]c: func(x: u32) -> own<c>;
+        constructor: func(x: u32) -> own<c>;
     };
     resource d {
-        [constructor]d: func(x: u32) -> own<d>;
-        constructor: func(self: borrow<d>);
+        constructor: func(x: u32) -> own<d>;
+        a: func(self: borrow<d>);
         b: func();
     };
     resource e {
-        [constructor]e: func(other: own<e>, other2: borrow<e>) -> own<e>;
-        constructor: func(self: borrow<e>, thing: own<e>, thing2: borrow<e>);
+        constructor: func(other: own<e>, other2: borrow<e>) -> own<e>;
+        method: func(self: borrow<e>, thing: own<e>, thing2: borrow<e>);
     };
 }
 
@@ -31,6 +31,6 @@ world w {
     resource a;
     resource b;
     resource c {
-        [constructor]c: func() -> own<c>;
+        constructor: func() -> own<c>;
     };
 }

--- a/testdata/wit-parser/resources1.wit.json.golden.wit
+++ b/testdata/wit-parser/resources1.wit.json.golden.wit
@@ -2,7 +2,7 @@ package foo:resources1;
 
 interface resources1 {
     resource r1 {
-        constructor: func(self: borrow<r1>);
+        f1: func(self: borrow<r1>);
     };
     t1: func(a: borrow<r1>);
     t2: func(a: own<r1>);

--- a/testdata/wit-parser/resources1.wit.json.golden.wit
+++ b/testdata/wit-parser/resources1.wit.json.golden.wit
@@ -2,7 +2,6 @@ package foo:resources1;
 
 interface resources1 {
     resource r1 {} // TODO: constructor, methods, and static functions;
-    [method]r1.f1: func(self: borrow<r1>);
     t1: func(a: borrow<r1>);
     t2: func(a: own<r1>);
     t3: func(a: own<r1>);

--- a/testdata/wit-parser/resources1.wit.json.golden.wit
+++ b/testdata/wit-parser/resources1.wit.json.golden.wit
@@ -1,7 +1,9 @@
 package foo:resources1;
 
 interface resources1 {
-    resource r1 {} // TODO: constructor, methods, and static functions;
+    resource r1 {
+        constructor: func(self: borrow<r1>);
+    };
     t1: func(a: borrow<r1>);
     t2: func(a: own<r1>);
     t3: func(a: own<r1>);

--- a/testdata/wit-parser/types.wit.json.golden.wit
+++ b/testdata/wit-parser/types.wit.json.golden.wit
@@ -12,8 +12,8 @@ interface types {
     type t14 = option<u32>;
     type t15 = result<u32, u32>;
     type t16 = result<_, u32>;
-    type t17 = result<u32, _>;
-    type t18 = result<_, _>;
+    type t17 = result<u32>;
+    type t18 = result<_>;
     type t2 = u16;
     record t20 {};
     record t21 { a: u32 };

--- a/testdata/wit-parser/world-top-level-resources.wit.json.golden.wit
+++ b/testdata/wit-parser/world-top-level-resources.wit.json.golden.wit
@@ -8,8 +8,14 @@ interface handler {
 }
 
 interface types {
-    resource request {} // TODO: constructor, methods, and static functions;
-    resource response {} // TODO: constructor, methods, and static functions;
+    resource request {
+        constructor: func(self: borrow<request>, arg: list<u32>);
+        constructor: func(self: borrow<request>);
+    };
+    resource response {
+        constructor: func(self: borrow<response>, arg: list<u32>);
+        constructor: func(self: borrow<response>);
+    };
 }
 
 world proxy {

--- a/testdata/wit-parser/world-top-level-resources.wit.json.golden.wit
+++ b/testdata/wit-parser/world-top-level-resources.wit.json.golden.wit
@@ -10,10 +10,6 @@ interface handler {
 interface types {
     resource request {} // TODO: constructor, methods, and static functions;
     resource response {} // TODO: constructor, methods, and static functions;
-    [method]request.bar: func(self: borrow<request>, arg: list<u32>);
-    [method]request.foo: func(self: borrow<request>);
-    [method]response.bar: func(self: borrow<response>, arg: list<u32>);
-    [method]response.foo: func(self: borrow<response>);
 }
 
 world proxy {

--- a/testdata/wit-parser/world-top-level-resources.wit.json.golden.wit
+++ b/testdata/wit-parser/world-top-level-resources.wit.json.golden.wit
@@ -9,12 +9,12 @@ interface handler {
 
 interface types {
     resource request {
-        constructor: func(self: borrow<request>, arg: list<u32>);
-        constructor: func(self: borrow<request>);
+        bar: func(self: borrow<request>, arg: list<u32>);
+        foo: func(self: borrow<request>);
     };
     resource response {
-        constructor: func(self: borrow<response>, arg: list<u32>);
-        constructor: func(self: borrow<response>);
+        bar: func(self: borrow<response>, arg: list<u32>);
+        foo: func(self: borrow<response>);
     };
 }
 

--- a/wit/abi.go
+++ b/wit/abi.go
@@ -8,7 +8,7 @@ func Align(ptr, align uintptr) uintptr {
 // Discriminant returns the smallest WIT integer type that can represent 0...n.
 // Used by the [Canonical ABI] for [Variant] types.
 //
-// Canonical ABI: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#alignment
+// [Canonical ABI]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#alignment
 func Discriminant(n uint32) Type {
 	switch {
 	case n <= 1<<8:

--- a/wit/docs.go
+++ b/wit/docs.go
@@ -29,7 +29,7 @@
 //
 //	// Do something with res
 //
-// [WebAssembly Interface Type]: https://component-model.bytecodealliance.org/wit-overview.html
+// [WebAssembly Interface Type]: https://component-model.bytecodealliance.org/design/wit.html
 // [WebAssembly Component Model]: https://component-model.bytecodealliance.org/introduction.html
 // [wit-parser]: https://docs.rs/wit-parser/latest/wit_parser/
 // [source]: https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-parser

--- a/wit/resolve.go
+++ b/wit/resolve.go
@@ -123,6 +123,19 @@ type TypeDef struct {
 	_type
 }
 
+// Root returns the Root [TypeDef] of t if it is an alias.
+// If t is not an alias, Root returns t.
+func (t *TypeDef) Root() *TypeDef {
+	for {
+		switch kind := t.Kind.(type) {
+		case *TypeDef:
+			t = kind
+		default:
+			return t
+		}
+	}
+}
+
 // Package returns the [Package] that t is associated with, if any.
 func (t *TypeDef) Package() *Package {
 	switch owner := t.Owner.(type) {

--- a/wit/resolve.go
+++ b/wit/resolve.go
@@ -171,9 +171,9 @@ func (t *TypeDef) Methods() []*Function {
 	return methods
 }
 
-// StaticMethods returns all static methods for [TypeDef] t.
-// Currently t must be a [Resource] to have static methods.
-func (t *TypeDef) StaticMethods() []*Function {
+// StaticFunctions returns all static functions for [TypeDef] t.
+// Currently t must be a [Resource] to have static functions.
+func (t *TypeDef) StaticFunctions() []*Function {
 	var statics []*Function
 	t.Owner.AllFunctions(func(f *Function) bool {
 		if m, ok := f.Kind.(*Static); ok && m.Type == t {

--- a/wit/resolve.go
+++ b/wit/resolve.go
@@ -459,7 +459,7 @@ func (v *Variant) maxCaseAlign() uintptr {
 // It implements the [Node] interface.
 type Case struct {
 	Name string
-	Type Type // optional associated [Type] (can be nil)
+	Type Type // optional associated Type (can be nil)
 	Docs Docs
 }
 
@@ -563,8 +563,8 @@ func (o *Option) Align() uintptr {
 //
 // [result type]: https://component-model.bytecodealliance.org/design/wit.html#results
 type Result struct {
-	OK  Type // optional associated [Type] (can be nil)
-	Err Type // optional associated [Type] (can be nil)
+	OK  Type // optional associated Type (can be nil)
+	Err Type // optional associated Type (can be nil)
 	_typeDefKind
 }
 
@@ -624,7 +624,7 @@ func (*List) Align() uintptr { return 8 } // [2]int32
 // [future type]: https://github.com/bytecodealliance/wit-bindgen/issues/270
 // [WASI Preview 3]: https://bytecodealliance.org/articles/webassembly-the-updated-roadmap-for-developers
 type Future struct {
-	Type Type // optional associated [Type] (can be nil)
+	Type Type // optional associated Type (can be nil)
 	_typeDefKind
 }
 
@@ -646,8 +646,8 @@ func (*Future) Align() uintptr { return 0 }
 // [stream type]: https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#streams
 // [WASI Preview 3]: https://bytecodealliance.org/articles/webassembly-the-updated-roadmap-for-developers
 type Stream struct {
-	Element Type // optional associated [Type] (can be nil)
-	End     Type // optional associated [Type] (can be nil)
+	Element Type // optional associated Type (can be nil)
+	End     Type // optional associated Type (can be nil)
 	_typeDefKind
 }
 

--- a/wit/resolve.go
+++ b/wit/resolve.go
@@ -123,8 +123,10 @@ type TypeDef struct {
 	_type
 }
 
-// Root returns the Root [TypeDef] of t if it is an alias.
-// If t is not an alias, Root returns t.
+// Root returns the Root [TypeDef] of [type alias] t.
+// If t is not a type alias, Root returns t.
+//
+// [type alias]: https://component-model.bytecodealliance.org/design/wit.html#type-aliases
 func (t *TypeDef) Root() *TypeDef {
 	for {
 		switch kind := t.Kind.(type) {

--- a/wit/resolve.go
+++ b/wit/resolve.go
@@ -19,7 +19,7 @@ import (
 //
 // Each [World], [Interface], [TypeDef], or [Package] in a Resolve must be non-nil.
 //
-// [WebAssembly Interface Type]: https://component-model.bytecodealliance.org/wit-overview.html
+// [WebAssembly Interface Type]: https://component-model.bytecodealliance.org/design/wit.html
 type Resolve struct {
 	Worlds     []*World
 	Interfaces []*Interface
@@ -320,7 +320,7 @@ type BorrowedHandle struct {
 // Flags represents a WIT [flags type], stored as a bitfield.
 // It implements the [Node], [Sized], and [TypeDefKind] interfaces.
 //
-// [flags type]: https://component-model.bytecodealliance.org/wit-overview.html#flags
+// [flags type]: https://component-model.bytecodealliance.org/design/wit.html#flags
 type Flags struct {
 	Flags []Flag
 	_typeDefKind
@@ -366,7 +366,7 @@ type Flag struct {
 // It is similar to a [Record], except that the fields are identified by their order instead of by names.
 // It implements the [Node], [Sized], and [TypeDefKind] interfaces.
 //
-// [tuple type]: https://component-model.bytecodealliance.org/wit-overview.html#tuples
+// [tuple type]: https://component-model.bytecodealliance.org/design/wit.html#tuples
 type Tuple struct {
 	Types []Type
 	_typeDefKind
@@ -410,7 +410,7 @@ func (t *Tuple) Align() uintptr {
 // a type of data associated with that case.
 // It implements the [Node], [Sized], and [TypeDefKind] interfaces.
 //
-// [variant type]: https://component-model.bytecodealliance.org/wit-overview.html#variants
+// [variant type]: https://component-model.bytecodealliance.org/design/wit.html#variants
 type Variant struct {
 	Cases []Case
 	_typeDefKind
@@ -465,7 +465,7 @@ type Case struct {
 // The equivalent in Go is a set of const identifiers declared with iota.
 // It implements the [Node], [Sized], and [TypeDefKind] interfaces.
 //
-// [enum type]: https://component-model.bytecodealliance.org/wit-overview.html#enums
+// [enum type]: https://component-model.bytecodealliance.org/design/wit.html#enums
 type Enum struct {
 	Cases []EnumCase
 	_typeDefKind
@@ -517,7 +517,7 @@ type EnumCase struct {
 // The equivalent in Go for an option<string> could be represented as *string.
 // It implements the [Node], [Sized], and [TypeDefKind] interfaces.
 //
-// [option type]: https://component-model.bytecodealliance.org/wit-overview.html#options
+// [option type]: https://component-model.bytecodealliance.org/design/wit.html#options
 type Option struct {
 	Type Type
 	_typeDefKind
@@ -559,7 +559,7 @@ func (o *Option) Align() uintptr {
 // the Go pattern of returning (T, error).
 // It implements the [Node], [Sized], and [TypeDefKind] interfaces.
 //
-// [result type]: https://component-model.bytecodealliance.org/wit-overview.html#results
+// [result type]: https://component-model.bytecodealliance.org/design/wit.html#results
 type Result struct {
 	OK  Type // optional associated [Type] (can be nil)
 	Err Type // optional associated [Type] (can be nil)
@@ -600,7 +600,7 @@ func (r *Result) Align() uintptr {
 // List represents a WIT [list type], which is an ordered vector of an arbitrary type.
 // It implements the [Node], [Sized], and [TypeDefKind] interfaces.
 //
-// [list type]: https://component-model.bytecodealliance.org/wit-overview.html#lists
+// [list type]: https://component-model.bytecodealliance.org/design/wit.html#lists
 type List struct {
 	Type Type
 	_typeDefKind
@@ -678,7 +678,7 @@ func (_typeOwner) isTypeOwner()                                 {}
 // [primitive type] or a user-defined type in a [TypeDef].
 // It also conforms to the [Node], [Sized], and [TypeDefKind] interfaces.
 //
-// [primitive type]: https://component-model.bytecodealliance.org/wit-overview.html#primitive-types
+// [primitive type]: https://component-model.bytecodealliance.org/design/wit.html#primitive-types
 type Type interface {
 	Node
 	Sized
@@ -696,7 +696,7 @@ func (_type) isType() {}
 // the associated Type implementation from this package.
 // It returns an error if the type string is not recoginized.
 //
-// [primitive type]: https://component-model.bytecodealliance.org/wit-overview.html#primitive-types
+// [primitive type]: https://component-model.bytecodealliance.org/design/wit.html#primitive-types
 func ParseType(s string) (Type, error) {
 	switch s {
 	case "bool":
@@ -731,7 +731,7 @@ func ParseType(s string) (Type, error) {
 
 // Primitive is a type constriant of the Go equivalents of WIT [primitive types].
 //
-// [primitive types]: https://component-model.bytecodealliance.org/wit-overview.html#primitive-types
+// [primitive types]: https://component-model.bytecodealliance.org/design/wit.html#primitive-types
 type Primitive interface {
 	bool | int8 | uint8 | int16 | uint16 | int32 | uint32 | int64 | uint64 | float32 | float64 | char | string
 }
@@ -743,7 +743,7 @@ type char rune
 // mapped to its equivalent Go type.
 // It conforms to the [Node], [Sized], [Type], and [TypeDefKind] interfaces.
 //
-// [primitive type]: https://component-model.bytecodealliance.org/wit-overview.html#primitive-types
+// [primitive type]: https://component-model.bytecodealliance.org/design/wit.html#primitive-types
 type _primitive[T Primitive] struct{ _type }
 
 // _primitive is a generic embeddable type that conforms to the [Type] interface.
@@ -774,7 +774,7 @@ func (_primitive[T]) Align() uintptr {
 // String returns the canonical [primitive type] name in [WIT] text format.
 //
 // [WIT]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md
-// [primitive type]: https://component-model.bytecodealliance.org/wit-overview.html#primitive-types
+// [primitive type]: https://component-model.bytecodealliance.org/design/wit.html#primitive-types
 func (_primitive[T]) String() string {
 	var v T
 	switch any(v).(type) {
@@ -813,7 +813,7 @@ func (_primitive[T]) String() string {
 // It is equivalent to the Go type [bool].
 // It implements the [Node], [Sized], [Type], and [TypeDefKind] interfaces.
 //
-// [primitive type]: https://component-model.bytecodealliance.org/wit-overview.html#primitive-types
+// [primitive type]: https://component-model.bytecodealliance.org/design/wit.html#primitive-types
 // [bool]: https://pkg.go.dev/builtin#bool
 type Bool struct{ _primitive[bool] }
 
@@ -821,7 +821,7 @@ type Bool struct{ _primitive[bool] }
 // It is equivalent to the Go type [int8].
 // It implements the [Node], [Sized], [Type], and [TypeDefKind] interfaces.
 //
-// [primitive type]: https://component-model.bytecodealliance.org/wit-overview.html#primitive-types
+// [primitive type]: https://component-model.bytecodealliance.org/design/wit.html#primitive-types
 // [int8]: https://pkg.go.dev/builtin#int8
 type S8 struct{ _primitive[int8] }
 
@@ -829,7 +829,7 @@ type S8 struct{ _primitive[int8] }
 // It is equivalent to the Go type [uint8].
 // It implements the [Node], [Sized], [Type], and [TypeDefKind] interfaces.
 //
-// [primitive type]: https://component-model.bytecodealliance.org/wit-overview.html#primitive-types
+// [primitive type]: https://component-model.bytecodealliance.org/design/wit.html#primitive-types
 // [uint8]: https://pkg.go.dev/builtin#uint8
 type U8 struct{ _primitive[uint8] }
 
@@ -837,7 +837,7 @@ type U8 struct{ _primitive[uint8] }
 // It is equivalent to the Go type [int16].
 // It implements the [Node], [Sized], [Type], and [TypeDefKind] interfaces.
 //
-// [primitive type]: https://component-model.bytecodealliance.org/wit-overview.html#primitive-types
+// [primitive type]: https://component-model.bytecodealliance.org/design/wit.html#primitive-types
 // [int16]: https://pkg.go.dev/builtin#int16
 type S16 struct{ _primitive[int16] }
 
@@ -845,7 +845,7 @@ type S16 struct{ _primitive[int16] }
 // It is equivalent to the Go type [uint16].
 // It implements the [Node], [Sized], [Type], and [TypeDefKind] interfaces.
 //
-// [primitive type]: https://component-model.bytecodealliance.org/wit-overview.html#primitive-types
+// [primitive type]: https://component-model.bytecodealliance.org/design/wit.html#primitive-types
 // [uint16]: https://pkg.go.dev/builtin#uint16
 type U16 struct{ _primitive[uint16] }
 
@@ -853,7 +853,7 @@ type U16 struct{ _primitive[uint16] }
 // It is equivalent to the Go type [int32].
 // It implements the [Node], [Sized], [Type], and [TypeDefKind] interfaces.
 //
-// [primitive type]: https://component-model.bytecodealliance.org/wit-overview.html#primitive-types
+// [primitive type]: https://component-model.bytecodealliance.org/design/wit.html#primitive-types
 // [int32]: https://pkg.go.dev/builtin#int32
 type S32 struct{ _primitive[int32] }
 
@@ -861,7 +861,7 @@ type S32 struct{ _primitive[int32] }
 // It is equivalent to the Go type [uint32].
 // It implements the [Node], [Sized], [Type], and [TypeDefKind] interfaces.
 //
-// [primitive type]: https://component-model.bytecodealliance.org/wit-overview.html#primitive-types
+// [primitive type]: https://component-model.bytecodealliance.org/design/wit.html#primitive-types
 // [uint32]: https://pkg.go.dev/builtin#uint32
 type U32 struct{ _primitive[uint32] }
 
@@ -869,7 +869,7 @@ type U32 struct{ _primitive[uint32] }
 // It is equivalent to the Go type [int64].
 // It implements the [Node], [Sized], [Type], and [TypeDefKind] interfaces.
 //
-// [primitive type]: https://component-model.bytecodealliance.org/wit-overview.html#primitive-types
+// [primitive type]: https://component-model.bytecodealliance.org/design/wit.html#primitive-types
 // [int64]: https://pkg.go.dev/builtin#int64
 type S64 struct{ _primitive[int64] }
 
@@ -877,7 +877,7 @@ type S64 struct{ _primitive[int64] }
 // It is equivalent to the Go type [uint64].
 // It implements the [Node], [Sized], [Type], and [TypeDefKind] interfaces.
 //
-// [primitive type]: https://component-model.bytecodealliance.org/wit-overview.html#primitive-types
+// [primitive type]: https://component-model.bytecodealliance.org/design/wit.html#primitive-types
 // [uint64]: https://pkg.go.dev/builtin#uint64
 type U64 struct{ _primitive[uint64] }
 
@@ -885,7 +885,7 @@ type U64 struct{ _primitive[uint64] }
 // It is equivalent to the Go type [float32].
 // It implements the [Node], [Sized], [Type], and [TypeDefKind] interfaces.
 //
-// [primitive type]: https://component-model.bytecodealliance.org/wit-overview.html#primitive-types
+// [primitive type]: https://component-model.bytecodealliance.org/design/wit.html#primitive-types
 // [float32]: https://pkg.go.dev/builtin#float32
 type Float32 struct{ _primitive[float32] }
 
@@ -893,7 +893,7 @@ type Float32 struct{ _primitive[float32] }
 // It is equivalent to the Go type [float64].
 // It implements the [Node], [Sized], [Type], and [TypeDefKind] interfaces.
 //
-// [primitive type]: https://component-model.bytecodealliance.org/wit-overview.html#primitive-types
+// [primitive type]: https://component-model.bytecodealliance.org/design/wit.html#primitive-types
 // [float64]: https://pkg.go.dev/builtin#float64
 type Float64 struct{ _primitive[float64] }
 
@@ -901,7 +901,7 @@ type Float64 struct{ _primitive[float64] }
 // specifically a [Unicode scalar value]. It is equivalent to the Go type [rune].
 // It implements the [Node], [Sized], [Type], and [TypeDefKind] interfaces.
 //
-// [primitive type]: https://component-model.bytecodealliance.org/wit-overview.html#primitive-types
+// [primitive type]: https://component-model.bytecodealliance.org/design/wit.html#primitive-types
 // [Unicode scalar value]: https://unicode.org/glossary/#unicode_scalar_value
 // [rune]: https://pkg.go.dev/builtin#rune
 type Char struct{ _primitive[char] }
@@ -910,7 +910,7 @@ type Char struct{ _primitive[char] }
 // It is equivalent to the Go type [string].
 // It implements the [Node], [Sized], [Type], and [TypeDefKind] interfaces.
 //
-// [primitive type]: https://component-model.bytecodealliance.org/wit-overview.html#primitive-types
+// [primitive type]: https://component-model.bytecodealliance.org/design/wit.html#primitive-types
 // [string]: https://pkg.go.dev/builtin#string
 type String struct{ _primitive[string] }
 
@@ -918,7 +918,7 @@ type String struct{ _primitive[string] }
 // Functions can be freestanding, methods, constructors or static.
 // It implements the [Node] and [WorldItem] interfaces.
 //
-// [function]: https://component-model.bytecodealliance.org/wit-overview.html#functions
+// [function]: https://component-model.bytecodealliance.org/design/wit.html#functions
 type Function struct {
 	Name    string
 	Kind    FunctionKind
@@ -932,7 +932,7 @@ type Function struct {
 // FunctionKind represents the kind of a WIT [function], which can be one of
 // [Freestanding], [Method], [Static], or [Constructor].
 //
-// [function]: https://component-model.bytecodealliance.org/wit-overview.html#functions
+// [function]: https://component-model.bytecodealliance.org/design/wit.html#functions
 type FunctionKind interface {
 	isFunctionKind()
 }
@@ -980,7 +980,7 @@ type Param struct {
 // a Package contains a unique identifier that affects generated components and uniquely
 // identifies this particular package.
 //
-// [WIT package]: https://component-model.bytecodealliance.org/wit-overview.html#packages
+// [WIT package]: https://component-model.bytecodealliance.org/design/wit.html#packages
 type Package struct {
 	Name       PackageName
 	Interfaces map[string]*Interface

--- a/wit/resolve.go
+++ b/wit/resolve.go
@@ -144,6 +144,46 @@ func (t *TypeDef) Align() uintptr {
 	return t.Kind.Align()
 }
 
+// Constructor returns the constructor for [TypeDef] t, or nil if none.
+// Currently t must be a [Resource] to have a constructor.
+func (t *TypeDef) Constructor() *Function {
+	var constructor *Function
+	t.Owner.AllFunctions(func(f *Function) bool {
+		if _, ok := f.Kind.(*Constructor); ok {
+			constructor = f
+			return false
+		}
+		return true
+	})
+	return constructor
+}
+
+// Methods returns all methods for [TypeDef] t.
+// Currently t must be a [Resource] to have methods.
+func (t *TypeDef) Methods() []*Function {
+	var methods []*Function
+	t.Owner.AllFunctions(func(f *Function) bool {
+		if m, ok := f.Kind.(*Method); ok && m.Type == t {
+			methods = append(methods, f)
+		}
+		return true
+	})
+	return methods
+}
+
+// StaticMethods returns all static methods for [TypeDef] t.
+// Currently t must be a [Resource] to have static methods.
+func (t *TypeDef) StaticMethods() []*Function {
+	var statics []*Function
+	t.Owner.AllFunctions(func(f *Function) bool {
+		if m, ok := f.Kind.(*Static); ok && m.Type == t {
+			statics = append(statics, f)
+		}
+		return true
+	})
+	return statics
+}
+
 // TypeDefKind represents the underlying type in a [TypeDef], which can be one of
 // [Record], [Resource], [Handle], [Flags], [Tuple], [Variant], [Enum],
 // [Option], [Result], [List], [Future], [Stream], or [Type].

--- a/wit/resolve.go
+++ b/wit/resolve.go
@@ -571,6 +571,7 @@ func (*Stream) Align() uintptr { return 0 }
 // TypeOwner is the interface implemented by any type that can own a TypeDef,
 // currently [World] and [Interface].
 type TypeOwner interface {
+	Node
 	isTypeOwner()
 }
 

--- a/wit/resolve.go
+++ b/wit/resolve.go
@@ -259,6 +259,11 @@ func (r *Resource) Align() uintptr { return 4 }
 
 // Handle represents a WIT [handle type].
 // It conforms to the [Node], [Sized], and [TypeDefKind] interfaces.
+// Handles represent the passing of unique ownership of a resource between
+// two components. When the owner of an owned handle drops that handle,
+// the resource is destroyed. In contrast, a borrowed handle represents
+// a temporary loan of a handle from the caller to the callee for the
+// duration of the call.
 //
 // [handle type]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md#handles
 type Handle interface {

--- a/wit/resolve.go
+++ b/wit/resolve.go
@@ -123,7 +123,7 @@ type TypeDef struct {
 	_type
 }
 
-// Root returns the Root [TypeDef] of [type alias] t.
+// Root returns the root [TypeDef] of [type alias] t.
 // If t is not a type alias, Root returns t.
 //
 // [type alias]: https://component-model.bytecodealliance.org/design/wit.html#type-aliases

--- a/wit/resolve.go
+++ b/wit/resolve.go
@@ -149,7 +149,7 @@ func (t *TypeDef) Align() uintptr {
 func (t *TypeDef) Constructor() *Function {
 	var constructor *Function
 	t.Owner.AllFunctions(func(f *Function) bool {
-		if _, ok := f.Kind.(*Constructor); ok {
+		if c, ok := f.Kind.(*Constructor); ok && c.Type == t {
 			constructor = f
 			return false
 		}
@@ -176,7 +176,7 @@ func (t *TypeDef) Methods() []*Function {
 func (t *TypeDef) StaticFunctions() []*Function {
 	var statics []*Function
 	t.Owner.AllFunctions(func(f *Function) bool {
-		if m, ok := f.Kind.(*Static); ok && m.Type == t {
+		if s, ok := f.Kind.(*Static); ok && s.Type == t {
 			statics = append(statics, f)
 		}
 		return true

--- a/wit/wit.go
+++ b/wit/wit.go
@@ -96,7 +96,7 @@ func (w *World) WIT(ctx Node, name string) string {
 func (w *World) itemWIT(motion, name string, v WorldItem) string {
 	switch v := v.(type) {
 	case *Interface, *Function:
-		return motion + " " + v.WIT(w, name)
+		return motion + " " + v.WIT(w, name) // TODO: handle resource methods?
 	case *TypeDef:
 		return v.WIT(w, name) // no motion, in Imports only
 	}

--- a/wit/wit.go
+++ b/wit/wit.go
@@ -511,6 +511,12 @@ func (p _primitive[T]) WIT(_ Node, name string) string {
 //
 // [WIT]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md
 func (f *Function) WIT(_ Node, name string) string {
+	if name == "" {
+		name = f.Name
+		if _, after, found := strings.Cut(name, "."); found {
+			name = after
+		}
+	}
 	// TODO: docs
 	var b strings.Builder
 	b.WriteString(name)

--- a/wit/wit.go
+++ b/wit/wit.go
@@ -124,25 +124,22 @@ func (i *Interface) WIT(ctx Node, name string) string {
 	}
 
 	b.WriteRune('{')
-	if len(i.TypeDefs) > 0 || len(i.Functions) > 0 {
-		b.WriteRune('\n')
-		n := 0
-		for _, name := range codec.SortedKeys(i.TypeDefs) {
-			// if n > 0 {
-			// 	b.WriteRune('\n')
-			// }
-			b.WriteString(indent(i.TypeDefs[name].WIT(i, name)))
-			b.WriteString(";\n")
-			n++
+	n := 0
+	for _, name := range codec.SortedKeys(i.TypeDefs) {
+		if n == 0 {
+			b.WriteRune('\n')
 		}
-		for _, name := range codec.SortedKeys(i.Functions) {
-			// if n > 0 {
-			// 	b.WriteRune('\n')
-			// }
-			b.WriteString(indent(i.Functions[name].WIT(i, name)))
-			b.WriteString(";\n")
-			n++
+		b.WriteString(indent(i.TypeDefs[name].WIT(i, name)))
+		b.WriteString(";\n")
+		n++
+	}
+	for _, name := range codec.SortedKeys(i.Functions) {
+		if n == 0 {
+			b.WriteRune('\n')
 		}
+		b.WriteString(indent(i.Functions[name].WIT(i, name)))
+		b.WriteString(";\n")
+		n++
 	}
 	b.WriteRune('}')
 	return b.String()

--- a/wit/wit.go
+++ b/wit/wit.go
@@ -187,12 +187,12 @@ func (t *TypeDef) WIT(ctx Node, name string) string {
 		if constructor != nil || len(methods) > 0 || len(statics) > 0 {
 			b.WriteString(" {\n")
 			if constructor != nil {
-				b.WriteString(indent(constructor.WIT(t, "")))
+				b.WriteString(indent(constructor.WIT(t, "constructor")))
 				b.WriteString(";\n")
 			}
 			slices.SortFunc(methods, functionCompare)
 			for _, f := range methods {
-				b.WriteString(indent(f.WIT(t, "constructor")))
+				b.WriteString(indent(f.WIT(t, "")))
 				b.WriteString(";\n")
 			}
 			slices.SortFunc(statics, functionCompare)

--- a/wit/wit.go
+++ b/wit/wit.go
@@ -69,7 +69,9 @@ func (w *World) WIT(ctx Node, name string) string {
 	}
 	var b strings.Builder
 	// TODO: docs
-	fmt.Fprintf(&b, "world %s {", name) // TODO: compare to w.Name?
+	b.WriteString("world ")
+	b.WriteString(name) // TODO: compare to w.Name?
+	b.WriteString(" {")
 	n := 0
 	for _, name := range codec.SortedKeys(w.Imports) {
 		if n == 0 {

--- a/wit/wit.go
+++ b/wit/wit.go
@@ -70,16 +70,22 @@ func (w *World) WIT(ctx Node, name string) string {
 	var b strings.Builder
 	// TODO: docs
 	fmt.Fprintf(&b, "world %s {", name) // TODO: compare to w.Name?
-	if len(w.Imports) > 0 || len(w.Exports) > 0 {
-		b.WriteRune('\n')
-		for _, name := range codec.SortedKeys(w.Imports) {
-			b.WriteString(indent(w.itemWIT("import", name, w.Imports[name])))
-			b.WriteString(";\n")
+	n := 0
+	for _, name := range codec.SortedKeys(w.Imports) {
+		if n == 0 {
+			b.WriteRune('\n')
 		}
-		for _, name := range codec.SortedKeys(w.Exports) {
-			b.WriteString(indent(w.itemWIT("export", name, w.Exports[name])))
-			b.WriteString(";\n")
+		b.WriteString(indent(w.itemWIT("import", name, w.Imports[name])))
+		b.WriteString(";\n")
+		n++
+	}
+	for _, name := range codec.SortedKeys(w.Exports) {
+		if n == 0 {
+			b.WriteRune('\n')
 		}
+		b.WriteString(indent(w.itemWIT("export", name, w.Exports[name])))
+		b.WriteString(";\n")
+		n++
 	}
 	b.WriteRune('}')
 	return b.String()

--- a/wit/wit.go
+++ b/wit/wit.go
@@ -169,11 +169,7 @@ func (t *TypeDef) WIT(ctx Node, name string) string {
 		return fmt.Sprintf("use %s.{%s}", ownerName, name)
 
 	case *World, *Interface:
-		switch t.Kind.(type) {
-		case *TypeDef:
-			return t.Kind.WIT(t, name)
-		}
-		return t.Kind.WIT(ctx, name)
+		return t.Kind.WIT(t, name)
 	}
 	if name != "" {
 		return name

--- a/wit/wit.go
+++ b/wit/wit.go
@@ -450,14 +450,12 @@ func (r *Result) WIT(_ Node, name string) string {
 	b.WriteString("result<")
 	if r.OK != nil {
 		b.WriteString(r.OK.WIT(r, ""))
-		b.WriteString(", ")
-	} else {
-		b.WriteString("_, ")
-	}
-	if r.Err != nil {
-		b.WriteString(r.Err.WIT(r, ""))
 	} else {
 		b.WriteRune('_')
+	}
+	if r.Err != nil {
+		b.WriteString(", ")
+		b.WriteString(r.Err.WIT(r, ""))
 	}
 	b.WriteRune('>')
 	return b.String()

--- a/wit/wit.go
+++ b/wit/wit.go
@@ -11,7 +11,7 @@ import (
 // Node is the interface implemented by the WIT ([WebAssembly Interface Type])
 // types in this package.
 //
-// [WebAssembly Interface Type]: https://component-model.bytecodealliance.org/wit-overview.html
+// [WebAssembly Interface Type]: https://component-model.bytecodealliance.org/design/wit.html
 type Node interface {
 	WIT(ctx Node, name string) string
 }

--- a/wit/wit.go
+++ b/wit/wit.go
@@ -134,10 +134,14 @@ func (i *Interface) WIT(ctx Node, name string) string {
 		n++
 	}
 	for _, name := range codec.SortedKeys(i.Functions) {
+		f := i.Functions[name]
+		if _, ok := f.Kind.(*Freestanding); !ok {
+			continue
+		}
 		if n == 0 {
 			b.WriteRune('\n')
 		}
-		b.WriteString(indent(i.Functions[name].WIT(i, name)))
+		b.WriteString(indent(f.WIT(i, name)))
 		b.WriteString(";\n")
 		n++
 	}


### PR DESCRIPTION
This PR improves support for Component Model resource types and own/borrow handles.

- `Resource` methods, constructor, and static functions can be reversed back into WIT form with `wasm-tools-go wit`
- `Result` types without an error value are `result<T>` and not `result<T, _>`
- Adds helper methods to `TypeDef`:
    - `Constructor() *Function`
    - `Methods() []*Function`
    - `StaticFunctions() []*Function`

These are needed for WIT generation and will serve as a foundation for Go codegen.