### PR TITLE
wit/bindgen: add experimental Go export bindings

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+.DS_Store
+.git
+.github
+*.csv
+*.log
+*.yaml
+*.yml

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,8 @@
+{
+	"useTabs": true,
+	"tabWidth": 8,
+	"semi": false,
+	"singleQuote": true,
+	"printWidth": 256,
+	"trailingComma": "es5"
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,23 @@
+{
+	// List of extensions which should be recommended for users of this workspace.
+	// See http://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+	"recommendations": [
+		"bytecodealliance.wit-idl",
+		"davidanson.vscode-markdownlint",
+		"dbaeumer.vscode-eslint",
+		"dzannotti.vscode-babel-coloring",
+		"eamodio.gitlens",
+		"eriklynd.json-tools",
+		"foxundermoon.shell-format",
+		"golang.go",
+		"redhat.vscode-yaml",
+		"stkb.rewrap",
+		"xaver.clang-format",
+		"esbenp.prettier-vscode",
+		"github.vscode-github-actions"
+	],
+
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": ["chenxsan.vscode-standardjs"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,115 @@
+{
+	// Editor
+	"editor.copyWithSyntaxHighlighting": false,
+	"editor.detectIndentation": false,
+	"editor.formatOnSave": true,
+	"editor.insertSpaces": false,
+	"editor.tabSize": 8,
+	"files.eol": "\n",
+
+	// Files
+	"files.exclude": {
+		"**/.git": true
+	},
+	"files.associations": {
+		"*.yapf": "ini",
+		"Brewfile": "ruby",
+		"Tiltfile": "starlark"
+	},
+	"files.insertFinalNewline": true,
+	"files.watcherExclude": {
+		"**/.git/objects/**": true,
+		"**/.git/subtree-cache/**": true
+	},
+	"files.trimTrailingWhitespace": true,
+
+	// Go
+	"[go]": {
+		"editor.codeActionsOnSave": {
+			"source.organizeImports": "explicit"
+		},
+		"editor.snippetSuggestions": "none"
+	},
+	"[go.mod]": {
+		"editor.codeActionsOnSave": {
+			"source.fixAll": "explicit",
+			"source.organizeImports": "explicit"
+		}
+	},
+	"go.useLanguageServer": true,
+	"go.diagnostic.vulncheck": "Imports",
+	"gopls": {
+		"formatting.gofumpt": true,
+		"ui.completion.usePlaceholders": true,
+		"ui.diagnostic.staticcheck": true,
+		"ui.diagnostic.analyses": {
+			"unusedwrite": true,
+			"useany": true
+		}
+	},
+
+	// JSON
+	"[json]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
+	},
+	"[jsonc]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
+	},
+
+	// Make
+	"[makefile]": {
+		"editor.tabSize": 8
+	},
+
+	// Markdown
+	"[markdown]": {
+		"editor.rulers": [80]
+	},
+	"markdown.preview.breaks": true,
+	"markdownlint.config": {
+		"default": true,
+		"MD007": false,
+		"MD010": false,
+		"MD022": false,
+		"MD024": false,
+		"MD032": false
+	},
+
+	// Shell
+	"[shellscript]": {
+		"editor.defaultFormatter": "foxundermoon.shell-format"
+	},
+
+	// YAML
+	"[yaml]": {
+		"editor.autoIndent": "keep",
+		"editor.detectIndentation": true,
+		"editor.insertSpaces": true,
+		"editor.tabSize": 2,
+		"editor.quickSuggestions": {
+			"other": true,
+			"comments": false,
+			"strings": true
+		}
+	},
+
+	// GitHub Actions workflow files
+	"[github-actions-workflow]": {
+		"editor.autoIndent": "keep",
+		"editor.detectIndentation": true,
+		"editor.insertSpaces": true,
+		"editor.tabSize": 2,
+		"editor.quickSuggestions": {
+			"other": true,
+			"comments": false,
+			"strings": true
+		}
+	},
+
+	// TOML
+	"evenBetterToml.formatter.alignComments": false,
+	"evenBetterToml.formatter.alignEntries": false,
+	"evenBetterToml.formatter.allowedBlankLines": 2,
+	"evenBetterToml.formatter.columnWidth": 80,
+	"evenBetterToml.formatter.indentEntries": false
+}

--- a/README.md
+++ b/README.md
@@ -65,6 +65,42 @@ This will emit JSON on `stdout`, which can be piped to a file or another program
 wasm-tools component wit -j example.wit > example.wit.json
 ```
 
+## Notes
+
+### Export Bindings for Resource Types
+
+For each exported resource type, in addition to constructors, methods, and static functions, a component must import and export a number of functions to manage the resource lifecycle.
+
+### Example
+
+For a hypothetical WIT resource `water` in package/interface `example:foo/bar`, a component _imports_ the following administrative functions:
+
+- **resource-new**: initialize a resource handle for a given `rep` (concrete representation). Called by the component before a resource value is returned by an exported function.
+	- Import: `[export]example:foo/bar [resource-new]water`
+	- Params: `i32` rep (in C bindings, this is a pointer to the representation)
+	- Results: `i32` handle
+- **resource-rep**: return the underlying representation of a handle. Can only be called by the component instance that created the original resource.
+	- Import: `[export]example:foo/bar [resource-rep]water`
+	- Params: `i32` handle
+	- Results: `i32` rep (in C bindings, this is a pointer to the representation)
+- **resource-drop**: drops an owned handle to a resource. If the resource has zero loans, the destructor (below) will be called.
+	- Import: `example:foo/bar [resource-drop]water`
+	- Params: `i32` handle
+	- Results: none
+
+In addition, the resource destructor is _exported_:
+
+- **dtor**: destructor, implemented by user code
+	- Export: `example:foo/bar#[dtor]water`
+	- Params: `i32` rep (in C bindings, this is a pointer)
+	- Results: none
+	- Notes: the
+
+Similarly, a function is exported for each resource method (e.g. `drink` and `spill`)
+
+- Export: `example:foo/bar#[method]water.drink` (implemented by user code)
+- Export: `example:foo/bar#[method]water.spill` (implemented by user code)
+
 ## License
 
 This project is licensed under the Apache 2.0 license with the LLVM exception. See [LICENSE](LICENSE) for more details.

--- a/README.md
+++ b/README.md
@@ -65,42 +65,6 @@ This will emit JSON on `stdout`, which can be piped to a file or another program
 wasm-tools component wit -j example.wit > example.wit.json
 ```
 
-## Notes
-
-### Export Bindings for Resource Types
-
-For each exported resource type, in addition to constructors, methods, and static functions, a component must import and export a number of functions to manage the resource lifecycle.
-
-### Example
-
-For a hypothetical WIT resource `water` in package/interface `example:foo/bar`, a component _imports_ the following administrative functions:
-
-- **resource-new**: initialize a resource handle for a given `rep` (concrete representation). Called by the component before a resource value is returned by an exported function.
-	- Import: `[export]example:foo/bar [resource-new]water`
-	- Params: `i32` rep (in C bindings, this is a pointer to the representation)
-	- Results: `i32` handle
-- **resource-rep**: return the underlying representation of a handle. Can only be called by the component instance that created the original resource.
-	- Import: `[export]example:foo/bar [resource-rep]water`
-	- Params: `i32` handle
-	- Results: `i32` rep (in C bindings, this is a pointer to the representation)
-- **resource-drop**: drops an owned handle to a resource. If the resource has zero loans, the destructor (below) will be called.
-	- Import: `example:foo/bar [resource-drop]water`
-	- Params: `i32` handle
-	- Results: none
-
-In addition, the resource destructor is _exported_:
-
-- **dtor**: destructor, implemented by user code
-	- Export: `example:foo/bar#[dtor]water`
-	- Params: `i32` rep (in C bindings, this is a pointer)
-	- Results: none
-	- Notes: the
-
-Similarly, a function is exported for each resource method (e.g. `drink` and `spill`)
-
-- Export: `example:foo/bar#[method]water.drink` (implemented by user code)
-- Export: `example:foo/bar#[method]water.spill` (implemented by user code)
-
 ## License
 
 This project is licensed under the Apache 2.0 license with the LLVM exception. See [LICENSE](LICENSE) for more details.

--- a/cmd/wit-bindgen-go/cmd/generate/generate.go
+++ b/cmd/wit-bindgen-go/cmd/generate/generate.go
@@ -37,6 +37,10 @@ var Command = &cli.Command{
 			Usage: "emit versioned Go package(s) for each WIT version",
 		},
 		&cli.BoolFlag{
+			Name:  "exports",
+			Usage: "emit export bindings (WIP)",
+		},
+		&cli.BoolFlag{
 			Name:  "dry-run",
 			Usage: "do not write files; print to stdout",
 		},
@@ -73,6 +77,7 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		bindgen.GeneratedBy(cmd.Root().Name),
 		bindgen.PackageRoot(pkgPath),
 		bindgen.Versioned(cmd.Bool("versioned")),
+		bindgen.GenerateExports(cmd.Bool("exports")),
 		bindgen.MapIdents(cmd.StringMap("map")),
 	)
 	if err != nil {

--- a/design/README.md
+++ b/design/README.md
@@ -1,0 +1,58 @@
+# Design
+
+This directory contains design notes and prototypes of Go bindings for Component Model interfaces.
+
+## Exports
+
+### Export Bindings for Resource Types
+
+For each exported resource type, in addition to constructors, methods, and static functions, a component must import and export a number of functions to manage the resource lifecycle.
+
+### Example
+
+For a hypothetical WIT resource `water` in package/interface `example:foo/bar`, a component _imports_ the following administrative functions:
+
+- **resource-new**: initialize a resource handle for a given `rep` (concrete representation). Called by the component before a resource value is returned by an exported function.
+	- Import: `[export]example:foo/bar [resource-new]water`
+	- Params: `i32` rep (in C bindings, this is a pointer to the representation)
+	- Results: `i32` handle
+- **resource-rep**: return the underlying representation of a handle. Can only be called by the component instance that created the original resource.
+	- Import: `[export]example:foo/bar [resource-rep]water`
+	- Params: `i32` handle
+	- Results: `i32` rep (in C bindings, this is a pointer to the representation)
+- **resource-drop**: drops an owned handle to a resource. If the resource has zero loans, the destructor (below) will be called.
+	- Import: `example:foo/bar [resource-drop]water`
+	- Params: `i32` handle
+	- Results: none
+
+In addition, the resource destructor is _exported_:
+
+- **dtor**: destructor, implemented by user code
+	- Export: `example:foo/bar#[dtor]water`
+	- Params: `i32` rep (in C bindings, this is a pointer)
+	- Results: none
+	- Notes: the
+
+Similarly, a function is exported for each resource method (e.g. `drink` and `spill`)
+
+- Export: `example:foo/bar#[method]water.drink` (implemented by user code)
+- Export: `example:foo/bar#[method]water.spill` (implemented by user code)
+
+### Example in Go
+
+#### Generated Bindings
+
+```go
+package bar
+
+// imports omitted
+
+type Water cm.Resource
+
+//go:wasmimport [export]example:foo/bar [resource-new]water
+func wasmimport_WaterResourceNew(rep uintptr) Water
+
+func WaterResourceNew[Rep WaterInterface](rep Rep) Water {
+	return wasmimport_WaterResourceNew(*(*uintptr)(unsafe.Pointer(&rep)))
+}
+```

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ydnar/wasm-tools-go
 
-go 1.22.0
+go 1.22
 
 require (
 	github.com/coreos/go-semver v0.3.1

--- a/internal/go/gen/file.go
+++ b/internal/go/gen/file.go
@@ -105,11 +105,11 @@ func (f *File) Bytes() ([]byte, error) {
 	return formatted, nil
 }
 
-// Declare adds a package-scoped identifier to [File] f.
+// DeclareName adds a package-scoped identifier to [File] f.
 // It additionally checks the file-scoped declarations (local package names).
 // It returns the package-unique name (which may be different than name).
-func (f *File) Declare(name string) string {
-	return f.Package.Declare(f.UniqueName(name))
+func (f *File) DeclareName(name string) string {
+	return f.Package.DeclareName(f.Scope.DeclareName(name))
 }
 
 // Import imports the Go package specified by path, returning the local name for the imported package.
@@ -122,7 +122,7 @@ func (f *File) Import(path string) string {
 		return ""
 	}
 	if f.Imports[path] == "" {
-		f.Imports[path] = f.UniqueName(name)
+		f.Imports[path] = f.Scope.DeclareName(name)
 	}
 	return f.Imports[path]
 }

--- a/internal/go/gen/names.go
+++ b/internal/go/gen/names.go
@@ -20,15 +20,6 @@ func UniqueName(name string, filters ...func(string) bool) string {
 	return name
 }
 
-// HasKey returns a function for map m that tests presence of key k.
-// The function returns true if m contains k, and false otherwise.
-func HasKey[M ~map[K]V, K comparable, V any](m M) func(k K) bool {
-	return func(k K) bool {
-		_, ok := m[k]
-		return ok
-	}
-}
-
 // Scope represents a Go name scope, like a package, file, interface, struct, or function blocks.
 type Scope interface {
 	// DeclareName declares name within this scope, modifying it as necessary to avoid

--- a/internal/go/gen/names.go
+++ b/internal/go/gen/names.go
@@ -1,5 +1,7 @@
 package gen
 
+import "go/token"
+
 // UniqueName tests name against filters and modifies name until all filters return false.
 // Use IsReserved to filter out Go keywords and predeclared identifiers.
 //
@@ -104,37 +106,10 @@ func (reservedScope) HasName(name string) bool {
 
 // IsReserved returns true for any name that is a Go keyword or predeclared identifier.
 func IsReserved(name string) bool {
-	return reserved[name]
+	return token.IsKeyword(name) || reserved[name]
 }
 
 var reserved = mapWords(
-	// Keywords
-	"break",
-	"case",
-	"chan",
-	"const",
-	"continue",
-	"default",
-	"defer",
-	"else",
-	"fallthrough",
-	"for",
-	"func",
-	"go",
-	"goto",
-	"if",
-	"import",
-	"interface",
-	"map",
-	"package",
-	"range",
-	"return",
-	"select",
-	"struct",
-	"switch",
-	"type",
-	"var",
-
 	// Types
 	"any",
 	"bool",

--- a/internal/go/gen/package.go
+++ b/internal/go/gen/package.go
@@ -28,12 +28,6 @@ func NewPackage(path string) *Package {
 	return p
 }
 
-// Declare adds a package-scoped identifier to [Package] pkg.
-// It returns the package-unique name (which may be different than name).
-func (pkg *Package) Declare(name string) string {
-	return pkg.UniqueName(name)
-}
-
 // File finds or adds a new file named name to pkg.
 func (pkg *Package) File(name string) *File {
 	file := pkg.Files[name]

--- a/wasi/cli/environment/environment.wit.go
+++ b/wasi/cli/environment/environment.wit.go
@@ -18,13 +18,13 @@ import (
 //go:nosplit
 func GetArguments() cm.List[string] {
 	var result cm.List[string]
-	getArguments(&result)
+	wasmimport_GetArguments(&result)
 	return result
 }
 
 //go:wasmimport wasi:cli/environment@0.2.0 get-arguments
 //go:noescape
-func getArguments(result *cm.List[string])
+func wasmimport_GetArguments(result *cm.List[string])
 
 // GetEnvironment represents function "wasi:cli/environment@0.2.0#get-environment".
 //
@@ -42,13 +42,13 @@ func getArguments(result *cm.List[string])
 //go:nosplit
 func GetEnvironment() cm.List[[2]string] {
 	var result cm.List[[2]string]
-	getEnvironment(&result)
+	wasmimport_GetEnvironment(&result)
 	return result
 }
 
 //go:wasmimport wasi:cli/environment@0.2.0 get-environment
 //go:noescape
-func getEnvironment(result *cm.List[[2]string])
+func wasmimport_GetEnvironment(result *cm.List[[2]string])
 
 // InitialCWD represents function "wasi:cli/environment@0.2.0#initial-cwd".
 //
@@ -60,10 +60,10 @@ func getEnvironment(result *cm.List[[2]string])
 //go:nosplit
 func InitialCWD() cm.Option[string] {
 	var result cm.Option[string]
-	initialCWD(&result)
+	wasmimport_InitialCWD(&result)
 	return result
 }
 
 //go:wasmimport wasi:cli/environment@0.2.0 initial-cwd
 //go:noescape
-func initialCWD(result *cm.Option[string])
+func wasmimport_InitialCWD(result *cm.Option[string])

--- a/wasi/cli/exit/exit.wit.go
+++ b/wasi/cli/exit/exit.wit.go
@@ -17,9 +17,9 @@ import (
 //
 //go:nosplit
 func Exit(status cm.Result) {
-	exit(status)
+	wasmimport_Exit(status)
 }
 
 //go:wasmimport wasi:cli/exit@0.2.0 exit
 //go:noescape
-func exit(status cm.Result)
+func wasmimport_Exit(status cm.Result)

--- a/wasi/cli/run/run.wit.go
+++ b/wasi/cli/run/run.wit.go
@@ -17,9 +17,9 @@ import (
 //
 //go:nosplit
 func Run() cm.Result {
-	return run()
+	return wasmimport_Run()
 }
 
 //go:wasmimport wasi:cli/run@0.2.0 run
 //go:noescape
-func run() cm.Result
+func wasmimport_Run() cm.Result

--- a/wasi/cli/stderr/stderr.wit.go
+++ b/wasi/cli/stderr/stderr.wit.go
@@ -20,9 +20,9 @@ type OutputStream = streams.OutputStream
 //
 //go:nosplit
 func GetStderr() OutputStream {
-	return getStderr()
+	return wasmimport_GetStderr()
 }
 
 //go:wasmimport wasi:cli/stderr@0.2.0 get-stderr
 //go:noescape
-func getStderr() OutputStream
+func wasmimport_GetStderr() OutputStream

--- a/wasi/cli/stdin/stdin.wit.go
+++ b/wasi/cli/stdin/stdin.wit.go
@@ -20,9 +20,9 @@ type InputStream = streams.InputStream
 //
 //go:nosplit
 func GetStdin() InputStream {
-	return getStdin()
+	return wasmimport_GetStdin()
 }
 
 //go:wasmimport wasi:cli/stdin@0.2.0 get-stdin
 //go:noescape
-func getStdin() InputStream
+func wasmimport_GetStdin() InputStream

--- a/wasi/cli/stdout/stdout.wit.go
+++ b/wasi/cli/stdout/stdout.wit.go
@@ -20,9 +20,9 @@ type OutputStream = streams.OutputStream
 //
 //go:nosplit
 func GetStdout() OutputStream {
-	return getStdout()
+	return wasmimport_GetStdout()
 }
 
 //go:wasmimport wasi:cli/stdout@0.2.0 get-stdout
 //go:noescape
-func getStdout() OutputStream
+func wasmimport_GetStdout() OutputStream

--- a/wasi/cli/terminal-input/terminal-input.wit.go
+++ b/wasi/cli/terminal-input/terminal-input.wit.go
@@ -28,9 +28,9 @@ type TerminalInput cm.Resource
 //
 //go:nosplit
 func (self TerminalInput) ResourceDrop() {
-	self.resourceDrop()
+	self.wasmimport_ResourceDrop()
 }
 
 //go:wasmimport wasi:cli/terminal-input@0.2.0 [resource-drop]terminal-input
 //go:noescape
-func (self TerminalInput) resourceDrop()
+func (self TerminalInput) wasmimport_ResourceDrop()

--- a/wasi/cli/terminal-output/terminal-output.wit.go
+++ b/wasi/cli/terminal-output/terminal-output.wit.go
@@ -28,9 +28,9 @@ type TerminalOutput cm.Resource
 //
 //go:nosplit
 func (self TerminalOutput) ResourceDrop() {
-	self.resourceDrop()
+	self.wasmimport_ResourceDrop()
 }
 
 //go:wasmimport wasi:cli/terminal-output@0.2.0 [resource-drop]terminal-output
 //go:noescape
-func (self TerminalOutput) resourceDrop()
+func (self TerminalOutput) wasmimport_ResourceDrop()

--- a/wasi/cli/terminal-stderr/terminal-stderr.wit.go
+++ b/wasi/cli/terminal-stderr/terminal-stderr.wit.go
@@ -28,10 +28,10 @@ type TerminalOutput = terminaloutput.TerminalOutput
 //go:nosplit
 func GetTerminalStderr() cm.Option[TerminalOutput] {
 	var result cm.Option[TerminalOutput]
-	getTerminalStderr(&result)
+	wasmimport_GetTerminalStderr(&result)
 	return result
 }
 
 //go:wasmimport wasi:cli/terminal-stderr@0.2.0 get-terminal-stderr
 //go:noescape
-func getTerminalStderr(result *cm.Option[TerminalOutput])
+func wasmimport_GetTerminalStderr(result *cm.Option[TerminalOutput])

--- a/wasi/cli/terminal-stdin/terminal-stdin.wit.go
+++ b/wasi/cli/terminal-stdin/terminal-stdin.wit.go
@@ -28,10 +28,10 @@ type TerminalInput = terminalinput.TerminalInput
 //go:nosplit
 func GetTerminalStdin() cm.Option[TerminalInput] {
 	var result cm.Option[TerminalInput]
-	getTerminalStdin(&result)
+	wasmimport_GetTerminalStdin(&result)
 	return result
 }
 
 //go:wasmimport wasi:cli/terminal-stdin@0.2.0 get-terminal-stdin
 //go:noescape
-func getTerminalStdin(result *cm.Option[TerminalInput])
+func wasmimport_GetTerminalStdin(result *cm.Option[TerminalInput])

--- a/wasi/cli/terminal-stdout/terminal-stdout.wit.go
+++ b/wasi/cli/terminal-stdout/terminal-stdout.wit.go
@@ -28,10 +28,10 @@ type TerminalOutput = terminaloutput.TerminalOutput
 //go:nosplit
 func GetTerminalStdout() cm.Option[TerminalOutput] {
 	var result cm.Option[TerminalOutput]
-	getTerminalStdout(&result)
+	wasmimport_GetTerminalStdout(&result)
 	return result
 }
 
 //go:wasmimport wasi:cli/terminal-stdout@0.2.0 get-terminal-stdout
 //go:noescape
-func getTerminalStdout(result *cm.Option[TerminalOutput])
+func wasmimport_GetTerminalStdout(result *cm.Option[TerminalOutput])

--- a/wasi/clocks/monotonic-clock/monotonic-clock.wit.go
+++ b/wasi/clocks/monotonic-clock/monotonic-clock.wit.go
@@ -52,12 +52,12 @@ type Pollable = poll.Pollable
 //
 //go:nosplit
 func Now() Instant {
-	return now()
+	return wasmimport_Now()
 }
 
 //go:wasmimport wasi:clocks/monotonic-clock@0.2.0 now
 //go:noescape
-func now() Instant
+func wasmimport_Now() Instant
 
 // Resolution represents function "wasi:clocks/monotonic-clock@0.2.0#resolution".
 //
@@ -68,12 +68,12 @@ func now() Instant
 //
 //go:nosplit
 func Resolution() Duration {
-	return resolution()
+	return wasmimport_Resolution()
 }
 
 //go:wasmimport wasi:clocks/monotonic-clock@0.2.0 resolution
 //go:noescape
-func resolution() Duration
+func wasmimport_Resolution() Duration
 
 // SubscribeDuration represents function "wasi:clocks/monotonic-clock@0.2.0#subscribe-duration".
 //
@@ -85,12 +85,12 @@ func resolution() Duration
 //
 //go:nosplit
 func SubscribeDuration(when Duration) Pollable {
-	return subscribeDuration(when)
+	return wasmimport_SubscribeDuration(when)
 }
 
 //go:wasmimport wasi:clocks/monotonic-clock@0.2.0 subscribe-duration
 //go:noescape
-func subscribeDuration(when Duration) Pollable
+func wasmimport_SubscribeDuration(when Duration) Pollable
 
 // SubscribeInstant represents function "wasi:clocks/monotonic-clock@0.2.0#subscribe-instant".
 //
@@ -101,9 +101,9 @@ func subscribeDuration(when Duration) Pollable
 //
 //go:nosplit
 func SubscribeInstant(when Instant) Pollable {
-	return subscribeInstant(when)
+	return wasmimport_SubscribeInstant(when)
 }
 
 //go:wasmimport wasi:clocks/monotonic-clock@0.2.0 subscribe-instant
 //go:noescape
-func subscribeInstant(when Instant) Pollable
+func wasmimport_SubscribeInstant(when Instant) Pollable

--- a/wasi/clocks/wall-clock/wall-clock.wit.go
+++ b/wasi/clocks/wall-clock/wall-clock.wit.go
@@ -54,13 +54,13 @@ type DateTime struct {
 //go:nosplit
 func Now() DateTime {
 	var result DateTime
-	now(&result)
+	wasmimport_Now(&result)
 	return result
 }
 
 //go:wasmimport wasi:clocks/wall-clock@0.2.0 now
 //go:noescape
-func now(result *DateTime)
+func wasmimport_Now(result *DateTime)
 
 // Resolution represents function "wasi:clocks/wall-clock@0.2.0#resolution".
 //
@@ -73,10 +73,10 @@ func now(result *DateTime)
 //go:nosplit
 func Resolution() DateTime {
 	var result DateTime
-	resolution(&result)
+	wasmimport_Resolution(&result)
 	return result
 }
 
 //go:wasmimport wasi:clocks/wall-clock@0.2.0 resolution
 //go:noescape
-func resolution(result *DateTime)
+func wasmimport_Resolution(result *DateTime)

--- a/wasi/filesystem/preopens/preopens.wit.go
+++ b/wasi/filesystem/preopens/preopens.wit.go
@@ -24,10 +24,10 @@ type Descriptor = types.Descriptor
 //go:nosplit
 func GetDirectories() cm.List[cm.Tuple[Descriptor, string]] {
 	var result cm.List[cm.Tuple[Descriptor, string]]
-	getDirectories(&result)
+	wasmimport_GetDirectories(&result)
 	return result
 }
 
 //go:wasmimport wasi:filesystem/preopens@0.2.0 get-directories
 //go:noescape
-func getDirectories(result *cm.List[cm.Tuple[Descriptor, string]])
+func wasmimport_GetDirectories(result *cm.List[cm.Tuple[Descriptor, string]])

--- a/wasi/filesystem/types/types.wit.go
+++ b/wasi/filesystem/types/types.wit.go
@@ -97,12 +97,12 @@ type Descriptor cm.Resource
 //
 //go:nosplit
 func (self Descriptor) ResourceDrop() {
-	self.resourceDrop()
+	self.wasmimport_ResourceDrop()
 }
 
 //go:wasmimport wasi:filesystem/types@0.2.0 [resource-drop]descriptor
 //go:noescape
-func (self Descriptor) resourceDrop()
+func (self Descriptor) wasmimport_ResourceDrop()
 
 // Advise represents method "advise".
 //
@@ -115,13 +115,13 @@ func (self Descriptor) resourceDrop()
 //go:nosplit
 func (self Descriptor) Advise(offset FileSize, length FileSize, advice Advice) cm.ErrResult[struct{}, ErrorCode] {
 	var result cm.ErrResult[struct{}, ErrorCode]
-	self.advise(offset, length, advice, &result)
+	self.wasmimport_Advise(offset, length, advice, &result)
 	return result
 }
 
 //go:wasmimport wasi:filesystem/types@0.2.0 [method]descriptor.advise
 //go:noescape
-func (self Descriptor) advise(offset FileSize, length FileSize, advice Advice, result *cm.ErrResult[struct{}, ErrorCode])
+func (self Descriptor) wasmimport_Advise(offset FileSize, length FileSize, advice Advice, result *cm.ErrResult[struct{}, ErrorCode])
 
 // AppendViaStream represents method "append-via-stream".
 //
@@ -137,13 +137,13 @@ func (self Descriptor) advise(offset FileSize, length FileSize, advice Advice, r
 //go:nosplit
 func (self Descriptor) AppendViaStream() cm.OKResult[OutputStream, ErrorCode] {
 	var result cm.OKResult[OutputStream, ErrorCode]
-	self.appendViaStream(&result)
+	self.wasmimport_AppendViaStream(&result)
 	return result
 }
 
 //go:wasmimport wasi:filesystem/types@0.2.0 [method]descriptor.append-via-stream
 //go:noescape
-func (self Descriptor) appendViaStream(result *cm.OKResult[OutputStream, ErrorCode])
+func (self Descriptor) wasmimport_AppendViaStream(result *cm.OKResult[OutputStream, ErrorCode])
 
 // CreateDirectoryAt represents method "create-directory-at".
 //
@@ -156,13 +156,13 @@ func (self Descriptor) appendViaStream(result *cm.OKResult[OutputStream, ErrorCo
 //go:nosplit
 func (self Descriptor) CreateDirectoryAt(path string) cm.ErrResult[struct{}, ErrorCode] {
 	var result cm.ErrResult[struct{}, ErrorCode]
-	self.createDirectoryAt(path, &result)
+	self.wasmimport_CreateDirectoryAt(path, &result)
 	return result
 }
 
 //go:wasmimport wasi:filesystem/types@0.2.0 [method]descriptor.create-directory-at
 //go:noescape
-func (self Descriptor) createDirectoryAt(path string, result *cm.ErrResult[struct{}, ErrorCode])
+func (self Descriptor) wasmimport_CreateDirectoryAt(path string, result *cm.ErrResult[struct{}, ErrorCode])
 
 // GetFlags represents method "get-flags".
 //
@@ -178,13 +178,13 @@ func (self Descriptor) createDirectoryAt(path string, result *cm.ErrResult[struc
 //go:nosplit
 func (self Descriptor) GetFlags() cm.OKResult[DescriptorFlags, ErrorCode] {
 	var result cm.OKResult[DescriptorFlags, ErrorCode]
-	self.getFlags(&result)
+	self.wasmimport_GetFlags(&result)
 	return result
 }
 
 //go:wasmimport wasi:filesystem/types@0.2.0 [method]descriptor.get-flags
 //go:noescape
-func (self Descriptor) getFlags(result *cm.OKResult[DescriptorFlags, ErrorCode])
+func (self Descriptor) wasmimport_GetFlags(result *cm.OKResult[DescriptorFlags, ErrorCode])
 
 // GetType represents method "get-type".
 //
@@ -204,13 +204,13 @@ func (self Descriptor) getFlags(result *cm.OKResult[DescriptorFlags, ErrorCode])
 //go:nosplit
 func (self Descriptor) GetType() cm.OKResult[DescriptorType, ErrorCode] {
 	var result cm.OKResult[DescriptorType, ErrorCode]
-	self.getType(&result)
+	self.wasmimport_GetType(&result)
 	return result
 }
 
 //go:wasmimport wasi:filesystem/types@0.2.0 [method]descriptor.get-type
 //go:noescape
-func (self Descriptor) getType(result *cm.OKResult[DescriptorType, ErrorCode])
+func (self Descriptor) wasmimport_GetType(result *cm.OKResult[DescriptorType, ErrorCode])
 
 // IsSameObject represents method "is-same-object".
 //
@@ -225,12 +225,12 @@ func (self Descriptor) getType(result *cm.OKResult[DescriptorType, ErrorCode])
 //
 //go:nosplit
 func (self Descriptor) IsSameObject(other Descriptor) bool {
-	return self.isSameObject(other)
+	return self.wasmimport_IsSameObject(other)
 }
 
 //go:wasmimport wasi:filesystem/types@0.2.0 [method]descriptor.is-same-object
 //go:noescape
-func (self Descriptor) isSameObject(other Descriptor) bool
+func (self Descriptor) wasmimport_IsSameObject(other Descriptor) bool
 
 // LinkAt represents method "link-at".
 //
@@ -244,13 +244,13 @@ func (self Descriptor) isSameObject(other Descriptor) bool
 //go:nosplit
 func (self Descriptor) LinkAt(oldPathFlags PathFlags, oldPath string, newDescriptor Descriptor, newPath string) cm.ErrResult[struct{}, ErrorCode] {
 	var result cm.ErrResult[struct{}, ErrorCode]
-	self.linkAt(oldPathFlags, oldPath, newDescriptor, newPath, &result)
+	self.wasmimport_LinkAt(oldPathFlags, oldPath, newDescriptor, newPath, &result)
 	return result
 }
 
 //go:wasmimport wasi:filesystem/types@0.2.0 [method]descriptor.link-at
 //go:noescape
-func (self Descriptor) linkAt(oldPathFlags PathFlags, oldPath string, newDescriptor Descriptor, newPath string, result *cm.ErrResult[struct{}, ErrorCode])
+func (self Descriptor) wasmimport_LinkAt(oldPathFlags PathFlags, oldPath string, newDescriptor Descriptor, newPath string, result *cm.ErrResult[struct{}, ErrorCode])
 
 // MetadataHash represents method "metadata-hash".
 //
@@ -279,13 +279,13 @@ func (self Descriptor) linkAt(oldPathFlags PathFlags, oldPath string, newDescrip
 //go:nosplit
 func (self Descriptor) MetadataHash() cm.OKResult[MetadataHashValue, ErrorCode] {
 	var result cm.OKResult[MetadataHashValue, ErrorCode]
-	self.metadataHash(&result)
+	self.wasmimport_MetadataHash(&result)
 	return result
 }
 
 //go:wasmimport wasi:filesystem/types@0.2.0 [method]descriptor.metadata-hash
 //go:noescape
-func (self Descriptor) metadataHash(result *cm.OKResult[MetadataHashValue, ErrorCode])
+func (self Descriptor) wasmimport_MetadataHash(result *cm.OKResult[MetadataHashValue, ErrorCode])
 
 // MetadataHashAt represents method "metadata-hash-at".
 //
@@ -300,13 +300,13 @@ func (self Descriptor) metadataHash(result *cm.OKResult[MetadataHashValue, Error
 //go:nosplit
 func (self Descriptor) MetadataHashAt(pathFlags PathFlags, path string) cm.OKResult[MetadataHashValue, ErrorCode] {
 	var result cm.OKResult[MetadataHashValue, ErrorCode]
-	self.metadataHashAt(pathFlags, path, &result)
+	self.wasmimport_MetadataHashAt(pathFlags, path, &result)
 	return result
 }
 
 //go:wasmimport wasi:filesystem/types@0.2.0 [method]descriptor.metadata-hash-at
 //go:noescape
-func (self Descriptor) metadataHashAt(pathFlags PathFlags, path string, result *cm.OKResult[MetadataHashValue, ErrorCode])
+func (self Descriptor) wasmimport_MetadataHashAt(pathFlags PathFlags, path string, result *cm.OKResult[MetadataHashValue, ErrorCode])
 
 // OpenAt represents method "open-at".
 //
@@ -335,13 +335,13 @@ func (self Descriptor) metadataHashAt(pathFlags PathFlags, path string, result *
 //go:nosplit
 func (self Descriptor) OpenAt(pathFlags PathFlags, path string, openFlags OpenFlags, flags DescriptorFlags) cm.OKResult[Descriptor, ErrorCode] {
 	var result cm.OKResult[Descriptor, ErrorCode]
-	self.openAt(pathFlags, path, openFlags, flags, &result)
+	self.wasmimport_OpenAt(pathFlags, path, openFlags, flags, &result)
 	return result
 }
 
 //go:wasmimport wasi:filesystem/types@0.2.0 [method]descriptor.open-at
 //go:noescape
-func (self Descriptor) openAt(pathFlags PathFlags, path string, openFlags OpenFlags, flags DescriptorFlags, result *cm.OKResult[Descriptor, ErrorCode])
+func (self Descriptor) wasmimport_OpenAt(pathFlags PathFlags, path string, openFlags OpenFlags, flags DescriptorFlags, result *cm.OKResult[Descriptor, ErrorCode])
 
 // Read represents method "read".
 //
@@ -363,13 +363,13 @@ func (self Descriptor) openAt(pathFlags PathFlags, path string, openFlags OpenFl
 //go:nosplit
 func (self Descriptor) Read(length FileSize, offset FileSize) cm.OKResult[cm.Tuple[cm.List[uint8], bool], ErrorCode] {
 	var result cm.OKResult[cm.Tuple[cm.List[uint8], bool], ErrorCode]
-	self.read(length, offset, &result)
+	self.wasmimport_Read(length, offset, &result)
 	return result
 }
 
 //go:wasmimport wasi:filesystem/types@0.2.0 [method]descriptor.read
 //go:noescape
-func (self Descriptor) read(length FileSize, offset FileSize, result *cm.OKResult[cm.Tuple[cm.List[uint8], bool], ErrorCode])
+func (self Descriptor) wasmimport_Read(length FileSize, offset FileSize, result *cm.OKResult[cm.Tuple[cm.List[uint8], bool], ErrorCode])
 
 // ReadDirectory represents method "read-directory".
 //
@@ -388,13 +388,13 @@ func (self Descriptor) read(length FileSize, offset FileSize, result *cm.OKResul
 //go:nosplit
 func (self Descriptor) ReadDirectory() cm.OKResult[DirectoryEntryStream, ErrorCode] {
 	var result cm.OKResult[DirectoryEntryStream, ErrorCode]
-	self.readDirectory(&result)
+	self.wasmimport_ReadDirectory(&result)
 	return result
 }
 
 //go:wasmimport wasi:filesystem/types@0.2.0 [method]descriptor.read-directory
 //go:noescape
-func (self Descriptor) readDirectory(result *cm.OKResult[DirectoryEntryStream, ErrorCode])
+func (self Descriptor) wasmimport_ReadDirectory(result *cm.OKResult[DirectoryEntryStream, ErrorCode])
 
 // ReadViaStream represents method "read-via-stream".
 //
@@ -412,13 +412,13 @@ func (self Descriptor) readDirectory(result *cm.OKResult[DirectoryEntryStream, E
 //go:nosplit
 func (self Descriptor) ReadViaStream(offset FileSize) cm.OKResult[InputStream, ErrorCode] {
 	var result cm.OKResult[InputStream, ErrorCode]
-	self.readViaStream(offset, &result)
+	self.wasmimport_ReadViaStream(offset, &result)
 	return result
 }
 
 //go:wasmimport wasi:filesystem/types@0.2.0 [method]descriptor.read-via-stream
 //go:noescape
-func (self Descriptor) readViaStream(offset FileSize, result *cm.OKResult[InputStream, ErrorCode])
+func (self Descriptor) wasmimport_ReadViaStream(offset FileSize, result *cm.OKResult[InputStream, ErrorCode])
 
 // ReadLinkAt represents method "readlink-at".
 //
@@ -434,13 +434,13 @@ func (self Descriptor) readViaStream(offset FileSize, result *cm.OKResult[InputS
 //go:nosplit
 func (self Descriptor) ReadLinkAt(path string) cm.OKResult[string, ErrorCode] {
 	var result cm.OKResult[string, ErrorCode]
-	self.readLinkAt(path, &result)
+	self.wasmimport_ReadLinkAt(path, &result)
 	return result
 }
 
 //go:wasmimport wasi:filesystem/types@0.2.0 [method]descriptor.readlink-at
 //go:noescape
-func (self Descriptor) readLinkAt(path string, result *cm.OKResult[string, ErrorCode])
+func (self Descriptor) wasmimport_ReadLinkAt(path string, result *cm.OKResult[string, ErrorCode])
 
 // RemoveDirectoryAt represents method "remove-directory-at".
 //
@@ -455,13 +455,13 @@ func (self Descriptor) readLinkAt(path string, result *cm.OKResult[string, Error
 //go:nosplit
 func (self Descriptor) RemoveDirectoryAt(path string) cm.ErrResult[struct{}, ErrorCode] {
 	var result cm.ErrResult[struct{}, ErrorCode]
-	self.removeDirectoryAt(path, &result)
+	self.wasmimport_RemoveDirectoryAt(path, &result)
 	return result
 }
 
 //go:wasmimport wasi:filesystem/types@0.2.0 [method]descriptor.remove-directory-at
 //go:noescape
-func (self Descriptor) removeDirectoryAt(path string, result *cm.ErrResult[struct{}, ErrorCode])
+func (self Descriptor) wasmimport_RemoveDirectoryAt(path string, result *cm.ErrResult[struct{}, ErrorCode])
 
 // RenameAt represents method "rename-at".
 //
@@ -475,13 +475,13 @@ func (self Descriptor) removeDirectoryAt(path string, result *cm.ErrResult[struc
 //go:nosplit
 func (self Descriptor) RenameAt(oldPath string, newDescriptor Descriptor, newPath string) cm.ErrResult[struct{}, ErrorCode] {
 	var result cm.ErrResult[struct{}, ErrorCode]
-	self.renameAt(oldPath, newDescriptor, newPath, &result)
+	self.wasmimport_RenameAt(oldPath, newDescriptor, newPath, &result)
 	return result
 }
 
 //go:wasmimport wasi:filesystem/types@0.2.0 [method]descriptor.rename-at
 //go:noescape
-func (self Descriptor) renameAt(oldPath string, newDescriptor Descriptor, newPath string, result *cm.ErrResult[struct{}, ErrorCode])
+func (self Descriptor) wasmimport_RenameAt(oldPath string, newDescriptor Descriptor, newPath string, result *cm.ErrResult[struct{}, ErrorCode])
 
 // SetSize represents method "set-size".
 //
@@ -495,13 +495,13 @@ func (self Descriptor) renameAt(oldPath string, newDescriptor Descriptor, newPat
 //go:nosplit
 func (self Descriptor) SetSize(size FileSize) cm.ErrResult[struct{}, ErrorCode] {
 	var result cm.ErrResult[struct{}, ErrorCode]
-	self.setSize(size, &result)
+	self.wasmimport_SetSize(size, &result)
 	return result
 }
 
 //go:wasmimport wasi:filesystem/types@0.2.0 [method]descriptor.set-size
 //go:noescape
-func (self Descriptor) setSize(size FileSize, result *cm.ErrResult[struct{}, ErrorCode])
+func (self Descriptor) wasmimport_SetSize(size FileSize, result *cm.ErrResult[struct{}, ErrorCode])
 
 // SetTimes represents method "set-times".
 //
@@ -517,13 +517,13 @@ func (self Descriptor) setSize(size FileSize, result *cm.ErrResult[struct{}, Err
 //go:nosplit
 func (self Descriptor) SetTimes(dataAccessTimestamp NewTimestamp, dataModificationTimestamp NewTimestamp) cm.ErrResult[struct{}, ErrorCode] {
 	var result cm.ErrResult[struct{}, ErrorCode]
-	self.setTimes(dataAccessTimestamp, dataModificationTimestamp, &result)
+	self.wasmimport_SetTimes(dataAccessTimestamp, dataModificationTimestamp, &result)
 	return result
 }
 
 //go:wasmimport wasi:filesystem/types@0.2.0 [method]descriptor.set-times
 //go:noescape
-func (self Descriptor) setTimes(dataAccessTimestamp NewTimestamp, dataModificationTimestamp NewTimestamp, result *cm.ErrResult[struct{}, ErrorCode])
+func (self Descriptor) wasmimport_SetTimes(dataAccessTimestamp NewTimestamp, dataModificationTimestamp NewTimestamp, result *cm.ErrResult[struct{}, ErrorCode])
 
 // SetTimesAt represents method "set-times-at".
 //
@@ -540,13 +540,13 @@ func (self Descriptor) setTimes(dataAccessTimestamp NewTimestamp, dataModificati
 //go:nosplit
 func (self Descriptor) SetTimesAt(pathFlags PathFlags, path string, dataAccessTimestamp NewTimestamp, dataModificationTimestamp NewTimestamp) cm.ErrResult[struct{}, ErrorCode] {
 	var result cm.ErrResult[struct{}, ErrorCode]
-	self.setTimesAt(pathFlags, path, dataAccessTimestamp, dataModificationTimestamp, &result)
+	self.wasmimport_SetTimesAt(pathFlags, path, dataAccessTimestamp, dataModificationTimestamp, &result)
 	return result
 }
 
 //go:wasmimport wasi:filesystem/types@0.2.0 [method]descriptor.set-times-at
 //go:noescape
-func (self Descriptor) setTimesAt(pathFlags PathFlags, path string, dataAccessTimestamp NewTimestamp, dataModificationTimestamp NewTimestamp, result *cm.ErrResult[struct{}, ErrorCode])
+func (self Descriptor) wasmimport_SetTimesAt(pathFlags PathFlags, path string, dataAccessTimestamp NewTimestamp, dataModificationTimestamp NewTimestamp, result *cm.ErrResult[struct{}, ErrorCode])
 
 // Stat represents method "stat".
 //
@@ -565,13 +565,13 @@ func (self Descriptor) setTimesAt(pathFlags PathFlags, path string, dataAccessTi
 //go:nosplit
 func (self Descriptor) Stat() cm.OKResult[DescriptorStat, ErrorCode] {
 	var result cm.OKResult[DescriptorStat, ErrorCode]
-	self.stat(&result)
+	self.wasmimport_Stat(&result)
 	return result
 }
 
 //go:wasmimport wasi:filesystem/types@0.2.0 [method]descriptor.stat
 //go:noescape
-func (self Descriptor) stat(result *cm.OKResult[DescriptorStat, ErrorCode])
+func (self Descriptor) wasmimport_Stat(result *cm.OKResult[DescriptorStat, ErrorCode])
 
 // StatAt represents method "stat-at".
 //
@@ -589,13 +589,13 @@ func (self Descriptor) stat(result *cm.OKResult[DescriptorStat, ErrorCode])
 //go:nosplit
 func (self Descriptor) StatAt(pathFlags PathFlags, path string) cm.OKResult[DescriptorStat, ErrorCode] {
 	var result cm.OKResult[DescriptorStat, ErrorCode]
-	self.statAt(pathFlags, path, &result)
+	self.wasmimport_StatAt(pathFlags, path, &result)
 	return result
 }
 
 //go:wasmimport wasi:filesystem/types@0.2.0 [method]descriptor.stat-at
 //go:noescape
-func (self Descriptor) statAt(pathFlags PathFlags, path string, result *cm.OKResult[DescriptorStat, ErrorCode])
+func (self Descriptor) wasmimport_StatAt(pathFlags PathFlags, path string, result *cm.OKResult[DescriptorStat, ErrorCode])
 
 // SymlinkAt represents method "symlink-at".
 //
@@ -611,13 +611,13 @@ func (self Descriptor) statAt(pathFlags PathFlags, path string, result *cm.OKRes
 //go:nosplit
 func (self Descriptor) SymlinkAt(oldPath string, newPath string) cm.ErrResult[struct{}, ErrorCode] {
 	var result cm.ErrResult[struct{}, ErrorCode]
-	self.symlinkAt(oldPath, newPath, &result)
+	self.wasmimport_SymlinkAt(oldPath, newPath, &result)
 	return result
 }
 
 //go:wasmimport wasi:filesystem/types@0.2.0 [method]descriptor.symlink-at
 //go:noescape
-func (self Descriptor) symlinkAt(oldPath string, newPath string, result *cm.ErrResult[struct{}, ErrorCode])
+func (self Descriptor) wasmimport_SymlinkAt(oldPath string, newPath string, result *cm.ErrResult[struct{}, ErrorCode])
 
 // Sync represents method "sync".
 //
@@ -633,13 +633,13 @@ func (self Descriptor) symlinkAt(oldPath string, newPath string, result *cm.ErrR
 //go:nosplit
 func (self Descriptor) Sync() cm.ErrResult[struct{}, ErrorCode] {
 	var result cm.ErrResult[struct{}, ErrorCode]
-	self.sync(&result)
+	self.wasmimport_Sync(&result)
 	return result
 }
 
 //go:wasmimport wasi:filesystem/types@0.2.0 [method]descriptor.sync
 //go:noescape
-func (self Descriptor) sync(result *cm.ErrResult[struct{}, ErrorCode])
+func (self Descriptor) wasmimport_Sync(result *cm.ErrResult[struct{}, ErrorCode])
 
 // SyncData represents method "sync-data".
 //
@@ -655,13 +655,13 @@ func (self Descriptor) sync(result *cm.ErrResult[struct{}, ErrorCode])
 //go:nosplit
 func (self Descriptor) SyncData() cm.ErrResult[struct{}, ErrorCode] {
 	var result cm.ErrResult[struct{}, ErrorCode]
-	self.syncData(&result)
+	self.wasmimport_SyncData(&result)
 	return result
 }
 
 //go:wasmimport wasi:filesystem/types@0.2.0 [method]descriptor.sync-data
 //go:noescape
-func (self Descriptor) syncData(result *cm.ErrResult[struct{}, ErrorCode])
+func (self Descriptor) wasmimport_SyncData(result *cm.ErrResult[struct{}, ErrorCode])
 
 // UnlinkFileAt represents method "unlink-file-at".
 //
@@ -675,13 +675,13 @@ func (self Descriptor) syncData(result *cm.ErrResult[struct{}, ErrorCode])
 //go:nosplit
 func (self Descriptor) UnlinkFileAt(path string) cm.ErrResult[struct{}, ErrorCode] {
 	var result cm.ErrResult[struct{}, ErrorCode]
-	self.unlinkFileAt(path, &result)
+	self.wasmimport_UnlinkFileAt(path, &result)
 	return result
 }
 
 //go:wasmimport wasi:filesystem/types@0.2.0 [method]descriptor.unlink-file-at
 //go:noescape
-func (self Descriptor) unlinkFileAt(path string, result *cm.ErrResult[struct{}, ErrorCode])
+func (self Descriptor) wasmimport_UnlinkFileAt(path string, result *cm.ErrResult[struct{}, ErrorCode])
 
 // Write represents method "write".
 //
@@ -700,13 +700,13 @@ func (self Descriptor) unlinkFileAt(path string, result *cm.ErrResult[struct{}, 
 //go:nosplit
 func (self Descriptor) Write(buffer cm.List[uint8], offset FileSize) cm.OKResult[FileSize, ErrorCode] {
 	var result cm.OKResult[FileSize, ErrorCode]
-	self.write(buffer, offset, &result)
+	self.wasmimport_Write(buffer, offset, &result)
 	return result
 }
 
 //go:wasmimport wasi:filesystem/types@0.2.0 [method]descriptor.write
 //go:noescape
-func (self Descriptor) write(buffer cm.List[uint8], offset FileSize, result *cm.OKResult[FileSize, ErrorCode])
+func (self Descriptor) wasmimport_Write(buffer cm.List[uint8], offset FileSize, result *cm.OKResult[FileSize, ErrorCode])
 
 // WriteViaStream represents method "write-via-stream".
 //
@@ -722,13 +722,13 @@ func (self Descriptor) write(buffer cm.List[uint8], offset FileSize, result *cm.
 //go:nosplit
 func (self Descriptor) WriteViaStream(offset FileSize) cm.OKResult[OutputStream, ErrorCode] {
 	var result cm.OKResult[OutputStream, ErrorCode]
-	self.writeViaStream(offset, &result)
+	self.wasmimport_WriteViaStream(offset, &result)
 	return result
 }
 
 //go:wasmimport wasi:filesystem/types@0.2.0 [method]descriptor.write-via-stream
 //go:noescape
-func (self Descriptor) writeViaStream(offset FileSize, result *cm.OKResult[OutputStream, ErrorCode])
+func (self Descriptor) wasmimport_WriteViaStream(offset FileSize, result *cm.OKResult[OutputStream, ErrorCode])
 
 // DescriptorFlags represents the flags "wasi:filesystem/types@0.2.0#descriptor-flags".
 //
@@ -909,12 +909,12 @@ type DirectoryEntryStream cm.Resource
 //
 //go:nosplit
 func (self DirectoryEntryStream) ResourceDrop() {
-	self.resourceDrop()
+	self.wasmimport_ResourceDrop()
 }
 
 //go:wasmimport wasi:filesystem/types@0.2.0 [resource-drop]directory-entry-stream
 //go:noescape
-func (self DirectoryEntryStream) resourceDrop()
+func (self DirectoryEntryStream) wasmimport_ResourceDrop()
 
 // ReadDirectoryEntry represents method "read-directory-entry".
 //
@@ -925,13 +925,13 @@ func (self DirectoryEntryStream) resourceDrop()
 //go:nosplit
 func (self DirectoryEntryStream) ReadDirectoryEntry() cm.OKResult[cm.Option[DirectoryEntry], ErrorCode] {
 	var result cm.OKResult[cm.Option[DirectoryEntry], ErrorCode]
-	self.readDirectoryEntry(&result)
+	self.wasmimport_ReadDirectoryEntry(&result)
 	return result
 }
 
 //go:wasmimport wasi:filesystem/types@0.2.0 [method]directory-entry-stream.read-directory-entry
 //go:noescape
-func (self DirectoryEntryStream) readDirectoryEntry(result *cm.OKResult[cm.Option[DirectoryEntry], ErrorCode])
+func (self DirectoryEntryStream) wasmimport_ReadDirectoryEntry(result *cm.OKResult[cm.Option[DirectoryEntry], ErrorCode])
 
 // Error represents the resource "wasi:io/error@0.2.0#error".
 //
@@ -1250,10 +1250,10 @@ const (
 //go:nosplit
 func FilesystemErrorCode(err Error) cm.Option[ErrorCode] {
 	var result cm.Option[ErrorCode]
-	filesystemErrorCode(err, &result)
+	wasmimport_FilesystemErrorCode(err, &result)
 	return result
 }
 
 //go:wasmimport wasi:filesystem/types@0.2.0 filesystem-error-code
 //go:noescape
-func filesystemErrorCode(err Error, result *cm.Option[ErrorCode])
+func wasmimport_FilesystemErrorCode(err Error, result *cm.Option[ErrorCode])

--- a/wasi/io/error/error.wit.go
+++ b/wasi/io/error/error.wit.go
@@ -40,12 +40,12 @@ type Error cm.Resource
 //
 //go:nosplit
 func (self Error) ResourceDrop() {
-	self.resourceDrop()
+	self.wasmimport_ResourceDrop()
 }
 
 //go:wasmimport wasi:io/error@0.2.0 [resource-drop]error
 //go:noescape
-func (self Error) resourceDrop()
+func (self Error) wasmimport_ResourceDrop()
 
 // ToDebugString represents method "to-debug-string".
 //
@@ -62,10 +62,10 @@ func (self Error) resourceDrop()
 //go:nosplit
 func (self Error) ToDebugString() string {
 	var result string
-	self.toDebugString(&result)
+	self.wasmimport_ToDebugString(&result)
 	return result
 }
 
 //go:wasmimport wasi:io/error@0.2.0 [method]error.to-debug-string
 //go:noescape
-func (self Error) toDebugString(result *string)
+func (self Error) wasmimport_ToDebugString(result *string)

--- a/wasi/io/poll/poll.wit.go
+++ b/wasi/io/poll/poll.wit.go
@@ -25,12 +25,12 @@ type Pollable cm.Resource
 //
 //go:nosplit
 func (self Pollable) ResourceDrop() {
-	self.resourceDrop()
+	self.wasmimport_ResourceDrop()
 }
 
 //go:wasmimport wasi:io/poll@0.2.0 [resource-drop]pollable
 //go:noescape
-func (self Pollable) resourceDrop()
+func (self Pollable) wasmimport_ResourceDrop()
 
 // Block represents method "block".
 //
@@ -44,12 +44,12 @@ func (self Pollable) resourceDrop()
 //
 //go:nosplit
 func (self Pollable) Block() {
-	self.block()
+	self.wasmimport_Block()
 }
 
 //go:wasmimport wasi:io/poll@0.2.0 [method]pollable.block
 //go:noescape
-func (self Pollable) block()
+func (self Pollable) wasmimport_Block()
 
 // Ready represents method "ready".
 //
@@ -61,12 +61,12 @@ func (self Pollable) block()
 //
 //go:nosplit
 func (self Pollable) Ready() bool {
-	return self.ready()
+	return self.wasmimport_Ready()
 }
 
 //go:wasmimport wasi:io/poll@0.2.0 [method]pollable.ready
 //go:noescape
-func (self Pollable) ready() bool
+func (self Pollable) wasmimport_Ready() bool
 
 // Poll represents function "wasi:io/poll@0.2.0#poll".
 //
@@ -94,10 +94,10 @@ func (self Pollable) ready() bool
 //go:nosplit
 func Poll(in cm.List[Pollable]) cm.List[uint32] {
 	var result cm.List[uint32]
-	poll(in, &result)
+	wasmimport_Poll(in, &result)
 	return result
 }
 
 //go:wasmimport wasi:io/poll@0.2.0 poll
 //go:noescape
-func poll(in cm.List[Pollable], result *cm.List[uint32])
+func wasmimport_Poll(in cm.List[Pollable], result *cm.List[uint32])

--- a/wasi/io/streams/streams.wit.go
+++ b/wasi/io/streams/streams.wit.go
@@ -42,12 +42,12 @@ type InputStream cm.Resource
 //
 //go:nosplit
 func (self InputStream) ResourceDrop() {
-	self.resourceDrop()
+	self.wasmimport_ResourceDrop()
 }
 
 //go:wasmimport wasi:io/streams@0.2.0 [resource-drop]input-stream
 //go:noescape
-func (self InputStream) resourceDrop()
+func (self InputStream) wasmimport_ResourceDrop()
 
 // BlockingRead represents method "blocking-read".
 //
@@ -59,13 +59,13 @@ func (self InputStream) resourceDrop()
 //go:nosplit
 func (self InputStream) BlockingRead(len_ uint64) cm.OKResult[cm.List[uint8], StreamError] {
 	var result cm.OKResult[cm.List[uint8], StreamError]
-	self.blockingRead(len_, &result)
+	self.wasmimport_BlockingRead(len_, &result)
 	return result
 }
 
 //go:wasmimport wasi:io/streams@0.2.0 [method]input-stream.blocking-read
 //go:noescape
-func (self InputStream) blockingRead(len_ uint64, result *cm.OKResult[cm.List[uint8], StreamError])
+func (self InputStream) wasmimport_BlockingRead(len_ uint64, result *cm.OKResult[cm.List[uint8], StreamError])
 
 // BlockingSkip represents method "blocking-skip".
 //
@@ -77,13 +77,13 @@ func (self InputStream) blockingRead(len_ uint64, result *cm.OKResult[cm.List[ui
 //go:nosplit
 func (self InputStream) BlockingSkip(len_ uint64) cm.OKResult[uint64, StreamError] {
 	var result cm.OKResult[uint64, StreamError]
-	self.blockingSkip(len_, &result)
+	self.wasmimport_BlockingSkip(len_, &result)
 	return result
 }
 
 //go:wasmimport wasi:io/streams@0.2.0 [method]input-stream.blocking-skip
 //go:noescape
-func (self InputStream) blockingSkip(len_ uint64, result *cm.OKResult[uint64, StreamError])
+func (self InputStream) wasmimport_BlockingSkip(len_ uint64, result *cm.OKResult[uint64, StreamError])
 
 // Read represents method "read".
 //
@@ -119,13 +119,13 @@ func (self InputStream) blockingSkip(len_ uint64, result *cm.OKResult[uint64, St
 //go:nosplit
 func (self InputStream) Read(len_ uint64) cm.OKResult[cm.List[uint8], StreamError] {
 	var result cm.OKResult[cm.List[uint8], StreamError]
-	self.read(len_, &result)
+	self.wasmimport_Read(len_, &result)
 	return result
 }
 
 //go:wasmimport wasi:io/streams@0.2.0 [method]input-stream.read
 //go:noescape
-func (self InputStream) read(len_ uint64, result *cm.OKResult[cm.List[uint8], StreamError])
+func (self InputStream) wasmimport_Read(len_ uint64, result *cm.OKResult[cm.List[uint8], StreamError])
 
 // Skip represents method "skip".
 //
@@ -139,13 +139,13 @@ func (self InputStream) read(len_ uint64, result *cm.OKResult[cm.List[uint8], St
 //go:nosplit
 func (self InputStream) Skip(len_ uint64) cm.OKResult[uint64, StreamError] {
 	var result cm.OKResult[uint64, StreamError]
-	self.skip(len_, &result)
+	self.wasmimport_Skip(len_, &result)
 	return result
 }
 
 //go:wasmimport wasi:io/streams@0.2.0 [method]input-stream.skip
 //go:noescape
-func (self InputStream) skip(len_ uint64, result *cm.OKResult[uint64, StreamError])
+func (self InputStream) wasmimport_Skip(len_ uint64, result *cm.OKResult[uint64, StreamError])
 
 // Subscribe represents method "subscribe".
 //
@@ -160,12 +160,12 @@ func (self InputStream) skip(len_ uint64, result *cm.OKResult[uint64, StreamErro
 //
 //go:nosplit
 func (self InputStream) Subscribe() Pollable {
-	return self.subscribe()
+	return self.wasmimport_Subscribe()
 }
 
 //go:wasmimport wasi:io/streams@0.2.0 [method]input-stream.subscribe
 //go:noescape
-func (self InputStream) subscribe() Pollable
+func (self InputStream) wasmimport_Subscribe() Pollable
 
 // OutputStream represents the resource "wasi:io/streams@0.2.0#output-stream".
 //
@@ -187,12 +187,12 @@ type OutputStream cm.Resource
 //
 //go:nosplit
 func (self OutputStream) ResourceDrop() {
-	self.resourceDrop()
+	self.wasmimport_ResourceDrop()
 }
 
 //go:wasmimport wasi:io/streams@0.2.0 [resource-drop]output-stream
 //go:noescape
-func (self OutputStream) resourceDrop()
+func (self OutputStream) wasmimport_ResourceDrop()
 
 // BlockingFlush represents method "blocking-flush".
 //
@@ -204,13 +204,13 @@ func (self OutputStream) resourceDrop()
 //go:nosplit
 func (self OutputStream) BlockingFlush() cm.ErrResult[struct{}, StreamError] {
 	var result cm.ErrResult[struct{}, StreamError]
-	self.blockingFlush(&result)
+	self.wasmimport_BlockingFlush(&result)
 	return result
 }
 
 //go:wasmimport wasi:io/streams@0.2.0 [method]output-stream.blocking-flush
 //go:noescape
-func (self OutputStream) blockingFlush(result *cm.ErrResult[struct{}, StreamError])
+func (self OutputStream) wasmimport_BlockingFlush(result *cm.ErrResult[struct{}, StreamError])
 
 // BlockingSplice represents method "blocking-splice".
 //
@@ -225,13 +225,13 @@ func (self OutputStream) blockingFlush(result *cm.ErrResult[struct{}, StreamErro
 //go:nosplit
 func (self OutputStream) BlockingSplice(src InputStream, len_ uint64) cm.OKResult[uint64, StreamError] {
 	var result cm.OKResult[uint64, StreamError]
-	self.blockingSplice(src, len_, &result)
+	self.wasmimport_BlockingSplice(src, len_, &result)
 	return result
 }
 
 //go:wasmimport wasi:io/streams@0.2.0 [method]output-stream.blocking-splice
 //go:noescape
-func (self OutputStream) blockingSplice(src InputStream, len_ uint64, result *cm.OKResult[uint64, StreamError])
+func (self OutputStream) wasmimport_BlockingSplice(src InputStream, len_ uint64, result *cm.OKResult[uint64, StreamError])
 
 // BlockingWriteAndFlush represents method "blocking-write-and-flush".
 //
@@ -263,13 +263,13 @@ func (self OutputStream) blockingSplice(src InputStream, len_ uint64, result *cm
 //go:nosplit
 func (self OutputStream) BlockingWriteAndFlush(contents cm.List[uint8]) cm.ErrResult[struct{}, StreamError] {
 	var result cm.ErrResult[struct{}, StreamError]
-	self.blockingWriteAndFlush(contents, &result)
+	self.wasmimport_BlockingWriteAndFlush(contents, &result)
 	return result
 }
 
 //go:wasmimport wasi:io/streams@0.2.0 [method]output-stream.blocking-write-and-flush
 //go:noescape
-func (self OutputStream) blockingWriteAndFlush(contents cm.List[uint8], result *cm.ErrResult[struct{}, StreamError])
+func (self OutputStream) wasmimport_BlockingWriteAndFlush(contents cm.List[uint8], result *cm.ErrResult[struct{}, StreamError])
 
 // BlockingWriteZeroesAndFlush represents method "blocking-write-zeroes-and-flush".
 //
@@ -301,13 +301,13 @@ func (self OutputStream) blockingWriteAndFlush(contents cm.List[uint8], result *
 //go:nosplit
 func (self OutputStream) BlockingWriteZeroesAndFlush(len_ uint64) cm.ErrResult[struct{}, StreamError] {
 	var result cm.ErrResult[struct{}, StreamError]
-	self.blockingWriteZeroesAndFlush(len_, &result)
+	self.wasmimport_BlockingWriteZeroesAndFlush(len_, &result)
 	return result
 }
 
 //go:wasmimport wasi:io/streams@0.2.0 [method]output-stream.blocking-write-zeroes-and-flush
 //go:noescape
-func (self OutputStream) blockingWriteZeroesAndFlush(len_ uint64, result *cm.ErrResult[struct{}, StreamError])
+func (self OutputStream) wasmimport_BlockingWriteZeroesAndFlush(len_ uint64, result *cm.ErrResult[struct{}, StreamError])
 
 // CheckWrite represents method "check-write".
 //
@@ -326,13 +326,13 @@ func (self OutputStream) blockingWriteZeroesAndFlush(len_ uint64, result *cm.Err
 //go:nosplit
 func (self OutputStream) CheckWrite() cm.OKResult[uint64, StreamError] {
 	var result cm.OKResult[uint64, StreamError]
-	self.checkWrite(&result)
+	self.wasmimport_CheckWrite(&result)
 	return result
 }
 
 //go:wasmimport wasi:io/streams@0.2.0 [method]output-stream.check-write
 //go:noescape
-func (self OutputStream) checkWrite(result *cm.OKResult[uint64, StreamError])
+func (self OutputStream) wasmimport_CheckWrite(result *cm.OKResult[uint64, StreamError])
 
 // Flush represents method "flush".
 //
@@ -352,13 +352,13 @@ func (self OutputStream) checkWrite(result *cm.OKResult[uint64, StreamError])
 //go:nosplit
 func (self OutputStream) Flush() cm.ErrResult[struct{}, StreamError] {
 	var result cm.ErrResult[struct{}, StreamError]
-	self.flush(&result)
+	self.wasmimport_Flush(&result)
 	return result
 }
 
 //go:wasmimport wasi:io/streams@0.2.0 [method]output-stream.flush
 //go:noescape
-func (self OutputStream) flush(result *cm.ErrResult[struct{}, StreamError])
+func (self OutputStream) wasmimport_Flush(result *cm.ErrResult[struct{}, StreamError])
 
 // Splice represents method "splice".
 //
@@ -381,13 +381,13 @@ func (self OutputStream) flush(result *cm.ErrResult[struct{}, StreamError])
 //go:nosplit
 func (self OutputStream) Splice(src InputStream, len_ uint64) cm.OKResult[uint64, StreamError] {
 	var result cm.OKResult[uint64, StreamError]
-	self.splice(src, len_, &result)
+	self.wasmimport_Splice(src, len_, &result)
 	return result
 }
 
 //go:wasmimport wasi:io/streams@0.2.0 [method]output-stream.splice
 //go:noescape
-func (self OutputStream) splice(src InputStream, len_ uint64, result *cm.OKResult[uint64, StreamError])
+func (self OutputStream) wasmimport_Splice(src InputStream, len_ uint64, result *cm.OKResult[uint64, StreamError])
 
 // Subscribe represents method "subscribe".
 //
@@ -406,12 +406,12 @@ func (self OutputStream) splice(src InputStream, len_ uint64, result *cm.OKResul
 //
 //go:nosplit
 func (self OutputStream) Subscribe() Pollable {
-	return self.subscribe()
+	return self.wasmimport_Subscribe()
 }
 
 //go:wasmimport wasi:io/streams@0.2.0 [method]output-stream.subscribe
 //go:noescape
-func (self OutputStream) subscribe() Pollable
+func (self OutputStream) wasmimport_Subscribe() Pollable
 
 // Write represents method "write".
 //
@@ -434,13 +434,13 @@ func (self OutputStream) subscribe() Pollable
 //go:nosplit
 func (self OutputStream) Write(contents cm.List[uint8]) cm.ErrResult[struct{}, StreamError] {
 	var result cm.ErrResult[struct{}, StreamError]
-	self.write(contents, &result)
+	self.wasmimport_Write(contents, &result)
 	return result
 }
 
 //go:wasmimport wasi:io/streams@0.2.0 [method]output-stream.write
 //go:noescape
-func (self OutputStream) write(contents cm.List[uint8], result *cm.ErrResult[struct{}, StreamError])
+func (self OutputStream) wasmimport_Write(contents cm.List[uint8], result *cm.ErrResult[struct{}, StreamError])
 
 // WriteZeroes represents method "write-zeroes".
 //
@@ -456,13 +456,13 @@ func (self OutputStream) write(contents cm.List[uint8], result *cm.ErrResult[str
 //go:nosplit
 func (self OutputStream) WriteZeroes(len_ uint64) cm.ErrResult[struct{}, StreamError] {
 	var result cm.ErrResult[struct{}, StreamError]
-	self.writeZeroes(len_, &result)
+	self.wasmimport_WriteZeroes(len_, &result)
 	return result
 }
 
 //go:wasmimport wasi:io/streams@0.2.0 [method]output-stream.write-zeroes
 //go:noescape
-func (self OutputStream) writeZeroes(len_ uint64, result *cm.ErrResult[struct{}, StreamError])
+func (self OutputStream) wasmimport_WriteZeroes(len_ uint64, result *cm.ErrResult[struct{}, StreamError])
 
 // Pollable represents the resource "wasi:io/poll@0.2.0#pollable".
 //

--- a/wasi/random/insecure-seed/insecure-seed.wit.go
+++ b/wasi/random/insecure-seed/insecure-seed.wit.go
@@ -35,10 +35,10 @@ package insecureseed
 //go:nosplit
 func InsecureSeed() [2]uint64 {
 	var result [2]uint64
-	insecureSeed(&result)
+	wasmimport_InsecureSeed(&result)
 	return result
 }
 
 //go:wasmimport wasi:random/insecure-seed@0.2.0 insecure-seed
 //go:noescape
-func insecureSeed(result *[2]uint64)
+func wasmimport_InsecureSeed(result *[2]uint64)

--- a/wasi/random/insecure/insecure.wit.go
+++ b/wasi/random/insecure/insecure.wit.go
@@ -30,13 +30,13 @@ import (
 //go:nosplit
 func GetInsecureRandomBytes(len_ uint64) cm.List[uint8] {
 	var result cm.List[uint8]
-	getInsecureRandomBytes(len_, &result)
+	wasmimport_GetInsecureRandomBytes(len_, &result)
 	return result
 }
 
 //go:wasmimport wasi:random/insecure@0.2.0 get-insecure-random-bytes
 //go:noescape
-func getInsecureRandomBytes(len_ uint64, result *cm.List[uint8])
+func wasmimport_GetInsecureRandomBytes(len_ uint64, result *cm.List[uint8])
 
 // GetInsecureRandomU64 represents function "wasi:random/insecure@0.2.0#get-insecure-random-u64".
 //
@@ -49,9 +49,9 @@ func getInsecureRandomBytes(len_ uint64, result *cm.List[uint8])
 //
 //go:nosplit
 func GetInsecureRandomU64() uint64 {
-	return getInsecureRandomU64()
+	return wasmimport_GetInsecureRandomU64()
 }
 
 //go:wasmimport wasi:random/insecure@0.2.0 get-insecure-random-u64
 //go:noescape
-func getInsecureRandomU64() uint64
+func wasmimport_GetInsecureRandomU64() uint64

--- a/wasi/random/random/random.wit.go
+++ b/wasi/random/random/random.wit.go
@@ -34,13 +34,13 @@ import (
 //go:nosplit
 func GetRandomBytes(len_ uint64) cm.List[uint8] {
 	var result cm.List[uint8]
-	getRandomBytes(len_, &result)
+	wasmimport_GetRandomBytes(len_, &result)
 	return result
 }
 
 //go:wasmimport wasi:random/random@0.2.0 get-random-bytes
 //go:noescape
-func getRandomBytes(len_ uint64, result *cm.List[uint8])
+func wasmimport_GetRandomBytes(len_ uint64, result *cm.List[uint8])
 
 // GetRandomU64 represents function "wasi:random/random@0.2.0#get-random-u64".
 //
@@ -53,9 +53,9 @@ func getRandomBytes(len_ uint64, result *cm.List[uint8])
 //
 //go:nosplit
 func GetRandomU64() uint64 {
-	return getRandomU64()
+	return wasmimport_GetRandomU64()
 }
 
 //go:wasmimport wasi:random/random@0.2.0 get-random-u64
 //go:noescape
-func getRandomU64() uint64
+func wasmimport_GetRandomU64() uint64

--- a/wasi/sockets/instance-network/instance-network.wit.go
+++ b/wasi/sockets/instance-network/instance-network.wit.go
@@ -24,9 +24,9 @@ type Network = network.Network
 //
 //go:nosplit
 func InstanceNetwork() Network {
-	return instanceNetwork()
+	return wasmimport_InstanceNetwork()
 }
 
 //go:wasmimport wasi:sockets/instance-network@0.2.0 instance-network
 //go:noescape
-func instanceNetwork() Network
+func wasmimport_InstanceNetwork() Network

--- a/wasi/sockets/ip-name-lookup/ip-name-lookup.wit.go
+++ b/wasi/sockets/ip-name-lookup/ip-name-lookup.wit.go
@@ -42,12 +42,12 @@ type ResolveAddressStream cm.Resource
 //
 //go:nosplit
 func (self ResolveAddressStream) ResourceDrop() {
-	self.resourceDrop()
+	self.wasmimport_ResourceDrop()
 }
 
 //go:wasmimport wasi:sockets/ip-name-lookup@0.2.0 [resource-drop]resolve-address-stream
 //go:noescape
-func (self ResolveAddressStream) resourceDrop()
+func (self ResolveAddressStream) wasmimport_ResourceDrop()
 
 // ResolveNextAddress represents method "resolve-next-address".
 //
@@ -73,13 +73,13 @@ func (self ResolveAddressStream) resourceDrop()
 //go:nosplit
 func (self ResolveAddressStream) ResolveNextAddress() cm.OKResult[cm.Option[IPAddress], ErrorCode] {
 	var result cm.OKResult[cm.Option[IPAddress], ErrorCode]
-	self.resolveNextAddress(&result)
+	self.wasmimport_ResolveNextAddress(&result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/ip-name-lookup@0.2.0 [method]resolve-address-stream.resolve-next-address
 //go:noescape
-func (self ResolveAddressStream) resolveNextAddress(result *cm.OKResult[cm.Option[IPAddress], ErrorCode])
+func (self ResolveAddressStream) wasmimport_ResolveNextAddress(result *cm.OKResult[cm.Option[IPAddress], ErrorCode])
 
 // Subscribe represents method "subscribe".
 //
@@ -92,12 +92,12 @@ func (self ResolveAddressStream) resolveNextAddress(result *cm.OKResult[cm.Optio
 //
 //go:nosplit
 func (self ResolveAddressStream) Subscribe() Pollable {
-	return self.subscribe()
+	return self.wasmimport_Subscribe()
 }
 
 //go:wasmimport wasi:sockets/ip-name-lookup@0.2.0 [method]resolve-address-stream.subscribe
 //go:noescape
-func (self ResolveAddressStream) subscribe() Pollable
+func (self ResolveAddressStream) wasmimport_Subscribe() Pollable
 
 // ResolveAddresses represents function "wasi:sockets/ip-name-lookup@0.2.0#resolve-addresses".
 //
@@ -128,10 +128,10 @@ func (self ResolveAddressStream) subscribe() Pollable
 //go:nosplit
 func ResolveAddresses(network_ Network, name string) cm.OKResult[ResolveAddressStream, ErrorCode] {
 	var result cm.OKResult[ResolveAddressStream, ErrorCode]
-	resolveAddresses(network_, name, &result)
+	wasmimport_ResolveAddresses(network_, name, &result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/ip-name-lookup@0.2.0 resolve-addresses
 //go:noescape
-func resolveAddresses(network_ Network, name string, result *cm.OKResult[ResolveAddressStream, ErrorCode])
+func wasmimport_ResolveAddresses(network_ Network, name string, result *cm.OKResult[ResolveAddressStream, ErrorCode])

--- a/wasi/sockets/network/network.wit.go
+++ b/wasi/sockets/network/network.wit.go
@@ -268,9 +268,9 @@ type Network cm.Resource
 //
 //go:nosplit
 func (self Network) ResourceDrop() {
-	self.resourceDrop()
+	self.wasmimport_ResourceDrop()
 }
 
 //go:wasmimport wasi:sockets/network@0.2.0 [resource-drop]network
 //go:noescape
-func (self Network) resourceDrop()
+func (self Network) wasmimport_ResourceDrop()

--- a/wasi/sockets/tcp-create-socket/tcp-create-socket.wit.go
+++ b/wasi/sockets/tcp-create-socket/tcp-create-socket.wit.go
@@ -65,10 +65,10 @@ type TCPSocket = tcp.TCPSocket
 //go:nosplit
 func CreateTCPSocket(addressFamily IPAddressFamily) cm.OKResult[TCPSocket, ErrorCode] {
 	var result cm.OKResult[TCPSocket, ErrorCode]
-	createTCPSocket(addressFamily, &result)
+	wasmimport_CreateTCPSocket(addressFamily, &result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/tcp-create-socket@0.2.0 create-tcp-socket
 //go:noescape
-func createTCPSocket(addressFamily IPAddressFamily, result *cm.OKResult[TCPSocket, ErrorCode])
+func wasmimport_CreateTCPSocket(addressFamily IPAddressFamily, result *cm.OKResult[TCPSocket, ErrorCode])

--- a/wasi/sockets/tcp/tcp.wit.go
+++ b/wasi/sockets/tcp/tcp.wit.go
@@ -107,12 +107,12 @@ type TCPSocket cm.Resource
 //
 //go:nosplit
 func (self TCPSocket) ResourceDrop() {
-	self.resourceDrop()
+	self.wasmimport_ResourceDrop()
 }
 
 //go:wasmimport wasi:sockets/tcp@0.2.0 [resource-drop]tcp-socket
 //go:noescape
-func (self TCPSocket) resourceDrop()
+func (self TCPSocket) wasmimport_ResourceDrop()
 
 // Accept represents method "accept".
 //
@@ -152,13 +152,13 @@ func (self TCPSocket) resourceDrop()
 //go:nosplit
 func (self TCPSocket) Accept() cm.OKResult[cm.Tuple3[TCPSocket, InputStream, OutputStream], ErrorCode] {
 	var result cm.OKResult[cm.Tuple3[TCPSocket, InputStream, OutputStream], ErrorCode]
-	self.accept(&result)
+	self.wasmimport_Accept(&result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/tcp@0.2.0 [method]tcp-socket.accept
 //go:noescape
-func (self TCPSocket) accept(result *cm.OKResult[cm.Tuple3[TCPSocket, InputStream, OutputStream], ErrorCode])
+func (self TCPSocket) wasmimport_Accept(result *cm.OKResult[cm.Tuple3[TCPSocket, InputStream, OutputStream], ErrorCode])
 
 // AddressFamily represents method "address-family".
 //
@@ -170,12 +170,12 @@ func (self TCPSocket) accept(result *cm.OKResult[cm.Tuple3[TCPSocket, InputStrea
 //
 //go:nosplit
 func (self TCPSocket) AddressFamily() IPAddressFamily {
-	return self.addressFamily()
+	return self.wasmimport_AddressFamily()
 }
 
 //go:wasmimport wasi:sockets/tcp@0.2.0 [method]tcp-socket.address-family
 //go:noescape
-func (self TCPSocket) addressFamily() IPAddressFamily
+func (self TCPSocket) wasmimport_AddressFamily() IPAddressFamily
 
 // FinishBind represents method "finish-bind".
 //
@@ -184,13 +184,13 @@ func (self TCPSocket) addressFamily() IPAddressFamily
 //go:nosplit
 func (self TCPSocket) FinishBind() cm.ErrResult[struct{}, ErrorCode] {
 	var result cm.ErrResult[struct{}, ErrorCode]
-	self.finishBind(&result)
+	self.wasmimport_FinishBind(&result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/tcp@0.2.0 [method]tcp-socket.finish-bind
 //go:noescape
-func (self TCPSocket) finishBind(result *cm.ErrResult[struct{}, ErrorCode])
+func (self TCPSocket) wasmimport_FinishBind(result *cm.ErrResult[struct{}, ErrorCode])
 
 // FinishConnect represents method "finish-connect".
 //
@@ -200,13 +200,13 @@ func (self TCPSocket) finishBind(result *cm.ErrResult[struct{}, ErrorCode])
 //go:nosplit
 func (self TCPSocket) FinishConnect() cm.OKResult[cm.Tuple[InputStream, OutputStream], ErrorCode] {
 	var result cm.OKResult[cm.Tuple[InputStream, OutputStream], ErrorCode]
-	self.finishConnect(&result)
+	self.wasmimport_FinishConnect(&result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/tcp@0.2.0 [method]tcp-socket.finish-connect
 //go:noescape
-func (self TCPSocket) finishConnect(result *cm.OKResult[cm.Tuple[InputStream, OutputStream], ErrorCode])
+func (self TCPSocket) wasmimport_FinishConnect(result *cm.OKResult[cm.Tuple[InputStream, OutputStream], ErrorCode])
 
 // FinishListen represents method "finish-listen".
 //
@@ -215,13 +215,13 @@ func (self TCPSocket) finishConnect(result *cm.OKResult[cm.Tuple[InputStream, Ou
 //go:nosplit
 func (self TCPSocket) FinishListen() cm.ErrResult[struct{}, ErrorCode] {
 	var result cm.ErrResult[struct{}, ErrorCode]
-	self.finishListen(&result)
+	self.wasmimport_FinishListen(&result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/tcp@0.2.0 [method]tcp-socket.finish-listen
 //go:noescape
-func (self TCPSocket) finishListen(result *cm.ErrResult[struct{}, ErrorCode])
+func (self TCPSocket) wasmimport_FinishListen(result *cm.ErrResult[struct{}, ErrorCode])
 
 // HopLimit represents method "hop-limit".
 //
@@ -237,13 +237,13 @@ func (self TCPSocket) finishListen(result *cm.ErrResult[struct{}, ErrorCode])
 //go:nosplit
 func (self TCPSocket) HopLimit() cm.OKResult[uint8, ErrorCode] {
 	var result cm.OKResult[uint8, ErrorCode]
-	self.hopLimit(&result)
+	self.wasmimport_HopLimit(&result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/tcp@0.2.0 [method]tcp-socket.hop-limit
 //go:noescape
-func (self TCPSocket) hopLimit(result *cm.OKResult[uint8, ErrorCode])
+func (self TCPSocket) wasmimport_HopLimit(result *cm.OKResult[uint8, ErrorCode])
 
 // IsListening represents method "is-listening".
 //
@@ -255,12 +255,12 @@ func (self TCPSocket) hopLimit(result *cm.OKResult[uint8, ErrorCode])
 //
 //go:nosplit
 func (self TCPSocket) IsListening() bool {
-	return self.isListening()
+	return self.wasmimport_IsListening()
 }
 
 //go:wasmimport wasi:sockets/tcp@0.2.0 [method]tcp-socket.is-listening
 //go:noescape
-func (self TCPSocket) isListening() bool
+func (self TCPSocket) wasmimport_IsListening() bool
 
 // KeepAliveCount represents method "keep-alive-count".
 //
@@ -282,13 +282,13 @@ func (self TCPSocket) isListening() bool
 //go:nosplit
 func (self TCPSocket) KeepAliveCount() cm.OKResult[uint32, ErrorCode] {
 	var result cm.OKResult[uint32, ErrorCode]
-	self.keepAliveCount(&result)
+	self.wasmimport_KeepAliveCount(&result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/tcp@0.2.0 [method]tcp-socket.keep-alive-count
 //go:noescape
-func (self TCPSocket) keepAliveCount(result *cm.OKResult[uint32, ErrorCode])
+func (self TCPSocket) wasmimport_KeepAliveCount(result *cm.OKResult[uint32, ErrorCode])
 
 // KeepAliveEnabled represents method "keep-alive-enabled".
 //
@@ -308,13 +308,13 @@ func (self TCPSocket) keepAliveCount(result *cm.OKResult[uint32, ErrorCode])
 //go:nosplit
 func (self TCPSocket) KeepAliveEnabled() cm.OKResult[bool, ErrorCode] {
 	var result cm.OKResult[bool, ErrorCode]
-	self.keepAliveEnabled(&result)
+	self.wasmimport_KeepAliveEnabled(&result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/tcp@0.2.0 [method]tcp-socket.keep-alive-enabled
 //go:noescape
-func (self TCPSocket) keepAliveEnabled(result *cm.OKResult[bool, ErrorCode])
+func (self TCPSocket) wasmimport_KeepAliveEnabled(result *cm.OKResult[bool, ErrorCode])
 
 // KeepAliveIdleTime represents method "keep-alive-idle-time".
 //
@@ -337,13 +337,13 @@ func (self TCPSocket) keepAliveEnabled(result *cm.OKResult[bool, ErrorCode])
 //go:nosplit
 func (self TCPSocket) KeepAliveIdleTime() cm.OKResult[Duration, ErrorCode] {
 	var result cm.OKResult[Duration, ErrorCode]
-	self.keepAliveIdleTime(&result)
+	self.wasmimport_KeepAliveIdleTime(&result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/tcp@0.2.0 [method]tcp-socket.keep-alive-idle-time
 //go:noescape
-func (self TCPSocket) keepAliveIdleTime(result *cm.OKResult[Duration, ErrorCode])
+func (self TCPSocket) wasmimport_KeepAliveIdleTime(result *cm.OKResult[Duration, ErrorCode])
 
 // KeepAliveInterval represents method "keep-alive-interval".
 //
@@ -365,13 +365,13 @@ func (self TCPSocket) keepAliveIdleTime(result *cm.OKResult[Duration, ErrorCode]
 //go:nosplit
 func (self TCPSocket) KeepAliveInterval() cm.OKResult[Duration, ErrorCode] {
 	var result cm.OKResult[Duration, ErrorCode]
-	self.keepAliveInterval(&result)
+	self.wasmimport_KeepAliveInterval(&result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/tcp@0.2.0 [method]tcp-socket.keep-alive-interval
 //go:noescape
-func (self TCPSocket) keepAliveInterval(result *cm.OKResult[Duration, ErrorCode])
+func (self TCPSocket) wasmimport_KeepAliveInterval(result *cm.OKResult[Duration, ErrorCode])
 
 // LocalAddress represents method "local-address".
 //
@@ -398,13 +398,13 @@ func (self TCPSocket) keepAliveInterval(result *cm.OKResult[Duration, ErrorCode]
 //go:nosplit
 func (self TCPSocket) LocalAddress() cm.OKResult[IPSocketAddress, ErrorCode] {
 	var result cm.OKResult[IPSocketAddress, ErrorCode]
-	self.localAddress(&result)
+	self.wasmimport_LocalAddress(&result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/tcp@0.2.0 [method]tcp-socket.local-address
 //go:noescape
-func (self TCPSocket) localAddress(result *cm.OKResult[IPSocketAddress, ErrorCode])
+func (self TCPSocket) wasmimport_LocalAddress(result *cm.OKResult[IPSocketAddress, ErrorCode])
 
 // ReceiveBufferSize represents method "receive-buffer-size".
 //
@@ -426,13 +426,13 @@ func (self TCPSocket) localAddress(result *cm.OKResult[IPSocketAddress, ErrorCod
 //go:nosplit
 func (self TCPSocket) ReceiveBufferSize() cm.OKResult[uint64, ErrorCode] {
 	var result cm.OKResult[uint64, ErrorCode]
-	self.receiveBufferSize(&result)
+	self.wasmimport_ReceiveBufferSize(&result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/tcp@0.2.0 [method]tcp-socket.receive-buffer-size
 //go:noescape
-func (self TCPSocket) receiveBufferSize(result *cm.OKResult[uint64, ErrorCode])
+func (self TCPSocket) wasmimport_ReceiveBufferSize(result *cm.OKResult[uint64, ErrorCode])
 
 // RemoteAddress represents method "remote-address".
 //
@@ -452,13 +452,13 @@ func (self TCPSocket) receiveBufferSize(result *cm.OKResult[uint64, ErrorCode])
 //go:nosplit
 func (self TCPSocket) RemoteAddress() cm.OKResult[IPSocketAddress, ErrorCode] {
 	var result cm.OKResult[IPSocketAddress, ErrorCode]
-	self.remoteAddress(&result)
+	self.wasmimport_RemoteAddress(&result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/tcp@0.2.0 [method]tcp-socket.remote-address
 //go:noescape
-func (self TCPSocket) remoteAddress(result *cm.OKResult[IPSocketAddress, ErrorCode])
+func (self TCPSocket) wasmimport_RemoteAddress(result *cm.OKResult[IPSocketAddress, ErrorCode])
 
 // SendBufferSize represents method "send-buffer-size".
 //
@@ -467,13 +467,13 @@ func (self TCPSocket) remoteAddress(result *cm.OKResult[IPSocketAddress, ErrorCo
 //go:nosplit
 func (self TCPSocket) SendBufferSize() cm.OKResult[uint64, ErrorCode] {
 	var result cm.OKResult[uint64, ErrorCode]
-	self.sendBufferSize(&result)
+	self.wasmimport_SendBufferSize(&result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/tcp@0.2.0 [method]tcp-socket.send-buffer-size
 //go:noescape
-func (self TCPSocket) sendBufferSize(result *cm.OKResult[uint64, ErrorCode])
+func (self TCPSocket) wasmimport_SendBufferSize(result *cm.OKResult[uint64, ErrorCode])
 
 // SetHopLimit represents method "set-hop-limit".
 //
@@ -482,13 +482,13 @@ func (self TCPSocket) sendBufferSize(result *cm.OKResult[uint64, ErrorCode])
 //go:nosplit
 func (self TCPSocket) SetHopLimit(value uint8) cm.ErrResult[struct{}, ErrorCode] {
 	var result cm.ErrResult[struct{}, ErrorCode]
-	self.setHopLimit(value, &result)
+	self.wasmimport_SetHopLimit(value, &result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/tcp@0.2.0 [method]tcp-socket.set-hop-limit
 //go:noescape
-func (self TCPSocket) setHopLimit(value uint8, result *cm.ErrResult[struct{}, ErrorCode])
+func (self TCPSocket) wasmimport_SetHopLimit(value uint8, result *cm.ErrResult[struct{}, ErrorCode])
 
 // SetKeepAliveCount represents method "set-keep-alive-count".
 //
@@ -497,13 +497,13 @@ func (self TCPSocket) setHopLimit(value uint8, result *cm.ErrResult[struct{}, Er
 //go:nosplit
 func (self TCPSocket) SetKeepAliveCount(value uint32) cm.ErrResult[struct{}, ErrorCode] {
 	var result cm.ErrResult[struct{}, ErrorCode]
-	self.setKeepAliveCount(value, &result)
+	self.wasmimport_SetKeepAliveCount(value, &result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/tcp@0.2.0 [method]tcp-socket.set-keep-alive-count
 //go:noescape
-func (self TCPSocket) setKeepAliveCount(value uint32, result *cm.ErrResult[struct{}, ErrorCode])
+func (self TCPSocket) wasmimport_SetKeepAliveCount(value uint32, result *cm.ErrResult[struct{}, ErrorCode])
 
 // SetKeepAliveEnabled represents method "set-keep-alive-enabled".
 //
@@ -512,13 +512,13 @@ func (self TCPSocket) setKeepAliveCount(value uint32, result *cm.ErrResult[struc
 //go:nosplit
 func (self TCPSocket) SetKeepAliveEnabled(value bool) cm.ErrResult[struct{}, ErrorCode] {
 	var result cm.ErrResult[struct{}, ErrorCode]
-	self.setKeepAliveEnabled(value, &result)
+	self.wasmimport_SetKeepAliveEnabled(value, &result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/tcp@0.2.0 [method]tcp-socket.set-keep-alive-enabled
 //go:noescape
-func (self TCPSocket) setKeepAliveEnabled(value bool, result *cm.ErrResult[struct{}, ErrorCode])
+func (self TCPSocket) wasmimport_SetKeepAliveEnabled(value bool, result *cm.ErrResult[struct{}, ErrorCode])
 
 // SetKeepAliveIdleTime represents method "set-keep-alive-idle-time".
 //
@@ -527,13 +527,13 @@ func (self TCPSocket) setKeepAliveEnabled(value bool, result *cm.ErrResult[struc
 //go:nosplit
 func (self TCPSocket) SetKeepAliveIdleTime(value Duration) cm.ErrResult[struct{}, ErrorCode] {
 	var result cm.ErrResult[struct{}, ErrorCode]
-	self.setKeepAliveIdleTime(value, &result)
+	self.wasmimport_SetKeepAliveIdleTime(value, &result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/tcp@0.2.0 [method]tcp-socket.set-keep-alive-idle-time
 //go:noescape
-func (self TCPSocket) setKeepAliveIdleTime(value Duration, result *cm.ErrResult[struct{}, ErrorCode])
+func (self TCPSocket) wasmimport_SetKeepAliveIdleTime(value Duration, result *cm.ErrResult[struct{}, ErrorCode])
 
 // SetKeepAliveInterval represents method "set-keep-alive-interval".
 //
@@ -542,13 +542,13 @@ func (self TCPSocket) setKeepAliveIdleTime(value Duration, result *cm.ErrResult[
 //go:nosplit
 func (self TCPSocket) SetKeepAliveInterval(value Duration) cm.ErrResult[struct{}, ErrorCode] {
 	var result cm.ErrResult[struct{}, ErrorCode]
-	self.setKeepAliveInterval(value, &result)
+	self.wasmimport_SetKeepAliveInterval(value, &result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/tcp@0.2.0 [method]tcp-socket.set-keep-alive-interval
 //go:noescape
-func (self TCPSocket) setKeepAliveInterval(value Duration, result *cm.ErrResult[struct{}, ErrorCode])
+func (self TCPSocket) wasmimport_SetKeepAliveInterval(value Duration, result *cm.ErrResult[struct{}, ErrorCode])
 
 // SetListenBacklogSize represents method "set-listen-backlog-size".
 //
@@ -570,13 +570,13 @@ func (self TCPSocket) setKeepAliveInterval(value Duration, result *cm.ErrResult[
 //go:nosplit
 func (self TCPSocket) SetListenBacklogSize(value uint64) cm.ErrResult[struct{}, ErrorCode] {
 	var result cm.ErrResult[struct{}, ErrorCode]
-	self.setListenBacklogSize(value, &result)
+	self.wasmimport_SetListenBacklogSize(value, &result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/tcp@0.2.0 [method]tcp-socket.set-listen-backlog-size
 //go:noescape
-func (self TCPSocket) setListenBacklogSize(value uint64, result *cm.ErrResult[struct{}, ErrorCode])
+func (self TCPSocket) wasmimport_SetListenBacklogSize(value uint64, result *cm.ErrResult[struct{}, ErrorCode])
 
 // SetReceiveBufferSize represents method "set-receive-buffer-size".
 //
@@ -585,13 +585,13 @@ func (self TCPSocket) setListenBacklogSize(value uint64, result *cm.ErrResult[st
 //go:nosplit
 func (self TCPSocket) SetReceiveBufferSize(value uint64) cm.ErrResult[struct{}, ErrorCode] {
 	var result cm.ErrResult[struct{}, ErrorCode]
-	self.setReceiveBufferSize(value, &result)
+	self.wasmimport_SetReceiveBufferSize(value, &result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/tcp@0.2.0 [method]tcp-socket.set-receive-buffer-size
 //go:noescape
-func (self TCPSocket) setReceiveBufferSize(value uint64, result *cm.ErrResult[struct{}, ErrorCode])
+func (self TCPSocket) wasmimport_SetReceiveBufferSize(value uint64, result *cm.ErrResult[struct{}, ErrorCode])
 
 // SetSendBufferSize represents method "set-send-buffer-size".
 //
@@ -600,13 +600,13 @@ func (self TCPSocket) setReceiveBufferSize(value uint64, result *cm.ErrResult[st
 //go:nosplit
 func (self TCPSocket) SetSendBufferSize(value uint64) cm.ErrResult[struct{}, ErrorCode] {
 	var result cm.ErrResult[struct{}, ErrorCode]
-	self.setSendBufferSize(value, &result)
+	self.wasmimport_SetSendBufferSize(value, &result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/tcp@0.2.0 [method]tcp-socket.set-send-buffer-size
 //go:noescape
-func (self TCPSocket) setSendBufferSize(value uint64, result *cm.ErrResult[struct{}, ErrorCode])
+func (self TCPSocket) wasmimport_SetSendBufferSize(value uint64, result *cm.ErrResult[struct{}, ErrorCode])
 
 // Shutdown represents method "shutdown".
 //
@@ -639,13 +639,13 @@ func (self TCPSocket) setSendBufferSize(value uint64, result *cm.ErrResult[struc
 //go:nosplit
 func (self TCPSocket) Shutdown(shutdownType ShutdownType) cm.ErrResult[struct{}, ErrorCode] {
 	var result cm.ErrResult[struct{}, ErrorCode]
-	self.shutdown(shutdownType, &result)
+	self.wasmimport_Shutdown(shutdownType, &result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/tcp@0.2.0 [method]tcp-socket.shutdown
 //go:noescape
-func (self TCPSocket) shutdown(shutdownType ShutdownType, result *cm.ErrResult[struct{}, ErrorCode])
+func (self TCPSocket) wasmimport_Shutdown(shutdownType ShutdownType, result *cm.ErrResult[struct{}, ErrorCode])
 
 // StartBind represents method "start-bind".
 //
@@ -703,13 +703,13 @@ func (self TCPSocket) shutdown(shutdownType ShutdownType, result *cm.ErrResult[s
 //go:nosplit
 func (self TCPSocket) StartBind(network_ Network, localAddress IPSocketAddress) cm.ErrResult[struct{}, ErrorCode] {
 	var result cm.ErrResult[struct{}, ErrorCode]
-	self.startBind(network_, localAddress, &result)
+	self.wasmimport_StartBind(network_, localAddress, &result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/tcp@0.2.0 [method]tcp-socket.start-bind
 //go:noescape
-func (self TCPSocket) startBind(network_ Network, localAddress IPSocketAddress, result *cm.ErrResult[struct{}, ErrorCode])
+func (self TCPSocket) wasmimport_StartBind(network_ Network, localAddress IPSocketAddress, result *cm.ErrResult[struct{}, ErrorCode])
 
 // StartConnect represents method "start-connect".
 //
@@ -773,13 +773,13 @@ func (self TCPSocket) startBind(network_ Network, localAddress IPSocketAddress, 
 //go:nosplit
 func (self TCPSocket) StartConnect(network_ Network, remoteAddress IPSocketAddress) cm.ErrResult[struct{}, ErrorCode] {
 	var result cm.ErrResult[struct{}, ErrorCode]
-	self.startConnect(network_, remoteAddress, &result)
+	self.wasmimport_StartConnect(network_, remoteAddress, &result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/tcp@0.2.0 [method]tcp-socket.start-connect
 //go:noescape
-func (self TCPSocket) startConnect(network_ Network, remoteAddress IPSocketAddress, result *cm.ErrResult[struct{}, ErrorCode])
+func (self TCPSocket) wasmimport_StartConnect(network_ Network, remoteAddress IPSocketAddress, result *cm.ErrResult[struct{}, ErrorCode])
 
 // StartListen represents method "start-listen".
 //
@@ -817,13 +817,13 @@ func (self TCPSocket) startConnect(network_ Network, remoteAddress IPSocketAddre
 //go:nosplit
 func (self TCPSocket) StartListen() cm.ErrResult[struct{}, ErrorCode] {
 	var result cm.ErrResult[struct{}, ErrorCode]
-	self.startListen(&result)
+	self.wasmimport_StartListen(&result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/tcp@0.2.0 [method]tcp-socket.start-listen
 //go:noescape
-func (self TCPSocket) startListen(result *cm.ErrResult[struct{}, ErrorCode])
+func (self TCPSocket) wasmimport_StartListen(result *cm.ErrResult[struct{}, ErrorCode])
 
 // Subscribe represents method "subscribe".
 //
@@ -849,9 +849,9 @@ func (self TCPSocket) startListen(result *cm.ErrResult[struct{}, ErrorCode])
 //
 //go:nosplit
 func (self TCPSocket) Subscribe() Pollable {
-	return self.subscribe()
+	return self.wasmimport_Subscribe()
 }
 
 //go:wasmimport wasi:sockets/tcp@0.2.0 [method]tcp-socket.subscribe
 //go:noescape
-func (self TCPSocket) subscribe() Pollable
+func (self TCPSocket) wasmimport_Subscribe() Pollable

--- a/wasi/sockets/udp-create-socket/udp-create-socket.wit.go
+++ b/wasi/sockets/udp-create-socket/udp-create-socket.wit.go
@@ -65,10 +65,10 @@ type UDPSocket = udp.UDPSocket
 //go:nosplit
 func CreateUDPSocket(addressFamily IPAddressFamily) cm.OKResult[UDPSocket, ErrorCode] {
 	var result cm.OKResult[UDPSocket, ErrorCode]
-	createUDPSocket(addressFamily, &result)
+	wasmimport_CreateUDPSocket(addressFamily, &result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/udp-create-socket@0.2.0 create-udp-socket
 //go:noescape
-func createUDPSocket(addressFamily IPAddressFamily, result *cm.OKResult[UDPSocket, ErrorCode])
+func wasmimport_CreateUDPSocket(addressFamily IPAddressFamily, result *cm.OKResult[UDPSocket, ErrorCode])

--- a/wasi/sockets/udp/udp.wit.go
+++ b/wasi/sockets/udp/udp.wit.go
@@ -50,12 +50,12 @@ type IncomingDatagramStream cm.Resource
 //
 //go:nosplit
 func (self IncomingDatagramStream) ResourceDrop() {
-	self.resourceDrop()
+	self.wasmimport_ResourceDrop()
 }
 
 //go:wasmimport wasi:sockets/udp@0.2.0 [resource-drop]incoming-datagram-stream
 //go:noescape
-func (self IncomingDatagramStream) resourceDrop()
+func (self IncomingDatagramStream) wasmimport_ResourceDrop()
 
 // Receive represents method "receive".
 //
@@ -90,13 +90,13 @@ func (self IncomingDatagramStream) resourceDrop()
 //go:nosplit
 func (self IncomingDatagramStream) Receive(maxResults uint64) cm.OKResult[cm.List[IncomingDatagram], ErrorCode] {
 	var result cm.OKResult[cm.List[IncomingDatagram], ErrorCode]
-	self.receive(maxResults, &result)
+	self.wasmimport_Receive(maxResults, &result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/udp@0.2.0 [method]incoming-datagram-stream.receive
 //go:noescape
-func (self IncomingDatagramStream) receive(maxResults uint64, result *cm.OKResult[cm.List[IncomingDatagram], ErrorCode])
+func (self IncomingDatagramStream) wasmimport_Receive(maxResults uint64, result *cm.OKResult[cm.List[IncomingDatagram], ErrorCode])
 
 // Subscribe represents method "subscribe".
 //
@@ -109,12 +109,12 @@ func (self IncomingDatagramStream) receive(maxResults uint64, result *cm.OKResul
 //
 //go:nosplit
 func (self IncomingDatagramStream) Subscribe() Pollable {
-	return self.subscribe()
+	return self.wasmimport_Subscribe()
 }
 
 //go:wasmimport wasi:sockets/udp@0.2.0 [method]incoming-datagram-stream.subscribe
 //go:noescape
-func (self IncomingDatagramStream) subscribe() Pollable
+func (self IncomingDatagramStream) wasmimport_Subscribe() Pollable
 
 // IPAddressFamily represents the enum "wasi:sockets/network@0.2.0#ip-address-family".
 //
@@ -166,12 +166,12 @@ type OutgoingDatagramStream cm.Resource
 //
 //go:nosplit
 func (self OutgoingDatagramStream) ResourceDrop() {
-	self.resourceDrop()
+	self.wasmimport_ResourceDrop()
 }
 
 //go:wasmimport wasi:sockets/udp@0.2.0 [resource-drop]outgoing-datagram-stream
 //go:noescape
-func (self OutgoingDatagramStream) resourceDrop()
+func (self OutgoingDatagramStream) wasmimport_ResourceDrop()
 
 // CheckSend represents method "check-send".
 //
@@ -192,13 +192,13 @@ func (self OutgoingDatagramStream) resourceDrop()
 //go:nosplit
 func (self OutgoingDatagramStream) CheckSend() cm.OKResult[uint64, ErrorCode] {
 	var result cm.OKResult[uint64, ErrorCode]
-	self.checkSend(&result)
+	self.wasmimport_CheckSend(&result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/udp@0.2.0 [method]outgoing-datagram-stream.check-send
 //go:noescape
-func (self OutgoingDatagramStream) checkSend(result *cm.OKResult[uint64, ErrorCode])
+func (self OutgoingDatagramStream) wasmimport_CheckSend(result *cm.OKResult[uint64, ErrorCode])
 
 // Send represents method "send".
 //
@@ -256,13 +256,13 @@ func (self OutgoingDatagramStream) checkSend(result *cm.OKResult[uint64, ErrorCo
 //go:nosplit
 func (self OutgoingDatagramStream) Send(datagrams cm.List[OutgoingDatagram]) cm.OKResult[uint64, ErrorCode] {
 	var result cm.OKResult[uint64, ErrorCode]
-	self.send(datagrams, &result)
+	self.wasmimport_Send(datagrams, &result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/udp@0.2.0 [method]outgoing-datagram-stream.send
 //go:noescape
-func (self OutgoingDatagramStream) send(datagrams cm.List[OutgoingDatagram], result *cm.OKResult[uint64, ErrorCode])
+func (self OutgoingDatagramStream) wasmimport_Send(datagrams cm.List[OutgoingDatagram], result *cm.OKResult[uint64, ErrorCode])
 
 // Subscribe represents method "subscribe".
 //
@@ -275,12 +275,12 @@ func (self OutgoingDatagramStream) send(datagrams cm.List[OutgoingDatagram], res
 //
 //go:nosplit
 func (self OutgoingDatagramStream) Subscribe() Pollable {
-	return self.subscribe()
+	return self.wasmimport_Subscribe()
 }
 
 //go:wasmimport wasi:sockets/udp@0.2.0 [method]outgoing-datagram-stream.subscribe
 //go:noescape
-func (self OutgoingDatagramStream) subscribe() Pollable
+func (self OutgoingDatagramStream) wasmimport_Subscribe() Pollable
 
 // Pollable represents the resource "wasi:io/poll@0.2.0#pollable".
 //
@@ -300,12 +300,12 @@ type UDPSocket cm.Resource
 //
 //go:nosplit
 func (self UDPSocket) ResourceDrop() {
-	self.resourceDrop()
+	self.wasmimport_ResourceDrop()
 }
 
 //go:wasmimport wasi:sockets/udp@0.2.0 [resource-drop]udp-socket
 //go:noescape
-func (self UDPSocket) resourceDrop()
+func (self UDPSocket) wasmimport_ResourceDrop()
 
 // AddressFamily represents method "address-family".
 //
@@ -317,12 +317,12 @@ func (self UDPSocket) resourceDrop()
 //
 //go:nosplit
 func (self UDPSocket) AddressFamily() IPAddressFamily {
-	return self.addressFamily()
+	return self.wasmimport_AddressFamily()
 }
 
 //go:wasmimport wasi:sockets/udp@0.2.0 [method]udp-socket.address-family
 //go:noescape
-func (self UDPSocket) addressFamily() IPAddressFamily
+func (self UDPSocket) wasmimport_AddressFamily() IPAddressFamily
 
 // FinishBind represents method "finish-bind".
 //
@@ -331,13 +331,13 @@ func (self UDPSocket) addressFamily() IPAddressFamily
 //go:nosplit
 func (self UDPSocket) FinishBind() cm.ErrResult[struct{}, ErrorCode] {
 	var result cm.ErrResult[struct{}, ErrorCode]
-	self.finishBind(&result)
+	self.wasmimport_FinishBind(&result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/udp@0.2.0 [method]udp-socket.finish-bind
 //go:noescape
-func (self UDPSocket) finishBind(result *cm.ErrResult[struct{}, ErrorCode])
+func (self UDPSocket) wasmimport_FinishBind(result *cm.ErrResult[struct{}, ErrorCode])
 
 // LocalAddress represents method "local-address".
 //
@@ -364,13 +364,13 @@ func (self UDPSocket) finishBind(result *cm.ErrResult[struct{}, ErrorCode])
 //go:nosplit
 func (self UDPSocket) LocalAddress() cm.OKResult[IPSocketAddress, ErrorCode] {
 	var result cm.OKResult[IPSocketAddress, ErrorCode]
-	self.localAddress(&result)
+	self.wasmimport_LocalAddress(&result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/udp@0.2.0 [method]udp-socket.local-address
 //go:noescape
-func (self UDPSocket) localAddress(result *cm.OKResult[IPSocketAddress, ErrorCode])
+func (self UDPSocket) wasmimport_LocalAddress(result *cm.OKResult[IPSocketAddress, ErrorCode])
 
 // ReceiveBufferSize represents method "receive-buffer-size".
 //
@@ -392,13 +392,13 @@ func (self UDPSocket) localAddress(result *cm.OKResult[IPSocketAddress, ErrorCod
 //go:nosplit
 func (self UDPSocket) ReceiveBufferSize() cm.OKResult[uint64, ErrorCode] {
 	var result cm.OKResult[uint64, ErrorCode]
-	self.receiveBufferSize(&result)
+	self.wasmimport_ReceiveBufferSize(&result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/udp@0.2.0 [method]udp-socket.receive-buffer-size
 //go:noescape
-func (self UDPSocket) receiveBufferSize(result *cm.OKResult[uint64, ErrorCode])
+func (self UDPSocket) wasmimport_ReceiveBufferSize(result *cm.OKResult[uint64, ErrorCode])
 
 // RemoteAddress represents method "remote-address".
 //
@@ -418,13 +418,13 @@ func (self UDPSocket) receiveBufferSize(result *cm.OKResult[uint64, ErrorCode])
 //go:nosplit
 func (self UDPSocket) RemoteAddress() cm.OKResult[IPSocketAddress, ErrorCode] {
 	var result cm.OKResult[IPSocketAddress, ErrorCode]
-	self.remoteAddress(&result)
+	self.wasmimport_RemoteAddress(&result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/udp@0.2.0 [method]udp-socket.remote-address
 //go:noescape
-func (self UDPSocket) remoteAddress(result *cm.OKResult[IPSocketAddress, ErrorCode])
+func (self UDPSocket) wasmimport_RemoteAddress(result *cm.OKResult[IPSocketAddress, ErrorCode])
 
 // SendBufferSize represents method "send-buffer-size".
 //
@@ -433,13 +433,13 @@ func (self UDPSocket) remoteAddress(result *cm.OKResult[IPSocketAddress, ErrorCo
 //go:nosplit
 func (self UDPSocket) SendBufferSize() cm.OKResult[uint64, ErrorCode] {
 	var result cm.OKResult[uint64, ErrorCode]
-	self.sendBufferSize(&result)
+	self.wasmimport_SendBufferSize(&result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/udp@0.2.0 [method]udp-socket.send-buffer-size
 //go:noescape
-func (self UDPSocket) sendBufferSize(result *cm.OKResult[uint64, ErrorCode])
+func (self UDPSocket) wasmimport_SendBufferSize(result *cm.OKResult[uint64, ErrorCode])
 
 // SetReceiveBufferSize represents method "set-receive-buffer-size".
 //
@@ -448,13 +448,13 @@ func (self UDPSocket) sendBufferSize(result *cm.OKResult[uint64, ErrorCode])
 //go:nosplit
 func (self UDPSocket) SetReceiveBufferSize(value uint64) cm.ErrResult[struct{}, ErrorCode] {
 	var result cm.ErrResult[struct{}, ErrorCode]
-	self.setReceiveBufferSize(value, &result)
+	self.wasmimport_SetReceiveBufferSize(value, &result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/udp@0.2.0 [method]udp-socket.set-receive-buffer-size
 //go:noescape
-func (self UDPSocket) setReceiveBufferSize(value uint64, result *cm.ErrResult[struct{}, ErrorCode])
+func (self UDPSocket) wasmimport_SetReceiveBufferSize(value uint64, result *cm.ErrResult[struct{}, ErrorCode])
 
 // SetSendBufferSize represents method "set-send-buffer-size".
 //
@@ -463,13 +463,13 @@ func (self UDPSocket) setReceiveBufferSize(value uint64, result *cm.ErrResult[st
 //go:nosplit
 func (self UDPSocket) SetSendBufferSize(value uint64) cm.ErrResult[struct{}, ErrorCode] {
 	var result cm.ErrResult[struct{}, ErrorCode]
-	self.setSendBufferSize(value, &result)
+	self.wasmimport_SetSendBufferSize(value, &result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/udp@0.2.0 [method]udp-socket.set-send-buffer-size
 //go:noescape
-func (self UDPSocket) setSendBufferSize(value uint64, result *cm.ErrResult[struct{}, ErrorCode])
+func (self UDPSocket) wasmimport_SetSendBufferSize(value uint64, result *cm.ErrResult[struct{}, ErrorCode])
 
 // SetUnicastHopLimit represents method "set-unicast-hop-limit".
 //
@@ -478,13 +478,13 @@ func (self UDPSocket) setSendBufferSize(value uint64, result *cm.ErrResult[struc
 //go:nosplit
 func (self UDPSocket) SetUnicastHopLimit(value uint8) cm.ErrResult[struct{}, ErrorCode] {
 	var result cm.ErrResult[struct{}, ErrorCode]
-	self.setUnicastHopLimit(value, &result)
+	self.wasmimport_SetUnicastHopLimit(value, &result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/udp@0.2.0 [method]udp-socket.set-unicast-hop-limit
 //go:noescape
-func (self UDPSocket) setUnicastHopLimit(value uint8, result *cm.ErrResult[struct{}, ErrorCode])
+func (self UDPSocket) wasmimport_SetUnicastHopLimit(value uint8, result *cm.ErrResult[struct{}, ErrorCode])
 
 // StartBind represents method "start-bind".
 //
@@ -526,13 +526,13 @@ func (self UDPSocket) setUnicastHopLimit(value uint8, result *cm.ErrResult[struc
 //go:nosplit
 func (self UDPSocket) StartBind(network_ Network, localAddress IPSocketAddress) cm.ErrResult[struct{}, ErrorCode] {
 	var result cm.ErrResult[struct{}, ErrorCode]
-	self.startBind(network_, localAddress, &result)
+	self.wasmimport_StartBind(network_, localAddress, &result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/udp@0.2.0 [method]udp-socket.start-bind
 //go:noescape
-func (self UDPSocket) startBind(network_ Network, localAddress IPSocketAddress, result *cm.ErrResult[struct{}, ErrorCode])
+func (self UDPSocket) wasmimport_StartBind(network_ Network, localAddress IPSocketAddress, result *cm.ErrResult[struct{}, ErrorCode])
 
 // Stream represents method "stream".
 //
@@ -593,13 +593,13 @@ func (self UDPSocket) startBind(network_ Network, localAddress IPSocketAddress, 
 //go:nosplit
 func (self UDPSocket) Stream(remoteAddress cm.Option[IPSocketAddress]) cm.OKResult[cm.Tuple[IncomingDatagramStream, OutgoingDatagramStream], ErrorCode] {
 	var result cm.OKResult[cm.Tuple[IncomingDatagramStream, OutgoingDatagramStream], ErrorCode]
-	self.stream(remoteAddress, &result)
+	self.wasmimport_Stream(remoteAddress, &result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/udp@0.2.0 [method]udp-socket.stream
 //go:noescape
-func (self UDPSocket) stream(remoteAddress cm.Option[IPSocketAddress], result *cm.OKResult[cm.Tuple[IncomingDatagramStream, OutgoingDatagramStream], ErrorCode])
+func (self UDPSocket) wasmimport_Stream(remoteAddress cm.Option[IPSocketAddress], result *cm.OKResult[cm.Tuple[IncomingDatagramStream, OutgoingDatagramStream], ErrorCode])
 
 // Subscribe represents method "subscribe".
 //
@@ -612,12 +612,12 @@ func (self UDPSocket) stream(remoteAddress cm.Option[IPSocketAddress], result *c
 //
 //go:nosplit
 func (self UDPSocket) Subscribe() Pollable {
-	return self.subscribe()
+	return self.wasmimport_Subscribe()
 }
 
 //go:wasmimport wasi:sockets/udp@0.2.0 [method]udp-socket.subscribe
 //go:noescape
-func (self UDPSocket) subscribe() Pollable
+func (self UDPSocket) wasmimport_Subscribe() Pollable
 
 // UnicastHopLimit represents method "unicast-hop-limit".
 //
@@ -633,10 +633,10 @@ func (self UDPSocket) subscribe() Pollable
 //go:nosplit
 func (self UDPSocket) UnicastHopLimit() cm.OKResult[uint8, ErrorCode] {
 	var result cm.OKResult[uint8, ErrorCode]
-	self.unicastHopLimit(&result)
+	self.wasmimport_UnicastHopLimit(&result)
 	return result
 }
 
 //go:wasmimport wasi:sockets/udp@0.2.0 [method]udp-socket.unicast-hop-limit
 //go:noescape
-func (self UDPSocket) unicastHopLimit(result *cm.OKResult[uint8, ErrorCode])
+func (self UDPSocket) wasmimport_UnicastHopLimit(result *cm.OKResult[uint8, ErrorCode])

--- a/wit/bindgen/function.go
+++ b/wit/bindgen/function.go
@@ -54,7 +54,7 @@ func goFunction(file *gen.File, f *wit.Function, goName string) function {
 func goParams(scope gen.Scope, params []wit.Param) []param {
 	out := make([]param, len(params))
 	for i := range params {
-		out[i].name = scope.UniqueName(GoName(params[i].Name, false))
+		out[i].name = scope.DeclareName(GoName(params[i].Name, false))
 		out[i].typ = params[i].Type
 	}
 	return out

--- a/wit/bindgen/function.go
+++ b/wit/bindgen/function.go
@@ -1,0 +1,61 @@
+package bindgen
+
+import (
+	"github.com/ydnar/wasm-tools-go/internal/go/gen"
+	"github.com/ydnar/wasm-tools-go/wit"
+)
+
+type funcDecl struct {
+	f     function // The exported Go function
+	lower function // The canon lower function (go:wasmimport)
+	lift  function // The canon lift function (go:wasmexport)
+}
+
+// function represents a Go function created from a Component Model function
+type function struct {
+	file     *gen.File // The Go file this function belongs to
+	scope    gen.Scope // Scope for function-local declarations
+	name     string    // The scoped unique Go name for this function (method names are scoped to recevier type)
+	receiver param     // The method receiver, if any
+	params   []param   // Function param(s), with unique Go name(s)
+	results  []param   // Function result(s), with unique Go name(s)
+}
+
+func (f *function) isMethod() bool {
+	return f.receiver.typ != nil
+}
+
+// param represents a Go function parameter or result.
+// name is a unique Go name within the function scope.
+type param struct {
+	name string
+	typ  wit.Type
+}
+
+func goFunction(file *gen.File, f *wit.Function, goName string) function {
+	scope := gen.NewScope(file)
+	out := function{
+		file:    file,
+		scope:   scope,
+		name:    goName,
+		params:  goParams(scope, f.Params),
+		results: goParams(scope, f.Results),
+	}
+	if len(out.results) == 1 && out.results[0].name == "" {
+		out.results[0].name = "result"
+	}
+	if f.IsMethod() {
+		out.receiver = out.params[0]
+		out.params = out.params[1:]
+	}
+	return out
+}
+
+func goParams(scope gen.Scope, params []wit.Param) []param {
+	out := make([]param, len(params))
+	for i := range params {
+		out[i].name = scope.UniqueName(GoName(params[i].Name, false))
+		out[i].typ = params[i].Type
+	}
+	return out
+}

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -54,19 +54,13 @@ type generator struct {
 	// witPackages map WIT identifier paths to Go packages.
 	witPackages map[string]*gen.Package
 
-	// worldPackages map [wit.World] to Go packages.
-	worldPackages map[*wit.World]*gen.Package
-
-	// interfacePackages map [wit.Interface] to Go packages.
-	interfacePackages map[*wit.Interface]*gen.Package
-
 	// typeDefPackages map [wit.TypeDef] to Go packages.
 	typeDefPackages map[*wit.TypeDef]*gen.Package
 
 	// typeDefNames map [wit.TypeDef] to a defined Go name.
 	typeDefNames map[*wit.TypeDef]string
 
-	// scopes map a [wit.TypeDEf] to a [gen.Scope]. Used for method lists.
+	// scopes map a [wit.TypeDef] to a [gen.Scope]. Used for method lists.
 	scopes map[*wit.TypeDef]gen.Scope
 
 	// functions map [wit.Function] to their equivalent Go identifier.
@@ -78,15 +72,13 @@ type generator struct {
 
 func newGenerator(res *wit.Resolve, opts ...Option) (*generator, error) {
 	g := &generator{
-		packages:          make(map[string]*gen.Package),
-		witPackages:       make(map[string]*gen.Package),
-		worldPackages:     make(map[*wit.World]*gen.Package),
-		interfacePackages: make(map[*wit.Interface]*gen.Package),
-		typeDefPackages:   make(map[*wit.TypeDef]*gen.Package),
-		typeDefNames:      make(map[*wit.TypeDef]string),
-		scopes:            make(map[*wit.TypeDef]gen.Scope),
-		functions:         make(map[*wit.Function]gen.Ident),
-		defined:           make(map[any]bool),
+		packages:        make(map[string]*gen.Package),
+		witPackages:     make(map[string]*gen.Package),
+		typeDefPackages: make(map[*wit.TypeDef]*gen.Package),
+		typeDefNames:    make(map[*wit.TypeDef]string),
+		scopes:          make(map[*wit.TypeDef]gen.Scope),
+		functions:       make(map[*wit.Function]gen.Ident),
+		defined:         make(map[any]bool),
 	}
 	err := g.opts.apply(opts...)
 	if err != nil {
@@ -224,13 +216,9 @@ func (g *generator) defineWorld(w *wit.World) error {
 	if g.defined[w] {
 		return nil
 	}
-	if g.worldPackages[w] != nil {
-		return nil
-	}
 	id := w.Package.Name
 	id.Extension = w.Name
 	pkg := g.packageFor(id)
-	g.worldPackages[w] = pkg
 	file := g.fileFor(id)
 
 	var b strings.Builder
@@ -268,16 +256,12 @@ func (g *generator) defineInterface(i *wit.Interface, name string) error {
 	if g.defined[i] {
 		return nil
 	}
-	if g.interfacePackages[i] != nil {
-		return nil
-	}
 	if i.Name != nil {
 		name = *i.Name
 	}
 	id := i.Package.Name
 	id.Extension = name
 	pkg := g.packageFor(id)
-	g.interfacePackages[i] = pkg
 	file := g.fileFor(id)
 
 	var b strings.Builder

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -272,10 +272,18 @@ func (g *generator) defineInterface(i *wit.Interface, name string) error {
 	}
 	file.PackageDocs = b.String()
 
+	// Define types
 	for _, name := range codec.SortedKeys(i.TypeDefs) {
 		g.defineTypeDef(i.TypeDefs[name], name)
 	}
 
+	// Declare all functions
+	for _, name := range codec.SortedKeys(i.Functions) {
+		f := i.Functions[name]
+		g.declareFunction(f, id)
+	}
+
+	// Define standalone functions
 	for _, name := range codec.SortedKeys(i.Functions) {
 		f := i.Functions[name]
 		if f.IsFreestanding() {

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -310,7 +310,7 @@ func (g *generator) defineInterface(i *wit.Interface, name string) error {
 		b.WriteString("}\n\n")
 		stringio.Write(&b, "var ", pkg.GetName("instance"), " ", pkg.GetName("Interface"), "\n\n")
 
-		// TODO: enable writing exports interface
+		// // TODO: enable writing exports interface
 		// _, err := file.Write(b.Bytes())
 		// if err != nil {
 		// 	return err

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -60,10 +60,10 @@ type generator struct {
 	// typeDefNames map [wit.TypeDef] to a defined Go name.
 	typeDefNames map[*wit.TypeDef]string
 
-	// scopes map a [wit.TypeDef] to a [gen.Scope]. Used for method lists.
-	scopes map[*wit.TypeDef]gen.Scope
+	// typeDefScopes map a [wit.TypeDef] to a [gen.Scope]. Used for method lists.
+	typeDefScopes map[*wit.TypeDef]gen.Scope
 
-	// functions map [wit.Function] to their equivalent Go identifier.
+	// functions map [wit.Function] to their Go equivalent.
 	functions map[*wit.Function]gen.Ident
 
 	// defined represent whether a type or function has been defined.
@@ -76,7 +76,7 @@ func newGenerator(res *wit.Resolve, opts ...Option) (*generator, error) {
 		witPackages:     make(map[string]*gen.Package),
 		typeDefPackages: make(map[*wit.TypeDef]*gen.Package),
 		typeDefNames:    make(map[*wit.TypeDef]string),
-		scopes:          make(map[*wit.TypeDef]gen.Scope),
+		typeDefScopes:   make(map[*wit.TypeDef]gen.Scope),
 		functions:       make(map[*wit.Function]gen.Ident),
 		defined:         make(map[any]bool),
 	}
@@ -165,7 +165,7 @@ func (g *generator) declareTypeDef(file *gen.File, goName string, t *wit.TypeDef
 	}
 	g.typeDefPackages[t] = file.Package
 	g.typeDefNames[t] = file.Declare(goName)
-	g.scopes[t] = gen.NewScope(nil)
+	g.typeDefScopes[t] = gen.NewScope(nil)
 	// fmt.Fprintf(os.Stderr, "Type:\t%s.%s\n\t%s.%s\n", owner.String(), name, decl.Package.Path, decl.Name)
 	return nil
 }
@@ -704,7 +704,7 @@ func (g *generator) defineImportedFunction(f *wit.Function, owner wit.Ident) err
 		if t.Package().Name.Package != owner.Package {
 			return fmt.Errorf("cannot emit functions in package %s to type %s", owner.Package, t.Package().Name.String())
 		}
-		scope := g.scopes[t]
+		scope := g.typeDefScopes[t]
 		funcName = scope.UniqueName(GoName(f.BaseName(), true))
 		if lowerIsMethod {
 			lowerName = scope.UniqueName(GoName(f.BaseName(), false))

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -6,7 +6,6 @@ package bindgen
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -123,7 +122,7 @@ func (g *generator) generate() ([]*gen.Package, error) {
 func (g *generator) detectVersionedPackages() {
 	if g.opts.versioned {
 		g.versioned = true
-		fmt.Fprintf(os.Stderr, "Generated versions for all package(s)\n")
+		// fmt.Fprintf(os.Stderr, "Generated versions for all package(s)\n")
 		return
 	}
 	packages := make(map[string]string)
@@ -137,9 +136,9 @@ func (g *generator) detectVersionedPackages() {
 			packages[path] = pkg.Name.String()
 		}
 	}
-	if g.versioned {
-		// fmt.Fprintf(os.Stderr, "Multiple versions of package(s) detected\n")
-	}
+	// if g.versioned {
+	// 	fmt.Fprintf(os.Stderr, "Multiple versions of package(s) detected\n")
+	// }
 }
 
 // declareTypeDefs declares all type definitions in res.

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -221,14 +221,13 @@ func (g *generator) defineWorld(w *wit.World) error {
 	file := g.fileFor(id)
 
 	var b strings.Builder
-	fmt.Fprintf(&b, "Package %s represents the %s \"%s\".\n", pkg.Name, w.WITKind(), id.String())
+	stringio.Write(&b, "Package ", pkg.Name, " represents the ", w.WITKind(), " \"", id.String(), "\".\n")
 	if w.Docs.Contents != "" {
 		b.WriteString("\n")
 		b.WriteString(w.Docs.Contents)
 	}
 	file.PackageDocs = b.String()
 
-	// fmt.Printf("// World: %s\n\n", id.String())
 	for _, name := range codec.SortedKeys(w.Imports) {
 		var err error
 		switch v := w.Imports[name].(type) {
@@ -264,7 +263,7 @@ func (g *generator) defineInterface(i *wit.Interface, name string) error {
 	file := g.fileFor(id)
 
 	var b strings.Builder
-	fmt.Fprintf(&b, "Package %s represents the %s \"%s\".\n", pkg.Name, i.WITKind(), id.String())
+	stringio.Write(&b, "Package ", pkg.Name, " represents the ", i.WITKind(), " \"", id.String(), "\".\n")
 	if i.Docs.Contents != "" {
 		b.WriteString("\n")
 		b.WriteString(i.Docs.Contents)

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -294,8 +294,8 @@ func (g *generator) defineInterface(i *wit.Interface, name string) error {
 		}
 	}
 
-	// Define WIT interface as Go interface
-	{
+	// Define export interface
+	if g.opts.exports {
 		var b bytes.Buffer
 		stringio.Write(&b, "type ", pkg.GetName("Interface"), " interface {\n")
 
@@ -310,11 +310,11 @@ func (g *generator) defineInterface(i *wit.Interface, name string) error {
 		b.WriteString("}\n\n")
 		stringio.Write(&b, "var ", pkg.GetName("instance"), " ", pkg.GetName("Interface"), "\n\n")
 
-		// // TODO: enable writing exports interface
-		// _, err := file.Write(b.Bytes())
-		// if err != nil {
-		// 	return err
-		// }
+		// TODO: enable writing exports interface
+		_, err := file.Write(b.Bytes())
+		if err != nil {
+			return err
+		}
 	}
 
 	g.defined[i] = true

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -163,7 +163,7 @@ func (g *generator) declareTypeDef(file *gen.File, goName string, t *wit.TypeDef
 		file = g.fileFor(typeDefOwner(t))
 	}
 	g.typeDefPackages[t] = file.Package
-	g.typeDefNames[t] = file.Declare(goName)
+	g.typeDefNames[t] = file.DeclareName(goName)
 	g.typeDefScopes[t] = gen.NewScope(nil)
 	// fmt.Fprintf(os.Stderr, "Type:\t%s.%s\n\t%s.%s\n", owner.String(), name, decl.Package.Path, decl.Name)
 	return nil
@@ -548,7 +548,7 @@ func (g *generator) flagsRep(file *gen.File, goName string, flags *wit.Flags) st
 			b.WriteRune('\n')
 		}
 		b.WriteString(formatDocComments(flag.Docs.Contents, false))
-		flagName := file.Declare(goName + GoName(flag.Name, true))
+		flagName := file.DeclareName(goName + GoName(flag.Name, true))
 		b.WriteString(flagName)
 		if i == 0 {
 			stringio.Write(&b, " ", goName, " = 1 << iota")
@@ -570,7 +570,7 @@ func (g *generator) enumRep(file *gen.File, goName string, e *wit.Enum) string {
 			b.WriteRune('\n')
 		}
 		b.WriteString(formatDocComments(c.Docs.Contents, false))
-		b.WriteString(file.Declare(goName + GoName(c.Name, true)))
+		b.WriteString(file.DeclareName(goName + GoName(c.Name, true)))
 		if i == 0 {
 			b.WriteRune(' ')
 			b.WriteString(goName)
@@ -601,7 +601,7 @@ func (g *generator) variantRep(file *gen.File, goName string, v *wit.Variant) st
 	for i, c := range v.Cases {
 		caseNum := strconv.Itoa(i)
 		caseName := GoName(c.Name, true)
-		constructorName := file.Declare(goName + caseName)
+		constructorName := file.DeclareName(goName + caseName)
 		typeRep := g.typeRep(file, c.Type)
 
 		// Emit constructor
@@ -699,21 +699,21 @@ func (g *generator) declareFunction(f *wit.Function, owner wit.Ident) (*funcDecl
 	var lowerName string
 	switch f.Kind.(type) {
 	case *wit.Freestanding:
-		funcName = file.Declare(GoName(f.BaseName(), true))
-		liftName = file.Declare(pfxLift + funcName)
-		lowerName = file.Declare(pfxLower + funcName)
+		funcName = file.DeclareName(GoName(f.BaseName(), true))
+		liftName = file.DeclareName(pfxLift + funcName)
+		lowerName = file.DeclareName(pfxLower + funcName)
 
 	case *wit.Constructor:
 		t := f.Type().(*wit.TypeDef)
-		funcName = file.Declare("New" + g.typeDefNames[t])
-		liftName = file.Declare(pfxLift + funcName)
-		lowerName = file.Declare(pfxLower + funcName)
+		funcName = file.DeclareName("New" + g.typeDefNames[t])
+		liftName = file.DeclareName(pfxLift + funcName)
+		lowerName = file.DeclareName(pfxLower + funcName)
 
 	case *wit.Static:
 		t := f.Type().(*wit.TypeDef)
-		funcName = file.Declare(g.typeDefNames[t] + GoName(f.BaseName(), true))
-		liftName = file.Declare(pfxLift + funcName)
-		lowerName = file.Declare(pfxLower + funcName)
+		funcName = file.DeclareName(g.typeDefNames[t] + GoName(f.BaseName(), true))
+		liftName = file.DeclareName(pfxLift + funcName)
+		lowerName = file.DeclareName(pfxLower + funcName)
 
 	case *wit.Method:
 		t := f.Type().(*wit.TypeDef)
@@ -721,12 +721,12 @@ func (g *generator) declareFunction(f *wit.Function, owner wit.Ident) (*funcDecl
 			return nil, fmt.Errorf("cannot emit functions in package %s to type %s", owner.Package, t.Package().Name.String())
 		}
 		scope := g.typeDefScopes[t]
-		funcName = scope.UniqueName(GoName(f.BaseName(), true))
-		liftName = file.Declare(pfxLift + g.typeDefNames[t] + funcName)
+		funcName = scope.DeclareName(GoName(f.BaseName(), true))
+		liftName = file.DeclareName(pfxLift + g.typeDefNames[t] + funcName)
 		if lower.IsMethod() {
-			lowerName = scope.UniqueName(pfxLower + funcName)
+			lowerName = scope.DeclareName(pfxLower + funcName)
 		} else {
-			lowerName = file.Declare(pfxLower + g.typeDefNames[t] + funcName)
+			lowerName = file.DeclareName(pfxLower + g.typeDefNames[t] + funcName)
 		}
 	}
 
@@ -767,7 +767,7 @@ func (g *generator) defineImportedFunction(f *wit.Function, owner wit.Ident) err
 
 	var compoundParams param
 	if len(d.f.params) > 0 && derefAnonRecord(d.lower.params[0].typ) != nil {
-		name := d.f.scope.UniqueName("params")
+		name := d.f.scope.DeclareName("params")
 		lowerCallParams[0].name = name
 		t := derefAnonRecord(d.lower.params[0].typ)
 		g.declareTypeDef(file, d.lower.name+"Params", t)
@@ -778,7 +778,7 @@ func (g *generator) defineImportedFunction(f *wit.Function, owner wit.Ident) err
 	var compoundResults param
 	var resultsRecord *wit.Record
 	if len(d.f.results) > 1 && derefAnonRecord(last(d.lower.params).typ) != nil {
-		name := d.f.scope.UniqueName("results")
+		name := d.f.scope.DeclareName("results")
 		last(lowerCallParams).name = name
 		t := derefAnonRecord(last(d.lower.params).typ)
 		g.declareTypeDef(file, d.lower.name+"Results", t)

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -680,7 +680,6 @@ func (g *generator) defineImportedFunction(f *wit.Function, owner wit.Ident) err
 
 	// Setup
 	lower := f.CoreFunction(wit.Lower)
-	lowerIsMethod := f.IsMethod() && lower.Params[0] == f.Params[0]
 
 	var funcName string
 	var lowerName string
@@ -706,7 +705,7 @@ func (g *generator) defineImportedFunction(f *wit.Function, owner wit.Ident) err
 		}
 		scope := g.typeDefScopes[t]
 		funcName = scope.UniqueName(GoName(f.BaseName(), true))
-		if lowerIsMethod {
+		if lower.IsMethod() {
 			lowerName = scope.UniqueName(GoName(f.BaseName(), false))
 		} else {
 			lowerName = file.Declare(GoName(*t.Name, false) + funcName)
@@ -727,7 +726,7 @@ func (g *generator) defineImportedFunction(f *wit.Function, owner wit.Ident) err
 	lowerScope := gen.NewScope(file)
 	lowerParams := goParams(lowerScope, lower.Params)
 	lowerResults := goParams(lowerScope, lower.Results)
-	if lowerIsMethod {
+	if lower.IsMethod() {
 		lowerParams = lowerParams[1:]
 	}
 
@@ -834,7 +833,7 @@ func (g *generator) defineImportedFunction(f *wit.Function, owner wit.Ident) err
 	if sameResults && len(lowerResults) > 0 {
 		b.WriteString("return ")
 	}
-	if lowerIsMethod {
+	if lower.IsMethod() {
 		stringio.Write(&b, receiver.Name, ".")
 	}
 	stringio.Write(&b, lowerName, "(")
@@ -873,7 +872,7 @@ func (g *generator) defineImportedFunction(f *wit.Function, owner wit.Ident) err
 	stringio.Write(&b, "//go:wasmimport ", owner.String(), " ", f.Name, "\n")
 	b.WriteString("//go:noescape\n")
 	b.WriteString("func ")
-	if lowerIsMethod {
+	if lower.IsMethod() {
 		stringio.Write(&b, "(", receiver.Name, " ", g.typeRep(file, receiver.Type), ") ", lowerName)
 	} else {
 		b.WriteString(lowerName)

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -938,6 +938,8 @@ func (g *generator) declareFunction(f *wit.Function, owner wit.Ident) (*funcDecl
 		lower: goFunction(file, lower, lowerName),
 	}
 
+	g.functions[f] = d
+
 	return d, nil
 }
 

--- a/wit/bindgen/options.go
+++ b/wit/bindgen/options.go
@@ -70,7 +70,7 @@ func CMPackage(path string) Option {
 	})
 }
 
-// Versioned returns an [Option] that that specifies that all generated Go packages
+// Versioned returns an [Option] that specifies that all generated Go packages
 // will have versions that match WIT versions.
 func Versioned(versioned bool) Option {
 	return optionFunc(func(opts *options) error {

--- a/wit/bindgen/options.go
+++ b/wit/bindgen/options.go
@@ -25,6 +25,9 @@ type options struct {
 	// versioned determines if Go packages are generated with version numbers.
 	versioned bool
 
+	// exports determines if export bindings are generated.
+	exports bool
+
 	// idents maps WIT identifiers to Go identifiers. Examples:
 	// "wasi:clocks" -> "wasi/clocks"
 	// "wasi:clocks/wall-clock" -> "wasi/clocks/wall"
@@ -75,6 +78,14 @@ func CMPackage(path string) Option {
 func Versioned(versioned bool) Option {
 	return optionFunc(func(opts *options) error {
 		opts.versioned = versioned
+		return nil
+	})
+}
+
+// GenerateExports returns an [Option] that specifies whether to generate export bindings.
+func GenerateExports(exports bool) Option {
+	return optionFunc(func(opts *options) error {
+		opts.exports = exports
 		return nil
 	})
 }


### PR DESCRIPTION
`wit-bindgen-go` will now emit WIP export bindings when called with the `--exports` flag.

The bindings are currently nonfunctional, but sketch out a direction for how they could work.

```go
// Package run represents the interface "wasi:cli/run@0.2.0".
package run

type Interface interface {
	Run() cm.Result
}

var instance Interface

func Export(impl Interface) {
    instance = impl
}
```

For #65.