### PR TITLE
option to generate versioned package paths by default

### DIFF
--- a/cmd/wit-bindgen-go/cmd/generate/generate.go
+++ b/cmd/wit-bindgen-go/cmd/generate/generate.go
@@ -33,6 +33,10 @@ var Command = &cli.Command{
 			Usage: "maps WIT identifiers to Go identifiers",
 		},
 		&cli.BoolFlag{
+			Name:  "versioned",
+			Usage: "emit versioned Go package(s) for each WIT version",
+		},
+		&cli.BoolFlag{
 			Name:  "dry-run",
 			Usage: "do not write files; print to stdout",
 		},
@@ -68,6 +72,7 @@ func action(ctx context.Context, cmd *cli.Command) error {
 	packages, err := bindgen.Go(res,
 		bindgen.GeneratedBy(cmd.Root().Name),
 		bindgen.PackageRoot(pkgPath),
+		bindgen.Versioned(cmd.Bool("versioned")),
 		bindgen.MapIdents(cmd.StringMap("map")),
 	)
 	if err != nil {

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -119,6 +119,11 @@ func (g *generator) generate() ([]*gen.Package, error) {
 }
 
 func (g *generator) detectVersionedPackages() {
+	if g.opts.versioned {
+		g.versioned = true
+		fmt.Fprintf(os.Stderr, "Generated versions for all package(s)\n")
+		return
+	}
 	packages := make(map[string]string)
 	for _, pkg := range g.res.Packages {
 		id := pkg.Name
@@ -460,13 +465,13 @@ func (g *generator) packageForIdent(id wit.Ident) *gen.Package {
 	}
 
 	// Create a new package
-	path := id.Namespace + "/" + id.Package + "/" + GoPackageName(id.Extension)
+	path := id.Namespace + "/" + id.Package + "/" + id.Extension
 	if g.opts.packageRoot != "" && g.opts.packageRoot != "std" {
 		path = g.opts.packageRoot + "/" + path
 	}
 	name := id.Extension
 	if g.versioned && id.Version != nil {
-		path += "/v" + id.Version.String()
+		path += "-" + id.Version.String()
 	}
 
 	name = GoPackageName(name)

--- a/wit/bindgen/options.go
+++ b/wit/bindgen/options.go
@@ -25,6 +25,9 @@ type options struct {
 	// Default: github.com/ydnar/wasm-tools-go/cm.
 	cmPackage string
 
+	// versioned determines if Go packages are generated with version numbers.
+	versioned bool
+
 	// idents maps WIT identifiers to Go identifiers. Examples:
 	// "wasi:clocks" -> "wasi/clocks"
 	// "wasi:clocks/wall-clock" -> "wasi/clocks/wall"
@@ -75,6 +78,15 @@ func PackageName(name string) Option {
 func CMPackage(path string) Option {
 	return optionFunc(func(opts *options) error {
 		opts.cmPackage = path
+		return nil
+	})
+}
+
+// Versioned returns an [Option] that that specifies that all generated Go packages
+// will have versions that match WIT versions.
+func Versioned(versioned bool) Option {
+	return optionFunc(func(opts *options) error {
+		opts.versioned = versioned
 		return nil
 	})
 }


### PR DESCRIPTION
This also changes the versioned path from <path>/v<version> to <path>-<version>.

This also preserves the kebab-case of a WIT interface or world into the Go package path.
