### PR TITLE
provably correct round-trip WIT generation

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Wasmtime
         uses: bytecodealliance/actions/wasmtime/setup@v1.0.0
         with:
-          version: "v13.0.0"
+          version: "v14.0.4"
 
       - name: Vet Go code
         run: go vet ./...
@@ -48,7 +48,10 @@ jobs:
         run: tinygo test -v ./...
 
       - name: Test with TinyGo + WASI
-        run: tinygo test -v -target=wasi -stack-size=64KB ./...
+        env:
+          GOOS: wasip1
+          GOARCH: wasm
+        run: tinygo test -stack-size=64KB ./...
 
       - name: Verify repo is unchanged
         run: git diff --exit-code HEAD

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -33,6 +33,9 @@ jobs:
         with:
           version: "v14.0.4"
 
+      - name: Set up wasm-tools
+        uses: bytecodealliance/actions/wasm-tools/setup@v1.0.0
+
       - name: Vet Go code
         run: go vet ./...
 

--- a/testdata/escape/escaped-names.wit
+++ b/testdata/escape/escaped-names.wit
@@ -1,0 +1,59 @@
+package example:escaped-names;
+
+interface %interface {
+    record %record {
+        %enum: %enum,
+        %result: result<string, error>,
+    }
+
+    enum error {
+        ok,
+        fail
+    }
+
+    record %export {
+        headers: list<tuple<list<u8>, list<u8>>>,
+        body: list<u8>
+    }
+
+    enum %enum {
+        %enum,
+        %export,
+        %flags,
+        %func,
+        %import,
+        %include,
+        %interface,
+        %package,
+        %record,
+        %resource,
+        %static,
+        %type,
+        %variant,
+        %world,
+    }
+
+    variant %variant {
+        %enum(%record),
+        %export(%record),
+        %flags(%record),
+        %func(%record),
+        %import(%record),
+        %include(%record),
+        %interface(%record),
+        %package(%record),
+        %record(%record),
+        %resource(%record),
+        %static(%record),
+        %type(%record),
+        %variant(%record),
+        %world(%record),
+    }
+
+    %func: func(rec: %record) -> result<%export, error>;
+}
+
+world %world {
+    import %interface;
+    export %interface;
+}

--- a/testdata/escape/escaped-names.wit.json
+++ b/testdata/escape/escaped-names.wit.json
@@ -1,0 +1,218 @@
+{
+  "worlds": [
+    {
+      "name": "world",
+      "imports": {
+        "interface-0": {
+          "interface": 0
+        }
+      },
+      "exports": {
+        "interface-0": {
+          "interface": 0
+        }
+      },
+      "package": 0
+    }
+  ],
+  "interfaces": [
+    {
+      "name": "interface",
+      "types": {
+        "error": 0,
+        "export": 4,
+        "enum": 5,
+        "record": 7
+      },
+      "functions": {
+        "func": {
+          "name": "func",
+          "kind": "freestanding",
+          "params": [
+            {
+              "name": "rec",
+              "type": 7
+            }
+          ],
+          "results": [
+            {
+              "type": 8
+            }
+          ]
+        }
+      },
+      "package": 0
+    }
+  ],
+  "types": [
+    {
+      "name": "error",
+      "kind": {
+        "enum": {
+          "cases": [
+            {
+              "name": "ok"
+            },
+            {
+              "name": "fail"
+            }
+          ]
+        }
+      },
+      "owner": {
+        "interface": 0
+      }
+    },
+    {
+      "name": null,
+      "kind": {
+        "list": "u8"
+      },
+      "owner": null
+    },
+    {
+      "name": null,
+      "kind": {
+        "tuple": {
+          "types": [
+            1,
+            1
+          ]
+        }
+      },
+      "owner": null
+    },
+    {
+      "name": null,
+      "kind": {
+        "list": 2
+      },
+      "owner": null
+    },
+    {
+      "name": "export",
+      "kind": {
+        "record": {
+          "fields": [
+            {
+              "name": "headers",
+              "type": 3
+            },
+            {
+              "name": "body",
+              "type": 1
+            }
+          ]
+        }
+      },
+      "owner": {
+        "interface": 0
+      }
+    },
+    {
+      "name": "enum",
+      "kind": {
+        "enum": {
+          "cases": [
+            {
+              "name": "enum"
+            },
+            {
+              "name": "export"
+            },
+            {
+              "name": "flags"
+            },
+            {
+              "name": "func"
+            },
+            {
+              "name": "import"
+            },
+            {
+              "name": "include"
+            },
+            {
+              "name": "interface"
+            },
+            {
+              "name": "package"
+            },
+            {
+              "name": "record"
+            },
+            {
+              "name": "resource"
+            },
+            {
+              "name": "static"
+            },
+            {
+              "name": "type"
+            },
+            {
+              "name": "variant"
+            },
+            {
+              "name": "world"
+            }
+          ]
+        }
+      },
+      "owner": {
+        "interface": 0
+      }
+    },
+    {
+      "name": null,
+      "kind": {
+        "result": {
+          "ok": "string",
+          "err": 0
+        }
+      },
+      "owner": null
+    },
+    {
+      "name": "record",
+      "kind": {
+        "record": {
+          "fields": [
+            {
+              "name": "enum",
+              "type": 5
+            },
+            {
+              "name": "result",
+              "type": 6
+            }
+          ]
+        }
+      },
+      "owner": {
+        "interface": 0
+      }
+    },
+    {
+      "name": null,
+      "kind": {
+        "result": {
+          "ok": 4,
+          "err": 0
+        }
+      },
+      "owner": null
+    }
+  ],
+  "packages": [
+    {
+      "name": "example:escaped-names",
+      "interfaces": {
+        "interface": 0
+      },
+      "worlds": {
+        "world": 0
+      }
+    }
+  ]
+}

--- a/testdata/escape/escaped-names.wit.json.golden
+++ b/testdata/escape/escaped-names.wit.json.golden
@@ -1,0 +1,1146 @@
+&wit.Resolve{
+    Worlds: {
+        &wit.World{
+            Name:    "world",
+            Imports: {
+                "interface-0": &wit.Interface{
+                    Name:     &"interface",
+                    TypeDefs: {
+                        "enum": &wit.TypeDef{
+                            Name: &"enum",
+                            Kind: &wit.Enum{
+                                Cases: {
+                                    {
+                                        Name: "enum",
+                                        Docs: wit.Docs{},
+                                    },
+                                    {
+                                        Name: "export",
+                                        Docs: wit.Docs{},
+                                    },
+                                    {
+                                        Name: "flags",
+                                        Docs: wit.Docs{},
+                                    },
+                                    {
+                                        Name: "func",
+                                        Docs: wit.Docs{},
+                                    },
+                                    {
+                                        Name: "import",
+                                        Docs: wit.Docs{},
+                                    },
+                                    {
+                                        Name: "include",
+                                        Docs: wit.Docs{},
+                                    },
+                                    {
+                                        Name: "interface",
+                                        Docs: wit.Docs{},
+                                    },
+                                    {
+                                        Name: "package",
+                                        Docs: wit.Docs{},
+                                    },
+                                    {
+                                        Name: "record",
+                                        Docs: wit.Docs{},
+                                    },
+                                    {
+                                        Name: "resource",
+                                        Docs: wit.Docs{},
+                                    },
+                                    {
+                                        Name: "static",
+                                        Docs: wit.Docs{},
+                                    },
+                                    {
+                                        Name: "type",
+                                        Docs: wit.Docs{},
+                                    },
+                                    {
+                                        Name: "variant",
+                                        Docs: wit.Docs{},
+                                    },
+                                    {
+                                        Name: "world",
+                                        Docs: wit.Docs{},
+                                    },
+                                },
+                                _typeDefKind: wit._typeDefKind{},
+                            },
+                            Owner:      &wit.Interface{(CYCLIC REFERENCE)},
+                            Docs:       wit.Docs{},
+                            _worldItem: wit._worldItem{},
+                            _type:      wit._type{},
+                        },
+                        "error": &wit.TypeDef{
+                            Name: &"error",
+                            Kind: &wit.Enum{
+                                Cases: {
+                                    {
+                                        Name: "ok",
+                                        Docs: wit.Docs{},
+                                    },
+                                    {
+                                        Name: "fail",
+                                        Docs: wit.Docs{},
+                                    },
+                                },
+                                _typeDefKind: wit._typeDefKind{},
+                            },
+                            Owner:      &wit.Interface{(CYCLIC REFERENCE)},
+                            Docs:       wit.Docs{},
+                            _worldItem: wit._worldItem{},
+                            _type:      wit._type{},
+                        },
+                        "export": &wit.TypeDef{
+                            Name: &"export",
+                            Kind: &wit.Record{
+                                Fields: {
+                                    {
+                                        Name: "headers",
+                                        Type: &wit.TypeDef{
+                                            Name: (*string)(nil),
+                                            Kind: &wit.List{
+                                                Type: &wit.TypeDef{
+                                                    Name: (*string)(nil),
+                                                    Kind: &wit.Tuple{
+                                                        Types: {
+                                                            !%v(DEPTH EXCEEDED),
+                                                            !%v(DEPTH EXCEEDED),
+                                                        },
+                                                        _typeDefKind: wit._typeDefKind{},
+                                                    },
+                                                    Owner:      nil,
+                                                    Docs:       wit.Docs{},
+                                                    _worldItem: wit._worldItem{},
+                                                    _type:      wit._type{},
+                                                },
+                                                _typeDefKind: wit._typeDefKind{},
+                                            },
+                                            Owner:      nil,
+                                            Docs:       wit.Docs{},
+                                            _worldItem: wit._worldItem{},
+                                            _type:      wit._type{},
+                                        },
+                                        Docs: wit.Docs{},
+                                    },
+                                    {
+                                        Name: "body",
+                                        Type: &wit.TypeDef{
+                                            Name: (*string)(nil),
+                                            Kind: &wit.List{
+                                                Type:         wit.U8{},
+                                                _typeDefKind: wit._typeDefKind{},
+                                            },
+                                            Owner:      nil,
+                                            Docs:       wit.Docs{},
+                                            _worldItem: wit._worldItem{},
+                                            _type:      wit._type{},
+                                        },
+                                        Docs: wit.Docs{},
+                                    },
+                                },
+                                _typeDefKind: wit._typeDefKind{},
+                            },
+                            Owner:      &wit.Interface{(CYCLIC REFERENCE)},
+                            Docs:       wit.Docs{},
+                            _worldItem: wit._worldItem{},
+                            _type:      wit._type{},
+                        },
+                        "record": &wit.TypeDef{
+                            Name: &"record",
+                            Kind: &wit.Record{
+                                Fields: {
+                                    {
+                                        Name: "enum",
+                                        Type: &wit.TypeDef{(CYCLIC REFERENCE)},
+                                        Docs: wit.Docs{},
+                                    },
+                                    {
+                                        Name: "result",
+                                        Type: &wit.TypeDef{
+                                            Name: (*string)(nil),
+                                            Kind: &wit.Result{
+                                                OK:           wit.String{},
+                                                Err:          &wit.TypeDef{(CYCLIC REFERENCE)},
+                                                _typeDefKind: wit._typeDefKind{},
+                                            },
+                                            Owner:      nil,
+                                            Docs:       wit.Docs{},
+                                            _worldItem: wit._worldItem{},
+                                            _type:      wit._type{},
+                                        },
+                                        Docs: wit.Docs{},
+                                    },
+                                },
+                                _typeDefKind: wit._typeDefKind{},
+                            },
+                            Owner:      &wit.Interface{(CYCLIC REFERENCE)},
+                            Docs:       wit.Docs{},
+                            _worldItem: wit._worldItem{},
+                            _type:      wit._type{},
+                        },
+                    },
+                    Functions: {
+                        "func": &wit.Function{
+                            Name:   "func",
+                            Kind:   &wit.Freestanding{},
+                            Params: {
+                                {
+                                    Name: "rec",
+                                    Type: &wit.TypeDef{(CYCLIC REFERENCE)},
+                                },
+                            },
+                            Results: {
+                                {
+                                    Name: "",
+                                    Type: &wit.TypeDef{
+                                        Name: (*string)(nil),
+                                        Kind: &wit.Result{
+                                            OK:           &wit.TypeDef{(CYCLIC REFERENCE)},
+                                            Err:          &wit.TypeDef{(CYCLIC REFERENCE)},
+                                            _typeDefKind: wit._typeDefKind{},
+                                        },
+                                        Owner:      nil,
+                                        Docs:       wit.Docs{},
+                                        _worldItem: wit._worldItem{},
+                                        _type:      wit._type{},
+                                    },
+                                },
+                            },
+                            Docs:       wit.Docs{},
+                            _worldItem: wit._worldItem{},
+                        },
+                    },
+                    Package: &wit.Package{
+                        Name: wit.PackageName{
+                            Namespace: "example",
+                            Name:      "escaped-names",
+                            Version:   (*semver.Version)(nil),
+                            _node:     wit._node{},
+                        },
+                        Interfaces: {
+                            "interface": &wit.Interface{(CYCLIC REFERENCE)},
+                        },
+                        Worlds: {
+                            "world": &wit.World{(CYCLIC REFERENCE)},
+                        },
+                        Docs: wit.Docs{},
+                    },
+                    Docs:       wit.Docs{},
+                    _typeOwner: wit._typeOwner{},
+                    _worldItem: wit._worldItem{},
+                },
+            },
+            Exports: {
+                "interface-0": &wit.Interface{
+                    Name:     &"interface",
+                    TypeDefs: {
+                        "enum": &wit.TypeDef{
+                            Name: &"enum",
+                            Kind: &wit.Enum{
+                                Cases: {
+                                    {
+                                        Name: "enum",
+                                        Docs: wit.Docs{},
+                                    },
+                                    {
+                                        Name: "export",
+                                        Docs: wit.Docs{},
+                                    },
+                                    {
+                                        Name: "flags",
+                                        Docs: wit.Docs{},
+                                    },
+                                    {
+                                        Name: "func",
+                                        Docs: wit.Docs{},
+                                    },
+                                    {
+                                        Name: "import",
+                                        Docs: wit.Docs{},
+                                    },
+                                    {
+                                        Name: "include",
+                                        Docs: wit.Docs{},
+                                    },
+                                    {
+                                        Name: "interface",
+                                        Docs: wit.Docs{},
+                                    },
+                                    {
+                                        Name: "package",
+                                        Docs: wit.Docs{},
+                                    },
+                                    {
+                                        Name: "record",
+                                        Docs: wit.Docs{},
+                                    },
+                                    {
+                                        Name: "resource",
+                                        Docs: wit.Docs{},
+                                    },
+                                    {
+                                        Name: "static",
+                                        Docs: wit.Docs{},
+                                    },
+                                    {
+                                        Name: "type",
+                                        Docs: wit.Docs{},
+                                    },
+                                    {
+                                        Name: "variant",
+                                        Docs: wit.Docs{},
+                                    },
+                                    {
+                                        Name: "world",
+                                        Docs: wit.Docs{},
+                                    },
+                                },
+                                _typeDefKind: wit._typeDefKind{},
+                            },
+                            Owner:      &wit.Interface{(CYCLIC REFERENCE)},
+                            Docs:       wit.Docs{},
+                            _worldItem: wit._worldItem{},
+                            _type:      wit._type{},
+                        },
+                        "error": &wit.TypeDef{
+                            Name: &"error",
+                            Kind: &wit.Enum{
+                                Cases: {
+                                    {
+                                        Name: "ok",
+                                        Docs: wit.Docs{},
+                                    },
+                                    {
+                                        Name: "fail",
+                                        Docs: wit.Docs{},
+                                    },
+                                },
+                                _typeDefKind: wit._typeDefKind{},
+                            },
+                            Owner:      &wit.Interface{(CYCLIC REFERENCE)},
+                            Docs:       wit.Docs{},
+                            _worldItem: wit._worldItem{},
+                            _type:      wit._type{},
+                        },
+                        "export": &wit.TypeDef{
+                            Name: &"export",
+                            Kind: &wit.Record{
+                                Fields: {
+                                    {
+                                        Name: "headers",
+                                        Type: &wit.TypeDef{
+                                            Name: (*string)(nil),
+                                            Kind: &wit.List{
+                                                Type: &wit.TypeDef{
+                                                    Name: (*string)(nil),
+                                                    Kind: &wit.Tuple{
+                                                        Types: {
+                                                            !%v(DEPTH EXCEEDED),
+                                                            !%v(DEPTH EXCEEDED),
+                                                        },
+                                                        _typeDefKind: wit._typeDefKind{},
+                                                    },
+                                                    Owner:      nil,
+                                                    Docs:       wit.Docs{},
+                                                    _worldItem: wit._worldItem{},
+                                                    _type:      wit._type{},
+                                                },
+                                                _typeDefKind: wit._typeDefKind{},
+                                            },
+                                            Owner:      nil,
+                                            Docs:       wit.Docs{},
+                                            _worldItem: wit._worldItem{},
+                                            _type:      wit._type{},
+                                        },
+                                        Docs: wit.Docs{},
+                                    },
+                                    {
+                                        Name: "body",
+                                        Type: &wit.TypeDef{
+                                            Name: (*string)(nil),
+                                            Kind: &wit.List{
+                                                Type:         wit.U8{},
+                                                _typeDefKind: wit._typeDefKind{},
+                                            },
+                                            Owner:      nil,
+                                            Docs:       wit.Docs{},
+                                            _worldItem: wit._worldItem{},
+                                            _type:      wit._type{},
+                                        },
+                                        Docs: wit.Docs{},
+                                    },
+                                },
+                                _typeDefKind: wit._typeDefKind{},
+                            },
+                            Owner:      &wit.Interface{(CYCLIC REFERENCE)},
+                            Docs:       wit.Docs{},
+                            _worldItem: wit._worldItem{},
+                            _type:      wit._type{},
+                        },
+                        "record": &wit.TypeDef{
+                            Name: &"record",
+                            Kind: &wit.Record{
+                                Fields: {
+                                    {
+                                        Name: "enum",
+                                        Type: &wit.TypeDef{(CYCLIC REFERENCE)},
+                                        Docs: wit.Docs{},
+                                    },
+                                    {
+                                        Name: "result",
+                                        Type: &wit.TypeDef{
+                                            Name: (*string)(nil),
+                                            Kind: &wit.Result{
+                                                OK:           wit.String{},
+                                                Err:          &wit.TypeDef{(CYCLIC REFERENCE)},
+                                                _typeDefKind: wit._typeDefKind{},
+                                            },
+                                            Owner:      nil,
+                                            Docs:       wit.Docs{},
+                                            _worldItem: wit._worldItem{},
+                                            _type:      wit._type{},
+                                        },
+                                        Docs: wit.Docs{},
+                                    },
+                                },
+                                _typeDefKind: wit._typeDefKind{},
+                            },
+                            Owner:      &wit.Interface{(CYCLIC REFERENCE)},
+                            Docs:       wit.Docs{},
+                            _worldItem: wit._worldItem{},
+                            _type:      wit._type{},
+                        },
+                    },
+                    Functions: {
+                        "func": &wit.Function{
+                            Name:   "func",
+                            Kind:   &wit.Freestanding{},
+                            Params: {
+                                {
+                                    Name: "rec",
+                                    Type: &wit.TypeDef{(CYCLIC REFERENCE)},
+                                },
+                            },
+                            Results: {
+                                {
+                                    Name: "",
+                                    Type: &wit.TypeDef{
+                                        Name: (*string)(nil),
+                                        Kind: &wit.Result{
+                                            OK:           &wit.TypeDef{(CYCLIC REFERENCE)},
+                                            Err:          &wit.TypeDef{(CYCLIC REFERENCE)},
+                                            _typeDefKind: wit._typeDefKind{},
+                                        },
+                                        Owner:      nil,
+                                        Docs:       wit.Docs{},
+                                        _worldItem: wit._worldItem{},
+                                        _type:      wit._type{},
+                                    },
+                                },
+                            },
+                            Docs:       wit.Docs{},
+                            _worldItem: wit._worldItem{},
+                        },
+                    },
+                    Package: &wit.Package{
+                        Name: wit.PackageName{
+                            Namespace: "example",
+                            Name:      "escaped-names",
+                            Version:   (*semver.Version)(nil),
+                            _node:     wit._node{},
+                        },
+                        Interfaces: {
+                            "interface": &wit.Interface{(CYCLIC REFERENCE)},
+                        },
+                        Worlds: {
+                            "world": &wit.World{(CYCLIC REFERENCE)},
+                        },
+                        Docs: wit.Docs{},
+                    },
+                    Docs:       wit.Docs{},
+                    _typeOwner: wit._typeOwner{},
+                    _worldItem: wit._worldItem{},
+                },
+            },
+            Package: &wit.Package{
+                Name: wit.PackageName{
+                    Namespace: "example",
+                    Name:      "escaped-names",
+                    Version:   (*semver.Version)(nil),
+                    _node:     wit._node{},
+                },
+                Interfaces: {
+                    "interface": &wit.Interface{
+                        Name:     &"interface",
+                        TypeDefs: {
+                            "enum": &wit.TypeDef{
+                                Name: &"enum",
+                                Kind: &wit.Enum{
+                                    Cases: {
+                                        {
+                                            Name: "enum",
+                                            Docs: wit.Docs{},
+                                        },
+                                        {
+                                            Name: "export",
+                                            Docs: wit.Docs{},
+                                        },
+                                        {
+                                            Name: "flags",
+                                            Docs: wit.Docs{},
+                                        },
+                                        {
+                                            Name: "func",
+                                            Docs: wit.Docs{},
+                                        },
+                                        {
+                                            Name: "import",
+                                            Docs: wit.Docs{},
+                                        },
+                                        {
+                                            Name: "include",
+                                            Docs: wit.Docs{},
+                                        },
+                                        {
+                                            Name: "interface",
+                                            Docs: wit.Docs{},
+                                        },
+                                        {
+                                            Name: "package",
+                                            Docs: wit.Docs{},
+                                        },
+                                        {
+                                            Name: "record",
+                                            Docs: wit.Docs{},
+                                        },
+                                        {
+                                            Name: "resource",
+                                            Docs: wit.Docs{},
+                                        },
+                                        {
+                                            Name: "static",
+                                            Docs: wit.Docs{},
+                                        },
+                                        {
+                                            Name: "type",
+                                            Docs: wit.Docs{},
+                                        },
+                                        {
+                                            Name: "variant",
+                                            Docs: wit.Docs{},
+                                        },
+                                        {
+                                            Name: "world",
+                                            Docs: wit.Docs{},
+                                        },
+                                    },
+                                    _typeDefKind: wit._typeDefKind{},
+                                },
+                                Owner:      &wit.Interface{(CYCLIC REFERENCE)},
+                                Docs:       wit.Docs{},
+                                _worldItem: wit._worldItem{},
+                                _type:      wit._type{},
+                            },
+                            "error": &wit.TypeDef{
+                                Name: &"error",
+                                Kind: &wit.Enum{
+                                    Cases: {
+                                        {
+                                            Name: "ok",
+                                            Docs: wit.Docs{},
+                                        },
+                                        {
+                                            Name: "fail",
+                                            Docs: wit.Docs{},
+                                        },
+                                    },
+                                    _typeDefKind: wit._typeDefKind{},
+                                },
+                                Owner:      &wit.Interface{(CYCLIC REFERENCE)},
+                                Docs:       wit.Docs{},
+                                _worldItem: wit._worldItem{},
+                                _type:      wit._type{},
+                            },
+                            "export": &wit.TypeDef{
+                                Name: &"export",
+                                Kind: &wit.Record{
+                                    Fields: {
+                                        {
+                                            Name: "headers",
+                                            Type: &wit.TypeDef{
+                                                Name: (*string)(nil),
+                                                Kind: &wit.List{
+                                                    Type: &wit.TypeDef{
+                                                        Name: (*string)(nil),
+                                                        Kind: &wit.Tuple{
+                                                            Types: {
+                                                                !%v(DEPTH EXCEEDED),
+                                                                !%v(DEPTH EXCEEDED),
+                                                            },
+                                                            _typeDefKind: wit._typeDefKind{},
+                                                        },
+                                                        Owner:      nil,
+                                                        Docs:       wit.Docs{},
+                                                        _worldItem: wit._worldItem{},
+                                                        _type:      wit._type{},
+                                                    },
+                                                    _typeDefKind: wit._typeDefKind{},
+                                                },
+                                                Owner:      nil,
+                                                Docs:       wit.Docs{},
+                                                _worldItem: wit._worldItem{},
+                                                _type:      wit._type{},
+                                            },
+                                            Docs: wit.Docs{},
+                                        },
+                                        {
+                                            Name: "body",
+                                            Type: &wit.TypeDef{
+                                                Name: (*string)(nil),
+                                                Kind: &wit.List{
+                                                    Type:         wit.U8{},
+                                                    _typeDefKind: wit._typeDefKind{},
+                                                },
+                                                Owner:      nil,
+                                                Docs:       wit.Docs{},
+                                                _worldItem: wit._worldItem{},
+                                                _type:      wit._type{},
+                                            },
+                                            Docs: wit.Docs{},
+                                        },
+                                    },
+                                    _typeDefKind: wit._typeDefKind{},
+                                },
+                                Owner:      &wit.Interface{(CYCLIC REFERENCE)},
+                                Docs:       wit.Docs{},
+                                _worldItem: wit._worldItem{},
+                                _type:      wit._type{},
+                            },
+                            "record": &wit.TypeDef{
+                                Name: &"record",
+                                Kind: &wit.Record{
+                                    Fields: {
+                                        {
+                                            Name: "enum",
+                                            Type: &wit.TypeDef{(CYCLIC REFERENCE)},
+                                            Docs: wit.Docs{},
+                                        },
+                                        {
+                                            Name: "result",
+                                            Type: &wit.TypeDef{
+                                                Name: (*string)(nil),
+                                                Kind: &wit.Result{
+                                                    OK:           wit.String{},
+                                                    Err:          &wit.TypeDef{(CYCLIC REFERENCE)},
+                                                    _typeDefKind: wit._typeDefKind{},
+                                                },
+                                                Owner:      nil,
+                                                Docs:       wit.Docs{},
+                                                _worldItem: wit._worldItem{},
+                                                _type:      wit._type{},
+                                            },
+                                            Docs: wit.Docs{},
+                                        },
+                                    },
+                                    _typeDefKind: wit._typeDefKind{},
+                                },
+                                Owner:      &wit.Interface{(CYCLIC REFERENCE)},
+                                Docs:       wit.Docs{},
+                                _worldItem: wit._worldItem{},
+                                _type:      wit._type{},
+                            },
+                        },
+                        Functions: {
+                            "func": &wit.Function{
+                                Name:   "func",
+                                Kind:   &wit.Freestanding{},
+                                Params: {
+                                    {
+                                        Name: "rec",
+                                        Type: &wit.TypeDef{(CYCLIC REFERENCE)},
+                                    },
+                                },
+                                Results: {
+                                    {
+                                        Name: "",
+                                        Type: &wit.TypeDef{
+                                            Name: (*string)(nil),
+                                            Kind: &wit.Result{
+                                                OK:           &wit.TypeDef{(CYCLIC REFERENCE)},
+                                                Err:          &wit.TypeDef{(CYCLIC REFERENCE)},
+                                                _typeDefKind: wit._typeDefKind{},
+                                            },
+                                            Owner:      nil,
+                                            Docs:       wit.Docs{},
+                                            _worldItem: wit._worldItem{},
+                                            _type:      wit._type{},
+                                        },
+                                    },
+                                },
+                                Docs:       wit.Docs{},
+                                _worldItem: wit._worldItem{},
+                            },
+                        },
+                        Package:    &wit.Package{(CYCLIC REFERENCE)},
+                        Docs:       wit.Docs{},
+                        _typeOwner: wit._typeOwner{},
+                        _worldItem: wit._worldItem{},
+                    },
+                },
+                Worlds: {
+                    "world": &wit.World{(CYCLIC REFERENCE)},
+                },
+                Docs: wit.Docs{},
+            },
+            Docs:       wit.Docs{},
+            _typeOwner: wit._typeOwner{},
+        },
+    },
+    Interfaces: {
+        &wit.Interface{
+            Name:     &"interface",
+            TypeDefs: {
+                "enum": &wit.TypeDef{
+                    Name: &"enum",
+                    Kind: &wit.Enum{
+                        Cases: {
+                            {
+                                Name: "enum",
+                                Docs: wit.Docs{},
+                            },
+                            {
+                                Name: "export",
+                                Docs: wit.Docs{},
+                            },
+                            {
+                                Name: "flags",
+                                Docs: wit.Docs{},
+                            },
+                            {
+                                Name: "func",
+                                Docs: wit.Docs{},
+                            },
+                            {
+                                Name: "import",
+                                Docs: wit.Docs{},
+                            },
+                            {
+                                Name: "include",
+                                Docs: wit.Docs{},
+                            },
+                            {
+                                Name: "interface",
+                                Docs: wit.Docs{},
+                            },
+                            {
+                                Name: "package",
+                                Docs: wit.Docs{},
+                            },
+                            {
+                                Name: "record",
+                                Docs: wit.Docs{},
+                            },
+                            {
+                                Name: "resource",
+                                Docs: wit.Docs{},
+                            },
+                            {
+                                Name: "static",
+                                Docs: wit.Docs{},
+                            },
+                            {
+                                Name: "type",
+                                Docs: wit.Docs{},
+                            },
+                            {
+                                Name: "variant",
+                                Docs: wit.Docs{},
+                            },
+                            {
+                                Name: "world",
+                                Docs: wit.Docs{},
+                            },
+                        },
+                        _typeDefKind: wit._typeDefKind{},
+                    },
+                    Owner:      &wit.Interface{(CYCLIC REFERENCE)},
+                    Docs:       wit.Docs{},
+                    _worldItem: wit._worldItem{},
+                    _type:      wit._type{},
+                },
+                "error": &wit.TypeDef{
+                    Name: &"error",
+                    Kind: &wit.Enum{
+                        Cases: {
+                            {
+                                Name: "ok",
+                                Docs: wit.Docs{},
+                            },
+                            {
+                                Name: "fail",
+                                Docs: wit.Docs{},
+                            },
+                        },
+                        _typeDefKind: wit._typeDefKind{},
+                    },
+                    Owner:      &wit.Interface{(CYCLIC REFERENCE)},
+                    Docs:       wit.Docs{},
+                    _worldItem: wit._worldItem{},
+                    _type:      wit._type{},
+                },
+                "export": &wit.TypeDef{
+                    Name: &"export",
+                    Kind: &wit.Record{
+                        Fields: {
+                            {
+                                Name: "headers",
+                                Type: &wit.TypeDef{
+                                    Name: (*string)(nil),
+                                    Kind: &wit.List{
+                                        Type: &wit.TypeDef{
+                                            Name: (*string)(nil),
+                                            Kind: &wit.Tuple{
+                                                Types: {
+                                                    &wit.TypeDef{(CYCLIC REFERENCE)},
+                                                    &wit.TypeDef{(CYCLIC REFERENCE)},
+                                                },
+                                                _typeDefKind: wit._typeDefKind{},
+                                            },
+                                            Owner:      nil,
+                                            Docs:       wit.Docs{},
+                                            _worldItem: wit._worldItem{},
+                                            _type:      wit._type{},
+                                        },
+                                        _typeDefKind: wit._typeDefKind{},
+                                    },
+                                    Owner:      nil,
+                                    Docs:       wit.Docs{},
+                                    _worldItem: wit._worldItem{},
+                                    _type:      wit._type{},
+                                },
+                                Docs: wit.Docs{},
+                            },
+                            {
+                                Name: "body",
+                                Type: &wit.TypeDef{
+                                    Name: (*string)(nil),
+                                    Kind: &wit.List{
+                                        Type:         wit.U8{},
+                                        _typeDefKind: wit._typeDefKind{},
+                                    },
+                                    Owner:      nil,
+                                    Docs:       wit.Docs{},
+                                    _worldItem: wit._worldItem{},
+                                    _type:      wit._type{},
+                                },
+                                Docs: wit.Docs{},
+                            },
+                        },
+                        _typeDefKind: wit._typeDefKind{},
+                    },
+                    Owner:      &wit.Interface{(CYCLIC REFERENCE)},
+                    Docs:       wit.Docs{},
+                    _worldItem: wit._worldItem{},
+                    _type:      wit._type{},
+                },
+                "record": &wit.TypeDef{
+                    Name: &"record",
+                    Kind: &wit.Record{
+                        Fields: {
+                            {
+                                Name: "enum",
+                                Type: &wit.TypeDef{(CYCLIC REFERENCE)},
+                                Docs: wit.Docs{},
+                            },
+                            {
+                                Name: "result",
+                                Type: &wit.TypeDef{
+                                    Name: (*string)(nil),
+                                    Kind: &wit.Result{
+                                        OK:           wit.String{},
+                                        Err:          &wit.TypeDef{(CYCLIC REFERENCE)},
+                                        _typeDefKind: wit._typeDefKind{},
+                                    },
+                                    Owner:      nil,
+                                    Docs:       wit.Docs{},
+                                    _worldItem: wit._worldItem{},
+                                    _type:      wit._type{},
+                                },
+                                Docs: wit.Docs{},
+                            },
+                        },
+                        _typeDefKind: wit._typeDefKind{},
+                    },
+                    Owner:      &wit.Interface{(CYCLIC REFERENCE)},
+                    Docs:       wit.Docs{},
+                    _worldItem: wit._worldItem{},
+                    _type:      wit._type{},
+                },
+            },
+            Functions: {
+                "func": &wit.Function{
+                    Name:   "func",
+                    Kind:   &wit.Freestanding{},
+                    Params: {
+                        {
+                            Name: "rec",
+                            Type: &wit.TypeDef{(CYCLIC REFERENCE)},
+                        },
+                    },
+                    Results: {
+                        {
+                            Name: "",
+                            Type: &wit.TypeDef{
+                                Name: (*string)(nil),
+                                Kind: &wit.Result{
+                                    OK:           &wit.TypeDef{(CYCLIC REFERENCE)},
+                                    Err:          &wit.TypeDef{(CYCLIC REFERENCE)},
+                                    _typeDefKind: wit._typeDefKind{},
+                                },
+                                Owner:      nil,
+                                Docs:       wit.Docs{},
+                                _worldItem: wit._worldItem{},
+                                _type:      wit._type{},
+                            },
+                        },
+                    },
+                    Docs:       wit.Docs{},
+                    _worldItem: wit._worldItem{},
+                },
+            },
+            Package: &wit.Package{
+                Name: wit.PackageName{
+                    Namespace: "example",
+                    Name:      "escaped-names",
+                    Version:   (*semver.Version)(nil),
+                    _node:     wit._node{},
+                },
+                Interfaces: {
+                    "interface": &wit.Interface{(CYCLIC REFERENCE)},
+                },
+                Worlds: {
+                    "world": &wit.World{(CYCLIC REFERENCE)},
+                },
+                Docs: wit.Docs{},
+            },
+            Docs:       wit.Docs{},
+            _typeOwner: wit._typeOwner{},
+            _worldItem: wit._worldItem{},
+        },
+    },
+    TypeDefs: {
+        &wit.TypeDef{
+            Name: &"error",
+            Kind: &wit.Enum{
+                Cases: {
+                    {
+                        Name: "ok",
+                        Docs: wit.Docs{},
+                    },
+                    {
+                        Name: "fail",
+                        Docs: wit.Docs{},
+                    },
+                },
+                _typeDefKind: wit._typeDefKind{},
+            },
+            Owner:      &wit.Interface{(CYCLIC REFERENCE)},
+            Docs:       wit.Docs{},
+            _worldItem: wit._worldItem{},
+            _type:      wit._type{},
+        },
+        &wit.TypeDef{
+            Name: (*string)(nil),
+            Kind: &wit.List{
+                Type:         wit.U8{},
+                _typeDefKind: wit._typeDefKind{},
+            },
+            Owner:      nil,
+            Docs:       wit.Docs{},
+            _worldItem: wit._worldItem{},
+            _type:      wit._type{},
+        },
+        &wit.TypeDef{
+            Name: (*string)(nil),
+            Kind: &wit.Tuple{
+                Types: {
+                    &wit.TypeDef{(CYCLIC REFERENCE)},
+                    &wit.TypeDef{(CYCLIC REFERENCE)},
+                },
+                _typeDefKind: wit._typeDefKind{},
+            },
+            Owner:      nil,
+            Docs:       wit.Docs{},
+            _worldItem: wit._worldItem{},
+            _type:      wit._type{},
+        },
+        &wit.TypeDef{
+            Name: (*string)(nil),
+            Kind: &wit.List{
+                Type:         &wit.TypeDef{(CYCLIC REFERENCE)},
+                _typeDefKind: wit._typeDefKind{},
+            },
+            Owner:      nil,
+            Docs:       wit.Docs{},
+            _worldItem: wit._worldItem{},
+            _type:      wit._type{},
+        },
+        &wit.TypeDef{
+            Name: &"export",
+            Kind: &wit.Record{
+                Fields: {
+                    {
+                        Name: "headers",
+                        Type: &wit.TypeDef{(CYCLIC REFERENCE)},
+                        Docs: wit.Docs{},
+                    },
+                    {
+                        Name: "body",
+                        Type: &wit.TypeDef{(CYCLIC REFERENCE)},
+                        Docs: wit.Docs{},
+                    },
+                },
+                _typeDefKind: wit._typeDefKind{},
+            },
+            Owner:      &wit.Interface{(CYCLIC REFERENCE)},
+            Docs:       wit.Docs{},
+            _worldItem: wit._worldItem{},
+            _type:      wit._type{},
+        },
+        &wit.TypeDef{
+            Name: &"enum",
+            Kind: &wit.Enum{
+                Cases: {
+                    {
+                        Name: "enum",
+                        Docs: wit.Docs{},
+                    },
+                    {
+                        Name: "export",
+                        Docs: wit.Docs{},
+                    },
+                    {
+                        Name: "flags",
+                        Docs: wit.Docs{},
+                    },
+                    {
+                        Name: "func",
+                        Docs: wit.Docs{},
+                    },
+                    {
+                        Name: "import",
+                        Docs: wit.Docs{},
+                    },
+                    {
+                        Name: "include",
+                        Docs: wit.Docs{},
+                    },
+                    {
+                        Name: "interface",
+                        Docs: wit.Docs{},
+                    },
+                    {
+                        Name: "package",
+                        Docs: wit.Docs{},
+                    },
+                    {
+                        Name: "record",
+                        Docs: wit.Docs{},
+                    },
+                    {
+                        Name: "resource",
+                        Docs: wit.Docs{},
+                    },
+                    {
+                        Name: "static",
+                        Docs: wit.Docs{},
+                    },
+                    {
+                        Name: "type",
+                        Docs: wit.Docs{},
+                    },
+                    {
+                        Name: "variant",
+                        Docs: wit.Docs{},
+                    },
+                    {
+                        Name: "world",
+                        Docs: wit.Docs{},
+                    },
+                },
+                _typeDefKind: wit._typeDefKind{},
+            },
+            Owner:      &wit.Interface{(CYCLIC REFERENCE)},
+            Docs:       wit.Docs{},
+            _worldItem: wit._worldItem{},
+            _type:      wit._type{},
+        },
+        &wit.TypeDef{
+            Name: (*string)(nil),
+            Kind: &wit.Result{
+                OK:           wit.String{},
+                Err:          &wit.TypeDef{(CYCLIC REFERENCE)},
+                _typeDefKind: wit._typeDefKind{},
+            },
+            Owner:      nil,
+            Docs:       wit.Docs{},
+            _worldItem: wit._worldItem{},
+            _type:      wit._type{},
+        },
+        &wit.TypeDef{
+            Name: &"record",
+            Kind: &wit.Record{
+                Fields: {
+                    {
+                        Name: "enum",
+                        Type: &wit.TypeDef{(CYCLIC REFERENCE)},
+                        Docs: wit.Docs{},
+                    },
+                    {
+                        Name: "result",
+                        Type: &wit.TypeDef{(CYCLIC REFERENCE)},
+                        Docs: wit.Docs{},
+                    },
+                },
+                _typeDefKind: wit._typeDefKind{},
+            },
+            Owner:      &wit.Interface{(CYCLIC REFERENCE)},
+            Docs:       wit.Docs{},
+            _worldItem: wit._worldItem{},
+            _type:      wit._type{},
+        },
+        &wit.TypeDef{
+            Name: (*string)(nil),
+            Kind: &wit.Result{
+                OK:           &wit.TypeDef{(CYCLIC REFERENCE)},
+                Err:          &wit.TypeDef{(CYCLIC REFERENCE)},
+                _typeDefKind: wit._typeDefKind{},
+            },
+            Owner:      nil,
+            Docs:       wit.Docs{},
+            _worldItem: wit._worldItem{},
+            _type:      wit._type{},
+        },
+    },
+    Packages: {
+        &wit.Package{
+            Name: wit.PackageName{
+                Namespace: "example",
+                Name:      "escaped-names",
+                Version:   (*semver.Version)(nil),
+                _node:     wit._node{},
+            },
+            Interfaces: {
+                "interface": &wit.Interface{(CYCLIC REFERENCE)},
+            },
+            Worlds: {
+                "world": &wit.World{(CYCLIC REFERENCE)},
+            },
+            Docs: wit.Docs{},
+        },
+    },
+}

--- a/testdata/escape/escaped-names.wit.json.golden.wit
+++ b/testdata/escape/escaped-names.wit.json.golden.wit
@@ -1,0 +1,35 @@
+package example:escaped-names;
+
+interface %interface {
+    enum %enum {
+        %enum,
+        %export,
+        %flags,
+        %func,
+        %import,
+        %include,
+        %interface,
+        %package,
+        %record,
+        %resource,
+        %static,
+        %type,
+        %variant,
+        %world
+    }
+    enum error { ok, fail }
+    record %export {
+        headers: list<tuple<list<u8>, list<u8>>>,
+        body: list<u8>
+    }
+    record %record {
+        %enum: %enum,
+        %result: result<string, error>
+    }
+    %func: func(rec: %record) -> result<%export, error>;
+}
+
+world %world {
+    import %interface;
+    export %interface;
+}

--- a/testdata/examples/resource-in-world.wit.json.golden.wit
+++ b/testdata/examples/resource-in-world.wit.json.golden.wit
@@ -2,8 +2,8 @@ package examples:resources-in-world;
 
 interface types {
     resource foo {
-        bar: func(self: borrow<foo>, arg: u32);
-        foo: func(self: borrow<foo>);
+        bar: func(arg: u32);
+        foo: func();
     }
 }
 

--- a/testdata/examples/resource-in-world.wit.json.golden.wit
+++ b/testdata/examples/resource-in-world.wit.json.golden.wit
@@ -4,7 +4,7 @@ interface types {
     resource foo {
         bar: func(self: borrow<foo>, arg: u32);
         foo: func(self: borrow<foo>);
-    };
+    }
 }
 
 world imports {

--- a/testdata/wasi/clocks.wit.json.golden.wit
+++ b/testdata/wasi/clocks.wit.json.golden.wit
@@ -13,7 +13,7 @@ interface streams {
         read: func(self: borrow<input-stream>, len: u64) -> result<tuple<list<u8>, stream-status>>;
         skip: func(self: borrow<input-stream>, len: u64) -> result<tuple<u64, stream-status>>;
         subscribe: func(self: borrow<input-stream>) -> own<pollable>;
-    };
+    }
     resource output-stream {
         blocking-flush: func(self: borrow<output-stream>) -> result<_, write-error>;
         blocking-splice: func(self: borrow<output-stream>, src: own<input-stream>, len: u64) -> result<tuple<u64, stream-status>>;
@@ -26,7 +26,7 @@ interface streams {
         subscribe: func(self: borrow<output-stream>) -> own<pollable>;
         write: func(self: borrow<output-stream>, contents: list<u8>) -> result<_, write-error>;
         write-zeroes: func(self: borrow<output-stream>, len: u64) -> result<_, write-error>;
-    };
+    }
     use poll.{pollable};
     enum stream-status { open, ended };
     enum write-error {

--- a/testdata/wasi/clocks.wit.json.golden.wit
+++ b/testdata/wasi/clocks.wit.json.golden.wit
@@ -28,11 +28,11 @@ interface streams {
         write-zeroes: func(self: borrow<output-stream>, len: u64) -> result<_, write-error>;
     }
     use poll.{pollable};
-    enum stream-status { open, ended };
+    enum stream-status { open, ended }
     enum write-error {
         last-operation-failed,
         closed
-    };
+    }
 }
 
 world imports {
@@ -57,7 +57,7 @@ interface timezone {
         utc-offset: s32,
         name: string,
         in-daylight-saving-time: bool
-    };
+    }
     display: func(when: datetime) -> timezone-display;
     utc-offset: func(when: datetime) -> s32;
 }
@@ -66,7 +66,7 @@ interface wall-clock {
     record datetime {
         seconds: u64,
         nanoseconds: u32
-    };
+    }
     now: func() -> datetime;
     resolution: func() -> datetime;
 }

--- a/testdata/wasi/clocks.wit.json.golden.wit
+++ b/testdata/wasi/clocks.wit.json.golden.wit
@@ -8,24 +8,24 @@ interface poll {
 
 interface streams {
     resource input-stream {
-        blocking-read: func(self: borrow<input-stream>, len: u64) -> result<tuple<list<u8>, stream-status>>;
-        blocking-skip: func(self: borrow<input-stream>, len: u64) -> result<tuple<u64, stream-status>>;
-        read: func(self: borrow<input-stream>, len: u64) -> result<tuple<list<u8>, stream-status>>;
-        skip: func(self: borrow<input-stream>, len: u64) -> result<tuple<u64, stream-status>>;
-        subscribe: func(self: borrow<input-stream>) -> own<pollable>;
+        blocking-read: func(len: u64) -> result<tuple<list<u8>, stream-status>>;
+        blocking-skip: func(len: u64) -> result<tuple<u64, stream-status>>;
+        read: func(len: u64) -> result<tuple<list<u8>, stream-status>>;
+        skip: func(len: u64) -> result<tuple<u64, stream-status>>;
+        subscribe: func() -> own<pollable>;
     }
     resource output-stream {
-        blocking-flush: func(self: borrow<output-stream>) -> result<_, write-error>;
-        blocking-splice: func(self: borrow<output-stream>, src: own<input-stream>, len: u64) -> result<tuple<u64, stream-status>>;
-        blocking-write-and-flush: func(self: borrow<output-stream>, contents: list<u8>) -> result<_, write-error>;
-        blocking-write-zeroes-and-flush: func(self: borrow<output-stream>, len: u64) -> result<_, write-error>;
-        check-write: func(self: borrow<output-stream>) -> result<u64, write-error>;
-        flush: func(self: borrow<output-stream>) -> result<_, write-error>;
-        forward: func(self: borrow<output-stream>, src: own<input-stream>) -> result<tuple<u64, stream-status>>;
-        splice: func(self: borrow<output-stream>, src: own<input-stream>, len: u64) -> result<tuple<u64, stream-status>>;
-        subscribe: func(self: borrow<output-stream>) -> own<pollable>;
-        write: func(self: borrow<output-stream>, contents: list<u8>) -> result<_, write-error>;
-        write-zeroes: func(self: borrow<output-stream>, len: u64) -> result<_, write-error>;
+        blocking-flush: func() -> result<_, write-error>;
+        blocking-splice: func(src: own<input-stream>, len: u64) -> result<tuple<u64, stream-status>>;
+        blocking-write-and-flush: func(contents: list<u8>) -> result<_, write-error>;
+        blocking-write-zeroes-and-flush: func(len: u64) -> result<_, write-error>;
+        check-write: func() -> result<u64, write-error>;
+        flush: func() -> result<_, write-error>;
+        forward: func(src: own<input-stream>) -> result<tuple<u64, stream-status>>;
+        splice: func(src: own<input-stream>, len: u64) -> result<tuple<u64, stream-status>>;
+        subscribe: func() -> own<pollable>;
+        write: func(contents: list<u8>) -> result<_, write-error>;
+        write-zeroes: func(len: u64) -> result<_, write-error>;
     }
     use poll.{pollable};
     enum stream-status { open, ended }

--- a/testdata/wasi/clocks.wit.json.golden.wit
+++ b/testdata/wasi/clocks.wit.json.golden.wit
@@ -72,8 +72,8 @@ interface wall-clock {
 }
 
 world imports {
-    import wasi:io/poll;
     import monotonic-clock;
-    import wall-clock;
+    import wasi:io/poll;
     import timezone;
+    import wall-clock;
 }

--- a/testdata/wasi/random.wit.json.golden.wit
+++ b/testdata/wasi/random.wit.json.golden.wit
@@ -15,7 +15,7 @@ interface random {
 }
 
 world imports {
-    import insecure-seed;
     import insecure;
+    import insecure-seed;
     import random;
 }

--- a/testdata/wit-parser/comments.wit.json.golden.wit
+++ b/testdata/wit-parser/comments.wit.json.golden.wit
@@ -1,6 +1,6 @@
 package foo:comments;
 
 interface foo {
-    type bar = stream<x, _>;
+    type bar = stream<x>;
     type x = u32;
 }

--- a/testdata/wit-parser/complex-include.wit.json.golden.wit
+++ b/testdata/wit-parser/complex-include.wit.json.golden.wit
@@ -45,9 +45,9 @@ world c {
 
 world union-world {
     import foo:bar/a;
-    import foo:bar/b;
     import foo:baz/a;
-    import foo:baz/b;
     import ai;
+    import foo:bar/b;
+    import foo:baz/b;
     import bi;
 }

--- a/testdata/wit-parser/disambiguate-diamond.wit.json.golden.wit
+++ b/testdata/wit-parser/disambiguate-diamond.wit.json.golden.wit
@@ -11,10 +11,10 @@ interface shared2 {
 world foo {
     import bar: interface {
         use shared2.{the-type};
-    };
+    }
     import foo: interface {
         use shared1.{the-type};
-    };
+    }
     import shared1;
     import shared2;
 }

--- a/testdata/wit-parser/foreign-deps-union.wit.json.golden.wit
+++ b/testdata/wit-parser/foreign-deps-union.wit.json.golden.wit
@@ -86,13 +86,13 @@ world my-world {
 world my-world2 {
     import foo:wasi/clocks;
     import foo:wasi/filesystem;
-    export foo:corp/saas;
     export foo;
+    export foo:corp/saas;
 }
 
 world unionw-world {
     import foo:wasi/clocks;
     import foo:wasi/filesystem;
-    export foo:corp/saas;
     export foo;
+    export foo:corp/saas;
 }

--- a/testdata/wit-parser/foreign-deps-union.wit.json.golden.wit
+++ b/testdata/wit-parser/foreign-deps-union.wit.json.golden.wit
@@ -42,7 +42,7 @@ interface clocks {
 }
 
 interface filesystem {
-    record stat { ino: u64 };
+    record stat { ino: u64 }
 }
 
 world wasi {

--- a/testdata/wit-parser/foreign-deps.wit.json.golden.wit
+++ b/testdata/wit-parser/foreign-deps.wit.json.golden.wit
@@ -81,6 +81,6 @@ world my-world {
 world my-world2 {
     import foo:wasi/clocks;
     import foo:wasi/filesystem;
-    export foo:corp/saas;
     export foo;
+    export foo:corp/saas;
 }

--- a/testdata/wit-parser/foreign-deps.wit.json.golden.wit
+++ b/testdata/wit-parser/foreign-deps.wit.json.golden.wit
@@ -42,7 +42,7 @@ interface clocks {
 }
 
 interface filesystem {
-    record stat { ino: u64 };
+    record stat { ino: u64 }
 }
 
 

--- a/testdata/wit-parser/functions.wit.json.golden.wit
+++ b/testdata/wit-parser/functions.wit.json.golden.wit
@@ -2,7 +2,7 @@ package foo:functions;
 
 interface functions {
     f1: func();
-    f10: func() -> u: u32;
+    f10: func() -> (u: u32);
     f11: func();
     f2: func(a: u32);
     f3: func(a: u32);
@@ -10,5 +10,5 @@ interface functions {
     f6: func() -> tuple<u32, u32>;
     f7: func(a: float32, b: float32) -> tuple<u32, u32>;
     f8: func(a: option<u32>) -> result<u32, float32>;
-    f9: func() -> u: u32, f: float32;
+    f9: func() -> (u: u32, f: float32);
 }

--- a/testdata/wit-parser/many-names.wit.json.golden.wit
+++ b/testdata/wit-parser/many-names.wit.json.golden.wit
@@ -3,5 +3,5 @@ package foo:name;
 interface x {}
 
 world name {
-    import name: interface {};
+    import name: interface {}
 }

--- a/testdata/wit-parser/multi-file.wit.json.golden.wit
+++ b/testdata/wit-parser/multi-file.wit.json.golden.wit
@@ -35,7 +35,7 @@ interface foo {
 }
 
 interface irrelevant-name {
-    record a-name {};
+    record a-name {}
 }
 
 interface later-interface {}

--- a/testdata/wit-parser/multi-file.wit.json.golden.wit
+++ b/testdata/wit-parser/multi-file.wit.json.golden.wit
@@ -50,7 +50,7 @@ world more-depends-on-later-things {
 }
 
 world the-world {
-    import foo: func() -> x;
     import depend-on-me;
     use depend-on-me.{x};
+    import foo: func() -> x;
 }

--- a/testdata/wit-parser/resources-multiple-returns-borrow.wit.json.golden.wit
+++ b/testdata/wit-parser/resources-multiple-returns-borrow.wit.json.golden.wit
@@ -2,7 +2,7 @@ package foo:resources1;
 
 interface resources1 {
     resource r1 {
-        f1: func(self: borrow<r1>) -> a: s32, handle: borrow<r1>;
+        f1: func() -> (a: s32, handle: borrow<r1>);
     }
     t1: func(a: borrow<r1>);
 }

--- a/testdata/wit-parser/resources-multiple-returns-borrow.wit.json.golden.wit
+++ b/testdata/wit-parser/resources-multiple-returns-borrow.wit.json.golden.wit
@@ -3,6 +3,6 @@ package foo:resources1;
 interface resources1 {
     resource r1 {
         f1: func(self: borrow<r1>) -> a: s32, handle: borrow<r1>;
-    };
+    }
     t1: func(a: borrow<r1>);
 }

--- a/testdata/wit-parser/resources-multiple-returns-own.wit.json.golden.wit
+++ b/testdata/wit-parser/resources-multiple-returns-own.wit.json.golden.wit
@@ -2,7 +2,7 @@ package foo:resources1;
 
 interface resources1 {
     resource r1 {
-        f1: func(self: borrow<r1>) -> a: s32, handle: own<r1>;
+        f1: func() -> (a: s32, handle: own<r1>);
     }
     t1: func(a: own<r1>);
 }

--- a/testdata/wit-parser/resources-multiple-returns-own.wit.json.golden.wit
+++ b/testdata/wit-parser/resources-multiple-returns-own.wit.json.golden.wit
@@ -3,6 +3,6 @@ package foo:resources1;
 interface resources1 {
     resource r1 {
         f1: func(self: borrow<r1>) -> a: s32, handle: own<r1>;
-    };
+    }
     t1: func(a: own<r1>);
 }

--- a/testdata/wit-parser/resources-multiple.wit.json.golden.wit
+++ b/testdata/wit-parser/resources-multiple.wit.json.golden.wit
@@ -12,7 +12,7 @@ interface resources-multiple {
         f7: func(self: borrow<r1>, a: float32, b: float32) -> tuple<u32, u32>;
         f8: func(self: borrow<r1>, a: option<u32>) -> result<u32, float32>;
         f9: func(self: borrow<r1>) -> u: u32, f: float32;
-    };
+    }
     t1: func(a: borrow<r1>);
     t2: func(a: own<r1>);
 }

--- a/testdata/wit-parser/resources-multiple.wit.json.golden.wit
+++ b/testdata/wit-parser/resources-multiple.wit.json.golden.wit
@@ -2,16 +2,16 @@ package foo:resources-multiple;
 
 interface resources-multiple {
     resource r1 {
-        f1: func(self: borrow<r1>);
-        f10: func(self: borrow<r1>) -> u: u32;
-        f11: func(self: borrow<r1>);
-        f2: func(self: borrow<r1>, a: u32);
-        f3: func(self: borrow<r1>, a: u32);
-        f4: func(self: borrow<r1>) -> u32;
-        f6: func(self: borrow<r1>) -> tuple<u32, u32>;
-        f7: func(self: borrow<r1>, a: float32, b: float32) -> tuple<u32, u32>;
-        f8: func(self: borrow<r1>, a: option<u32>) -> result<u32, float32>;
-        f9: func(self: borrow<r1>) -> u: u32, f: float32;
+        f1: func();
+        f10: func() -> (u: u32);
+        f11: func();
+        f2: func(a: u32);
+        f3: func(a: u32);
+        f4: func() -> u32;
+        f6: func() -> tuple<u32, u32>;
+        f7: func(a: float32, b: float32) -> tuple<u32, u32>;
+        f8: func(a: option<u32>) -> result<u32, float32>;
+        f9: func() -> (u: u32, f: float32);
     }
     t1: func(a: borrow<r1>);
     t2: func(a: own<r1>);

--- a/testdata/wit-parser/resources-return-borrow.wit.json.golden.wit
+++ b/testdata/wit-parser/resources-return-borrow.wit.json.golden.wit
@@ -3,6 +3,6 @@ package foo:resources1;
 interface resources1 {
     resource r1 {
         f1: func(self: borrow<r1>) -> borrow<r1>;
-    };
+    }
     t1: func(a: borrow<r1>);
 }

--- a/testdata/wit-parser/resources-return-borrow.wit.json.golden.wit
+++ b/testdata/wit-parser/resources-return-borrow.wit.json.golden.wit
@@ -2,7 +2,7 @@ package foo:resources1;
 
 interface resources1 {
     resource r1 {
-        f1: func(self: borrow<r1>) -> borrow<r1>;
+        f1: func() -> borrow<r1>;
     }
     t1: func(a: borrow<r1>);
 }

--- a/testdata/wit-parser/resources-return-own.wit.json.golden.wit
+++ b/testdata/wit-parser/resources-return-own.wit.json.golden.wit
@@ -2,7 +2,7 @@ package foo:resources1;
 
 interface resources1 {
     resource r1 {
-        f1: func(self: borrow<r1>) -> own<r1>;
+        f1: func() -> own<r1>;
     }
     t1: func(a: own<r1>);
 }

--- a/testdata/wit-parser/resources-return-own.wit.json.golden.wit
+++ b/testdata/wit-parser/resources-return-own.wit.json.golden.wit
@@ -3,6 +3,6 @@ package foo:resources1;
 interface resources1 {
     resource r1 {
         f1: func(self: borrow<r1>) -> own<r1>;
-    };
+    }
     t1: func(a: own<r1>);
 }

--- a/testdata/wit-parser/resources.wit.json.golden.wit
+++ b/testdata/wit-parser/resources.wit.json.golden.wit
@@ -4,19 +4,19 @@ interface foo {
     resource a;
     resource b {
         constructor: func() -> own<b>;
-    };
+    }
     resource c {
         constructor: func(x: u32) -> own<c>;
-    };
+    }
     resource d {
         constructor: func(x: u32) -> own<d>;
         a: func(self: borrow<d>);
         b: func();
-    };
+    }
     resource e {
         constructor: func(other: own<e>, other2: borrow<e>) -> own<e>;
         method: func(self: borrow<e>, thing: own<e>, thing2: borrow<e>);
-    };
+    }
 }
 
 interface i {
@@ -31,5 +31,5 @@ world w {
     resource b;
     resource c {
         constructor: func() -> own<c>;
-    };
+    }
 }

--- a/testdata/wit-parser/resources.wit.json.golden.wit
+++ b/testdata/wit-parser/resources.wit.json.golden.wit
@@ -3,19 +3,19 @@ package foo:bar;
 interface foo {
     resource a;
     resource b {
-        constructor: func() -> own<b>;
+        constructor();
     }
     resource c {
-        constructor: func(x: u32) -> own<c>;
+        constructor(x: u32);
     }
     resource d {
-        constructor: func(x: u32) -> own<d>;
-        a: func(self: borrow<d>);
-        b: func();
+        constructor(x: u32);
+        a: func();
+        b: static func();
     }
     resource e {
-        constructor: func(other: own<e>, other2: borrow<e>) -> own<e>;
-        method: func(self: borrow<e>, thing: own<e>, thing2: borrow<e>);
+        constructor(other: own<e>, other2: borrow<e>);
+        method: func(thing: own<e>, thing2: borrow<e>);
     }
 }
 
@@ -30,6 +30,6 @@ world w {
     resource a;
     resource b;
     resource c {
-        constructor: func() -> own<c>;
+        constructor();
     }
 }

--- a/testdata/wit-parser/resources1.wit.json.golden.wit
+++ b/testdata/wit-parser/resources1.wit.json.golden.wit
@@ -3,7 +3,7 @@ package foo:resources1;
 interface resources1 {
     resource r1 {
         f1: func(self: borrow<r1>);
-    };
+    }
     t1: func(a: borrow<r1>);
     t2: func(a: own<r1>);
     t3: func(a: own<r1>);

--- a/testdata/wit-parser/resources1.wit.json.golden.wit
+++ b/testdata/wit-parser/resources1.wit.json.golden.wit
@@ -2,7 +2,7 @@ package foo:resources1;
 
 interface resources1 {
     resource r1 {
-        f1: func(self: borrow<r1>);
+        f1: func();
     }
     t1: func(a: borrow<r1>);
     t2: func(a: own<r1>);

--- a/testdata/wit-parser/shared-types.wit.json.golden.wit
+++ b/testdata/wit-parser/shared-types.wit.json.golden.wit
@@ -3,8 +3,8 @@ package foo:shared-items;
 world foo {
     import foo: interface {
         a: func() -> list<u8>;
-    };
+    }
     export bar: interface {
         a: func() -> tuple<list<u8>>;
-    };
+    }
 }

--- a/testdata/wit-parser/types.wit.json.golden.wit
+++ b/testdata/wit-parser/types.wit.json.golden.wit
@@ -13,7 +13,7 @@ interface types {
     type t15 = result<u32, u32>;
     type t16 = result<_, u32>;
     type t17 = result<u32>;
-    type t18 = result<_>;
+    type t18 = result;
     type t2 = u16;
     record t20 {}
     record t21 { a: u32 }

--- a/testdata/wit-parser/types.wit.json.golden.wit
+++ b/testdata/wit-parser/types.wit.json.golden.wit
@@ -45,8 +45,8 @@ interface types {
     type t48 = stream<u32, u32>;
     type t49 = stream<_, u32>;
     type t5 = s8;
-    type t50 = stream<u32, _>;
-    type t51 = stream<_, _>;
+    type t50 = stream<u32>;
+    type t51 = stream;
     type t52 = future<u32>;
     type t53 = future;
     type t6 = s16;

--- a/testdata/wit-parser/types.wit.json.golden.wit
+++ b/testdata/wit-parser/types.wit.json.golden.wit
@@ -21,10 +21,10 @@ interface types {
     record t23 { a: u32, b: u64 }
     record t24 { a: u32, b: u64 }
     record t25 { x: u32 }
-    tuple<>;
-    tuple<u32>;
-    tuple<u32>;
-    tuple<u32, u64>;
+    type t26 = tuple<>;
+    type t27 = tuple<u32>;
+    type t28 = tuple<u32>;
+    type t29 = tuple<u32, u64>;
     type t3 = u32;
     flags t30 {}
     flags t31 {a, b, c}

--- a/testdata/wit-parser/types.wit.json.golden.wit
+++ b/testdata/wit-parser/types.wit.json.golden.wit
@@ -3,7 +3,7 @@ package foo:types;
 interface types {
     type bar = u32;
     type foo = bar;
-    record record {}
+    record %record {}
     type t1 = u8;
     type t10 = float64;
     type t11 = char;

--- a/testdata/wit-parser/types.wit.json.golden.wit
+++ b/testdata/wit-parser/types.wit.json.golden.wit
@@ -3,7 +3,7 @@ package foo:types;
 interface types {
     type bar = u32;
     type foo = bar;
-    record record {};
+    record record {}
     type t1 = u8;
     type t10 = float64;
     type t11 = char;
@@ -15,28 +15,28 @@ interface types {
     type t17 = result<u32>;
     type t18 = result<_>;
     type t2 = u16;
-    record t20 {};
-    record t21 { a: u32 };
-    record t22 { a: u32 };
-    record t23 { a: u32, b: u64 };
-    record t24 { a: u32, b: u64 };
-    record t25 { x: u32 };
+    record t20 {}
+    record t21 { a: u32 }
+    record t22 { a: u32 }
+    record t23 { a: u32, b: u64 }
+    record t24 { a: u32, b: u64 }
+    record t25 { x: u32 }
     tuple<>;
     tuple<u32>;
     tuple<u32>;
     tuple<u32, u64>;
     type t3 = u32;
-    flags t30 {};
-    flags t31 {a, b, c};
-    flags t32 {a, b, c};
-    variant t33 { a };
-    variant t34 { a, b };
-    variant t35 { a, b };
-    variant t36 { a, b(u32) };
-    variant t37 { a, b(option<u32>) };
+    flags t30 {}
+    flags t31 {a, b, c}
+    flags t32 {a, b, c}
+    variant t33 { a }
+    variant t34 { a, b }
+    variant t35 { a, b }
+    variant t36 { a, b(u32) }
+    variant t37 { a, b(option<u32>) }
     type t4 = u64;
-    enum t41 { a, b, c };
-    enum t42 { a, b, c };
+    enum t41 { a, b, c }
+    enum t42 { a, b, c }
     type t43 = bool;
     type t44 = string;
     type t45 = list<list<list<t32>>>;

--- a/testdata/wit-parser/use-chain.wit.json.golden.wit
+++ b/testdata/wit-parser/use-chain.wit.json.golden.wit
@@ -1,7 +1,7 @@
 package foo:name;
 
 interface foo {
-    record foo {};
+    record foo {}
 }
 
 interface name {

--- a/testdata/wit-parser/use.wit.json.golden.wit
+++ b/testdata/wit-parser/use.wit.json.golden.wit
@@ -16,7 +16,7 @@ interface foo {
 }
 
 interface trailing-comma {
-    record the-foo { a: the-type };
+    record the-foo { a: the-type }
     use foo.{the-type};
 }
 

--- a/testdata/wit-parser/wasi.wit.json.golden.wit
+++ b/testdata/wit-parser/wasi.wit.json.golden.wit
@@ -1,7 +1,7 @@
 package wasi:filesystem;
 
 interface wasi {
-    enum clockid { realtime, monotonic };
+    enum clockid { realtime, monotonic }
     enum errno {
         success,
         toobig,
@@ -80,6 +80,6 @@ interface wasi {
         txtbsy,
         xdev,
         notcapable
-    };
+    }
     type timestamp = u64;
 }

--- a/testdata/wit-parser/world-diamond.wit.json.golden.wit
+++ b/testdata/wit-parser/world-diamond.wit.json.golden.wit
@@ -15,8 +15,8 @@ interface shared-items {
 }
 
 world the-world {
-    import a: func();
-    import shared-items;
     import i1;
     import i2;
+    import shared-items;
+    import a: func();
 }

--- a/testdata/wit-parser/world-iface-no-collide.wit.json.golden.wit
+++ b/testdata/wit-parser/world-iface-no-collide.wit.json.golden.wit
@@ -5,7 +5,7 @@ interface foo {
 }
 
 world bar {
-    import foo: func();
     import foo;
     use foo.{t};
+    import foo: func();
 }

--- a/testdata/wit-parser/world-implicit-import1.wit.json.golden.wit
+++ b/testdata/wit-parser/world-implicit-import1.wit.json.golden.wit
@@ -7,7 +7,7 @@ interface foo {
 world the-world {
     import bar: interface {
         use foo.{a};
-    };
-    import foo: interface {};
+    }
+    import foo: interface {}
     import foo;
 }

--- a/testdata/wit-parser/world-implicit-import2.wit.json.golden.wit
+++ b/testdata/wit-parser/world-implicit-import2.wit.json.golden.wit
@@ -5,7 +5,7 @@ interface foo {
 }
 
 world w {
-    import foo: func() -> g;
-    use foo.{g};
     import foo;
+    use foo.{g};
+    import foo: func() -> g;
 }

--- a/testdata/wit-parser/world-implicit-import3.wit.json.golden.wit
+++ b/testdata/wit-parser/world-implicit-import3.wit.json.golden.wit
@@ -5,7 +5,7 @@ interface foo {
 }
 
 world w {
-    use foo.{g};
     import foo;
+    use foo.{g};
     export foo: func() -> g;
 }

--- a/testdata/wit-parser/world-same-fields4.wit.json.golden.wit
+++ b/testdata/wit-parser/world-same-fields4.wit.json.golden.wit
@@ -6,8 +6,8 @@ interface shared-items {
 
 world foo {
     import shared-items;
-    import shared-items: interface {};
+    import shared-items: interface {}
     export a-name: interface {
         use shared-items.{a};
-    };
+    }
 }

--- a/testdata/wit-parser/world-top-level-resources.wit.json.golden.wit
+++ b/testdata/wit-parser/world-top-level-resources.wit.json.golden.wit
@@ -19,7 +19,7 @@ interface types {
 }
 
 world proxy {
-    import types;
     import handler;
+    import types;
     export handler;
 }

--- a/testdata/wit-parser/world-top-level-resources.wit.json.golden.wit
+++ b/testdata/wit-parser/world-top-level-resources.wit.json.golden.wit
@@ -9,12 +9,12 @@ interface handler {
 
 interface types {
     resource request {
-        bar: func(self: borrow<request>, arg: list<u32>);
-        foo: func(self: borrow<request>);
+        bar: func(arg: list<u32>);
+        foo: func();
     }
     resource response {
-        bar: func(self: borrow<response>, arg: list<u32>);
-        foo: func(self: borrow<response>);
+        bar: func(arg: list<u32>);
+        foo: func();
     }
 }
 

--- a/testdata/wit-parser/world-top-level-resources.wit.json.golden.wit
+++ b/testdata/wit-parser/world-top-level-resources.wit.json.golden.wit
@@ -11,11 +11,11 @@ interface types {
     resource request {
         bar: func(self: borrow<request>, arg: list<u32>);
         foo: func(self: borrow<request>);
-    };
+    }
     resource response {
         bar: func(self: borrow<response>, arg: list<u32>);
         foo: func(self: borrow<response>);
-    };
+    }
 }
 
 world proxy {

--- a/testdata/wit-parser/worlds-with-types.wit.json.golden.wit
+++ b/testdata/wit-parser/worlds-with-types.wit.json.golden.wit
@@ -17,8 +17,8 @@ world foo {
 }
 
 world the-test {
-    record a { x: u32 };
-    variant b { c(a) };
+    record a { x: u32 }
+    variant b { c(a) }
     import foo: func(a: a) -> b;
     export bar: func(a: a) -> b;
 }

--- a/wit/resolve.go
+++ b/wit/resolve.go
@@ -113,12 +113,17 @@ func iterateWorldItems(m map[string]WorldItem, yield func(name string, i WorldIt
 	sort.Slice(items, func(i, j int) bool {
 		a, b := items[i], items[j]
 		as, bs := worldItemTypeSort(a.item), worldItemTypeSort(b.item)
-		if as < bs {
+		switch {
+		case as < bs:
 			return true
-		} else if as > bs {
+		case as > bs:
+			return false
+		case a.sortName < b.sortName:
+			return true
+		case a.sortName > b.sortName:
 			return false
 		}
-		return a.sortName < b.sortName
+		return a.name < b.name
 	})
 
 	// Iterate

--- a/wit/resolve.go
+++ b/wit/resolve.go
@@ -86,25 +86,26 @@ func (w *World) AllExports(yield func(name string, i WorldItem) bool) bool {
 // calling yield for each item.
 func iterateWorldItems(m map[string]WorldItem, yield func(name string, i WorldItem) bool) bool {
 	type named struct {
-		name string
-		item WorldItem
+		name     string
+		sortName string
+		item     WorldItem
 	}
 	items := make([]named, 0, len(m))
 	for name, v := range m {
+		item := named{name, name, v}
 		// TODO: add WorldItem.ItemName() method or something
 		switch v := v.(type) {
 		case *Interface:
 			if v.Name != nil {
-				name = *v.Name
+				item.sortName = *v.Name
 			}
 		case *TypeDef:
 			if v.Name != nil {
-				name = *v.Name
+				item.sortName = *v.Name
 			}
 		case *Function:
-			name = v.Name
+			item.sortName = v.Name
 		}
-		item := named{name, v}
 		items = append(items, item)
 	}
 
@@ -117,7 +118,7 @@ func iterateWorldItems(m map[string]WorldItem, yield func(name string, i WorldIt
 		} else if as > bs {
 			return false
 		}
-		return a.name < b.name
+		return a.sortName < b.sortName
 	})
 
 	// Iterate

--- a/wit/resolve.go
+++ b/wit/resolve.go
@@ -49,14 +49,14 @@ type World struct {
 //
 // [iterates]: https://github.com/golang/go/issues/61897
 func (w *World) AllFunctions(yield func(*Function) bool) bool {
-	return w.AllImports(func(i WorldItem) bool {
+	return w.AllImports(func(name string, i WorldItem) bool {
 		if f, ok := i.(*Function); ok {
 			if !yield(f) {
 				return false
 			}
 		}
 		return true
-	}) && w.AllExports(func(i WorldItem) bool {
+	}) && w.AllExports(func(name string, i WorldItem) bool {
 		if f, ok := i.(*Function); ok {
 			if !yield(f) {
 				return false
@@ -70,7 +70,7 @@ func (w *World) AllFunctions(yield func(*Function) bool) bool {
 // calling yield for each. Iteration will stop if yield returns false.
 //
 // [iterates]: https://github.com/golang/go/issues/61897
-func (w *World) AllImports(yield func(WorldItem) bool) bool {
+func (w *World) AllImports(yield func(name string, i WorldItem) bool) bool {
 	return iterateWorldItems(w.Imports, yield)
 }
 
@@ -78,13 +78,13 @@ func (w *World) AllImports(yield func(WorldItem) bool) bool {
 // calling yield for each. Iteration will stop if yield returns false.
 //
 // [iterates]: https://github.com/golang/go/issues/61897
-func (w *World) AllExports(yield func(WorldItem) bool) bool {
+func (w *World) AllExports(yield func(name string, i WorldItem) bool) bool {
 	return iterateWorldItems(w.Exports, yield)
 }
 
 // iterateWorldItems sorts a map of [WorldItem] by type, then name,
 // calling yield for each item.
-func iterateWorldItems(m map[string]WorldItem, yield func(WorldItem) bool) bool {
+func iterateWorldItems(m map[string]WorldItem, yield func(name string, i WorldItem) bool) bool {
 	type named struct {
 		name string
 		item WorldItem
@@ -122,7 +122,7 @@ func iterateWorldItems(m map[string]WorldItem, yield func(WorldItem) bool) bool 
 
 	// Iterate
 	for _, item := range items {
-		if !yield(item.item) {
+		if !yield(item.name, item.item) {
 			return false
 		}
 	}

--- a/wit/testdata_test.go
+++ b/wit/testdata_test.go
@@ -92,7 +92,12 @@ func TestGoldenWITFiles(t *testing.T) {
 }
 
 func TestGoldenWITRoundTrip(t *testing.T) {
-	err := loadTestdata(func(path string, res *Resolve) error {
+	err := exec.Command("wasm-tools", "--version").Run()
+	if err != nil {
+		t.Log("skipping test: wasm-tools not installed")
+		return
+	}
+	err = loadTestdata(func(path string, res *Resolve) error {
 		data := res.WIT(nil, "")
 		if strings.Count(data, "package ") > 1 {
 			return nil

--- a/wit/testdata_test.go
+++ b/wit/testdata_test.go
@@ -75,7 +75,7 @@ func TestGoldenFiles(t *testing.T) {
 	}
 }
 
-func TestWITGoldenFiles(t *testing.T) {
+func TestGoldenWITFiles(t *testing.T) {
 	err := loadTestdata(func(path string, res *Resolve) error {
 		t.Run(strings.TrimPrefix(path, testdataDir), func(t *testing.T) {
 			data := res.WIT(nil, "")

--- a/wit/testdata_test.go
+++ b/wit/testdata_test.go
@@ -1,10 +1,12 @@
 package wit
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -80,6 +82,50 @@ func TestGoldenWITFiles(t *testing.T) {
 		t.Run(strings.TrimPrefix(path, testdataDir), func(t *testing.T) {
 			data := res.WIT(nil, "")
 			compareOrWrite(t, path, path+".golden.wit", data)
+		})
+		return nil
+	})
+
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestGoldenWITRoundTrip(t *testing.T) {
+	err := loadTestdata(func(path string, res *Resolve) error {
+		data := res.WIT(nil, "")
+		if strings.Count(data, "package ") > 1 {
+			return nil
+		}
+		t.Run(strings.TrimPrefix(path, testdataDir), func(t *testing.T) {
+			// Run the generated WIT through wasm-tools to generate JSON.
+			cmd := exec.Command("wasm-tools", "component", "wit", "-j")
+			cmd.Stdin = strings.NewReader(data)
+			stdout := &bytes.Buffer{}
+			stderr := &bytes.Buffer{}
+			cmd.Stdout = stdout
+			cmd.Stderr = stderr
+			err := cmd.Run()
+			if err != nil {
+				t.Error(err, stderr.String())
+				return
+			}
+
+			// Parse the JSON into a Resolve.
+			res2, err := DecodeJSON(stdout)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+
+			// Convert back to WIT.
+			data2 := res2.WIT(nil, "")
+			if string(data2) != data {
+				dmp := diffmatchpatch.New()
+				dmp.PatchMargin = 3
+				diffs := dmp.DiffMain(data, data2, false)
+				t.Errorf("round-trip WIT for %s through wasm-tools did not match:\n%v", path, dmp.DiffPrettyText(diffs))
+			}
 		})
 		return nil
 	})

--- a/wit/testdata_test.go
+++ b/wit/testdata_test.go
@@ -92,6 +92,10 @@ func TestGoldenWITFiles(t *testing.T) {
 }
 
 func TestGoldenWITRoundTrip(t *testing.T) {
+	if testing.Short() {
+		// t.Skip is not available in TinyGo, requires runtime.Goexit()
+		return
+	}
 	err := exec.Command("wasm-tools", "--version").Run()
 	if err != nil {
 		t.Log("skipping test: wasm-tools not installed")

--- a/wit/wit.go
+++ b/wit/wit.go
@@ -74,27 +74,29 @@ func (w *World) WIT(ctx Node, name string) string {
 	b.WriteString(escape(name)) // TODO: compare to w.Name?
 	b.WriteString(" {")
 	n := 0
-	for _, name := range codec.SortedKeys(w.Imports) {
-		if f, ok := w.Imports[name].(*Function); ok {
+	w.AllImports(func(name string, i WorldItem) bool {
+		if f, ok := i.(*Function); ok {
 			if _, ok := f.Kind.(*Freestanding); !ok {
-				continue
+				return true
 			}
 		}
 		if n == 0 {
 			b.WriteRune('\n')
 		}
-		b.WriteString(indent(w.itemWIT("import", name, w.Imports[name])))
+		b.WriteString(indent(w.itemWIT("import", name, i)))
 		b.WriteRune('\n')
 		n++
-	}
-	for _, name := range codec.SortedKeys(w.Exports) {
+		return true
+	})
+	w.AllExports(func(name string, i WorldItem) bool {
 		if n == 0 {
 			b.WriteRune('\n')
 		}
-		b.WriteString(indent(w.itemWIT("export", name, w.Exports[name])))
+		b.WriteString(indent(w.itemWIT("export", name, i)))
 		b.WriteRune('\n')
 		n++
-	}
+		return true
+	})
 	b.WriteRune('}')
 	return b.String()
 }

--- a/wit/wit.go
+++ b/wit/wit.go
@@ -375,8 +375,13 @@ func (f *Flag) WIT(_ Node, _ string) string {
 // WIT returns the [WIT] text format for [Tuple] t.
 //
 // [WIT]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md
-func (t *Tuple) WIT(ctx Node, _ string) string {
+func (t *Tuple) WIT(ctx Node, name string) string {
 	var b strings.Builder
+	if name != "" {
+		b.WriteString("type ")
+		b.WriteString(escape(name))
+		b.WriteString(" = ")
+	}
 	b.WriteString("tuple<")
 	for i := range t.Types {
 		if i > 0 {

--- a/wit/wit.go
+++ b/wit/wit.go
@@ -84,7 +84,7 @@ func (w *World) WIT(ctx Node, name string) string {
 			b.WriteRune('\n')
 		}
 		b.WriteString(indent(w.itemWIT("import", name, w.Imports[name])))
-		b.WriteString(";\n")
+		b.WriteRune('\n')
 		n++
 	}
 	for _, name := range codec.SortedKeys(w.Exports) {
@@ -92,7 +92,7 @@ func (w *World) WIT(ctx Node, name string) string {
 			b.WriteRune('\n')
 		}
 		b.WriteString(indent(w.itemWIT("export", name, w.Exports[name])))
-		b.WriteString(";\n")
+		b.WriteRune('\n')
 		n++
 	}
 	b.WriteRune('}')
@@ -129,7 +129,7 @@ func (i *Interface) WIT(ctx Node, name string) string {
 	case *World:
 		rname := relativeName(i, ctx.Package)
 		if rname != "" {
-			return rname
+			return rname + ";"
 		}
 
 		// Otherwise, this is an inline interface decl.
@@ -144,7 +144,7 @@ func (i *Interface) WIT(ctx Node, name string) string {
 			b.WriteRune('\n')
 		}
 		b.WriteString(indent(i.TypeDefs[name].WIT(i, name)))
-		b.WriteString(";\n")
+		b.WriteRune('\n')
 		n++
 	}
 	for _, name := range codec.SortedKeys(i.Functions) {
@@ -156,7 +156,7 @@ func (i *Interface) WIT(ctx Node, name string) string {
 			b.WriteRune('\n')
 		}
 		b.WriteString(indent(f.WIT(i, name)))
-		b.WriteString(";\n")
+		b.WriteRune('\n')
 		n++
 	}
 	b.WriteRune('}')
@@ -193,19 +193,21 @@ func (t *TypeDef) WIT(ctx Node, name string) string {
 			b.WriteString(" {\n")
 			if constructor != nil {
 				b.WriteString(indent(constructor.WIT(t, "constructor")))
-				b.WriteString(";\n")
+				b.WriteRune('\n')
 			}
 			slices.SortFunc(methods, functionCompare)
 			for _, f := range methods {
 				b.WriteString(indent(f.WIT(t, "")))
-				b.WriteString(";\n")
+				b.WriteRune('\n')
 			}
 			slices.SortFunc(statics, functionCompare)
 			for _, f := range statics {
 				b.WriteString(indent(f.WIT(t, "")))
-				b.WriteString(";\n")
+				b.WriteRune('\n')
 			}
 			b.WriteRune('}')
+		} else {
+			b.WriteRune(';')
 		}
 		return b.String()
 	}
@@ -557,6 +559,7 @@ func (f *Function) WIT(_ Node, name string) string {
 		b.WriteString(" -> ")
 		b.WriteString(paramsWIT(f.Results))
 	}
+	b.WriteRune(';')
 	return b.String()
 }
 

--- a/wit/wit.go
+++ b/wit/wit.go
@@ -549,17 +549,19 @@ func (s *Stream) WIT(_ Node, name string) string {
 		b.WriteString(escape(name))
 		b.WriteString(" = ")
 	}
-	b.WriteString("stream<")
+	b.WriteString("stream")
+	if s.Element == nil && s.End == nil {
+		return b.String()
+	}
+	b.WriteRune('<')
 	if s.Element != nil {
 		b.WriteString(s.Element.WIT(s, ""))
-		b.WriteString(", ")
-	} else {
-		b.WriteString("_, ")
-	}
-	if s.End != nil {
-		b.WriteString(s.End.WIT(s, ""))
 	} else {
 		b.WriteRune('_')
+	}
+	if s.End != nil {
+		b.WriteString(", ")
+		b.WriteString(s.End.WIT(s, ""))
 	}
 	b.WriteRune('>')
 	return b.String()

--- a/wit/wit.go
+++ b/wit/wit.go
@@ -486,7 +486,11 @@ func (r *Result) WIT(_ Node, name string) string {
 		b.WriteString(escape(name))
 		b.WriteString(" = ")
 	}
-	b.WriteString("result<")
+	b.WriteString("result")
+	if r.OK == nil && r.Err == nil {
+		return b.String()
+	}
+	b.WriteRune('<')
 	if r.OK != nil {
 		b.WriteString(r.OK.WIT(r, ""))
 	} else {

--- a/wit/wit.go
+++ b/wit/wit.go
@@ -179,9 +179,9 @@ func (t *TypeDef) WIT(ctx Node, name string) string {
 		}
 		ownerName := relativeName(t.Owner, ctx.Package())
 		if t.Name != nil && *t.Name != name {
-			return fmt.Sprintf("use %s.{%s as %s}", ownerName, *t.Name, name)
+			return fmt.Sprintf("use %s.{%s as %s};", ownerName, *t.Name, name)
 		}
-		return fmt.Sprintf("use %s.{%s}", ownerName, name)
+		return fmt.Sprintf("use %s.{%s};", ownerName, name)
 
 	case *World, *Interface:
 		var b strings.Builder
@@ -206,7 +206,9 @@ func (t *TypeDef) WIT(ctx Node, name string) string {
 				b.WriteRune('\n')
 			}
 			b.WriteRune('}')
-		} else {
+		}
+		s := b.String()
+		if s[len(s)-1] != '}' && s[len(s)-1] != ';' {
 			b.WriteRune(';')
 		}
 		return b.String()


### PR DESCRIPTION
This PR implements provably correct round-trip WIT parsing and generation. It makes a handful of changes to the WIT generator.

1. Semicolons are elided when not necessary, after `}` such as `record` or `enum` declarations.
2. Reserved words are escaped with `%` to spec. See [here](https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md#keywords) for a list (might be outdated).
3. Resource constructors, methods, and static functions are correctly emitted.
4. Correctly serialize WIT for functions with multiple or named results.
5. World imports and exports are deterministically sorted by type, intrinsic name (if present), then import/export name.

It tests this by using the `wasm-tools` program to parse the generated WIT back into JSON via `wasm-tools component wit -j`, which is then decoded back into the Go representation, and finally re-serialized into WIT and compared.