### PR TITLE
wit: shell out to wasm-tools to load WIT files directly

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,6 +40,9 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Set up wasm-tools
+        uses: bytecodealliance/actions/wasm-tools/setup@v1.0.2
+
       - name: Set up Go
         uses: actions/setup-go@v5.0.0
         with:
@@ -74,6 +77,9 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Set up wasm-tools
+        uses: bytecodealliance/actions/wasm-tools/setup@v1.0.2
+
       - name: Set up Go
         uses: actions/setup-go@v5.0.0
         with:
@@ -106,6 +112,14 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Set up wasm-tools
+        uses: bytecodealliance/actions/wasm-tools/setup@v1.0.2
+
+      - name: Set up Wasmtime
+        uses: bytecodealliance/actions/wasmtime/setup@v1.0.2
+        with:
+          version: ${{ matrix.wasmtime-version }}
+
       - name: Set up Go
         uses: actions/setup-go@v5.0.0
         with:
@@ -115,11 +129,6 @@ jobs:
         uses: acifani/setup-tinygo@v2.0.0
         with:
           tinygo-version: ${{ matrix.tinygo-version }}
-
-      - name: Set up Wasmtime
-        uses: bytecodealliance/actions/wasmtime/setup@v1.0.2
-        with:
-          version: ${{ matrix.wasmtime-version }}
 
       - name: Add Go wasm exec to $PATH
         run: echo "$(go env GOROOT)/misc/wasm" >> $GITHUB_PATH

--- a/cmd/wit-bindgen-go/cmd/generate/generate.go
+++ b/cmd/wit-bindgen-go/cmd/generate/generate.go
@@ -64,7 +64,7 @@ func action(ctx context.Context, cmd *cli.Command) error {
 	}
 	fmt.Fprintf(os.Stderr, "Package root: %s\n", pkgPath)
 
-	res, err := witcli.LoadOne(cmd.Args().Slice()...)
+	res, err := witcli.LoadOne(cmd.Bool("force-wit"), cmd.Args().Slice()...)
 	if err != nil {
 		return err
 	}

--- a/cmd/wit-bindgen-go/cmd/print/print.go
+++ b/cmd/wit-bindgen-go/cmd/print/print.go
@@ -18,7 +18,7 @@ var Command = &cli.Command{
 }
 
 func action(ctx context.Context, cmd *cli.Command) error {
-	res, err := witcli.LoadOne(cmd.Args().Slice()...)
+	res, err := witcli.LoadOne(cmd.Bool("force-wit"), cmd.Args().Slice()...)
 	if err != nil {
 		return err
 	}

--- a/cmd/wit-bindgen-go/cmd/wit/wit.go
+++ b/cmd/wit-bindgen-go/cmd/wit/wit.go
@@ -16,7 +16,7 @@ var Command = &cli.Command{
 }
 
 func action(ctx context.Context, cmd *cli.Command) error {
-	res, err := witcli.LoadOne(cmd.Args().Slice()...)
+	res, err := witcli.LoadOne(cmd.Bool("force-wit"), cmd.Args().Slice()...)
 	if err != nil {
 		return err
 	}

--- a/cmd/wit-bindgen-go/main.go
+++ b/cmd/wit-bindgen-go/main.go
@@ -21,6 +21,12 @@ func main() {
 			print.Command,
 			wit.Command,
 		},
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:  "force-wit",
+				Usage: "force loading WIT via wasm-tools",
+			},
+		},
 	}
 
 	err := cmd.Run(context.Background(), os.Args)

--- a/wit/load.go
+++ b/wit/load.go
@@ -1,0 +1,60 @@
+package wit
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// LoadJSON loads a [WIT] JSON file from path.
+// If path is "" or "-", it reads from os.Stdin.
+//
+// [WIT]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md
+func LoadJSON(path string) (*Resolve, error) {
+	if path == "" || path == "-" {
+		return DecodeJSON(os.Stdin)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return DecodeJSON(f)
+}
+
+// LoadWIT loads [WIT] data from path by processing it through [wasm-tools].
+// This will fail if wasm-tools is not in $PATH.
+// If path is "" or "-", it reads from os.Stdin.
+//
+// [WIT]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md
+// [wasm-tools]: https://crates.io/crates/wasm-tools
+func LoadWIT(path string) (*Resolve, error) {
+	wasmTools, err := exec.LookPath("wasm-tools")
+	if err != nil {
+		return nil, err
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	cmd := exec.Command(wasmTools, "component", "wit", "-j")
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if path == "" || path == "-" {
+		cmd.Stdin = os.Stdin
+	} else {
+		cmd.Args = append(cmd.Args, path)
+	}
+
+	fmt.Printf("%s\n", strings.Join(cmd.Args, " "))
+
+	err = cmd.Run()
+	if err != nil {
+		fmt.Fprint(os.Stderr, stderr.String())
+		return nil, err
+	}
+
+	return DecodeJSON(&stdout)
+}

--- a/wit/testdata_test.go
+++ b/wit/testdata_test.go
@@ -50,12 +50,7 @@ func loadTestdata(f func(path string, res *Resolve) error) error {
 		if !strings.HasSuffix(path, ".wit.json") && !strings.HasSuffix(path, ".wit.md.json") {
 			return nil
 		}
-		file, err := os.Open(path)
-		if err != nil {
-			return err
-		}
-		defer file.Close()
-		res, err := DecodeJSON(file)
+		res, err := LoadJSON(path)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
- **wit: add LoadJSON and LoadWIT functions**
- **cmd/wit-bindgen-go**
- **.github/workflows/test: setup wasm-tools**
- **README: update with additional context**
