### PR TITLE
cm: streamline API

Remove unused exported types and functions.

### DIFF
--- a/cm/bounds_check.go
+++ b/cm/bounds_check.go
@@ -1,8 +1,0 @@
-//go:build cmboundscheck
-
-package cm
-
-// BoundsCheck determines if bounds-checking is compiled into this package.
-// To enable bounds-checking, build this package with -tags cmboundscheck.
-// The default is off.
-const BoundsCheck = true

--- a/cm/bounds_check_default.go
+++ b/cm/bounds_check_default.go
@@ -1,8 +1,0 @@
-//go:build !cmboundscheck
-
-package cm
-
-// BoundsCheck determines if bounds-checking is compiled into this package.
-// To enable bounds-checking, build this package with -tags cmboundscheck.
-// The default is off.
-const BoundsCheck = false

--- a/cm/enum.go
+++ b/cm/enum.go
@@ -1,7 +1,0 @@
-package cm
-
-type (
-	Enum8  uint8
-	Enum16 uint16
-	Enum32 uint32
-)

--- a/cm/flags.go
+++ b/cm/flags.go
@@ -1,3 +1,5 @@
+//go:build cmflagsexperiment
+
 package cm
 
 import (

--- a/cm/flags_test.go
+++ b/cm/flags_test.go
@@ -1,3 +1,5 @@
+//go:build cmflagsexperiment
+
 package cm
 
 import (

--- a/cm/resource.go
+++ b/cm/resource.go
@@ -1,6 +1,10 @@
 package cm
 
-// TODO: should there be separate types for owned vs borrowed handles?
+// Resource represents an opaque Component Model [resource handle].
+// It is represented in the [Canonical ABI] as an 32-bit integer.
+//
+// [resource handle]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/Explainer.md#handle-types
+// [Canonical ABI]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md
 type Resource uint32
 
 // ResourceNone is a sentinel value indicating a null or uninitialized resource.
@@ -8,9 +12,3 @@ type Resource uint32
 //
 // [Canonical ABI runtime state]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#runtime-state
 const ResourceNone = 0
-
-type Handle uint32
-
-type Own[T any] Handle
-
-type Borrow[T any] Handle

--- a/cm/variant_test.go
+++ b/cm/variant_test.go
@@ -1,6 +1,8 @@
 package cm
 
 import (
+	"runtime"
+	"strings"
 	"testing"
 	"unsafe"
 )
@@ -42,9 +44,9 @@ func TestVariantLayout(t *testing.T) {
 	}
 }
 
-func TestGetBoundsCheck(t *testing.T) {
-	if !BoundsCheck {
-		return // TinyGo does not support t.SkipNow
+func TestGetValidates(t *testing.T) {
+	if runtime.Compiler == "tinygo" && strings.Contains(runtime.GOARCH, "wasm") {
+		return
 	}
 	defer func() {
 		if recover() == nil {
@@ -55,9 +57,9 @@ func TestGetBoundsCheck(t *testing.T) {
 	_ = Case[string](&v, 0)
 }
 
-func TestNewVariantBoundsCheck(t *testing.T) {
-	if !BoundsCheck {
-		return // TinyGo does not support t.SkipNow
+func TestNewVariantValidates(t *testing.T) {
+	if runtime.Compiler == "tinygo" && strings.Contains(runtime.GOARCH, "wasm") {
+		return
 	}
 	defer func() {
 		if recover() == nil {


### PR DESCRIPTION
Remove unused types from package `cm` until needed. Inline bounds checking for `variant` types.