### PR TITLE
all: --package-root argument to allow binding generation in module std

### DIFF
--- a/cmd/wit-bindgen-go/cmd/generate/generate.go
+++ b/cmd/wit-bindgen-go/cmd/generate/generate.go
@@ -28,10 +28,6 @@ var Command = &cli.Command{
 			OnlyOnce:  true,
 			Usage:     "output directory",
 		},
-		&cli.StringMapFlag{
-			Name:  "map",
-			Usage: "maps WIT identifiers to Go identifiers",
-		},
 		&cli.BoolFlag{
 			Name:  "versioned",
 			Usage: "emit versioned Go package(s) for each WIT version",
@@ -78,7 +74,6 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		bindgen.PackageRoot(pkgPath),
 		bindgen.Versioned(cmd.Bool("versioned")),
 		bindgen.GenerateExports(cmd.Bool("exports")),
-		bindgen.MapIdents(cmd.StringMap("map")),
 	)
 	if err != nil {
 		return err

--- a/cmd/wit-bindgen-go/cmd/generate/generate.go
+++ b/cmd/wit-bindgen-go/cmd/generate/generate.go
@@ -26,6 +26,7 @@ var Command = &cli.Command{
 			Value:     ".",
 			TakesFile: true,
 			OnlyOnce:  true,
+			Config:    cli.StringConfig{TrimSpace: true},
 			Usage:     "output directory",
 		},
 		&cli.BoolFlag{

--- a/wit/bindgen/options.go
+++ b/wit/bindgen/options.go
@@ -27,14 +27,6 @@ type options struct {
 
 	// exports determines if export bindings are generated.
 	exports bool
-
-	// idents maps WIT identifiers to Go identifiers. Examples:
-	// "wasi:clocks" -> "wasi/clocks"
-	// "wasi:clocks/wall-clock" -> "wasi/clocks/wall"
-	// "wasi:clocks/wall-clock" -> "wasi/clocks/wall#wallclock" (for a Go short package name of wallclock)
-	// "wasi:clocks/wall-clock.datetime" -> "wasi/clocks/wall#DateTime"
-	// "wasi:clocks/wall-clock.now" -> "wasi/clocks/wall#Now"
-	idents map[string]string
 }
 
 func (opts *options) apply(o ...Option) error {
@@ -86,43 +78,6 @@ func Versioned(versioned bool) Option {
 func GenerateExports(exports bool) Option {
 	return optionFunc(func(opts *options) error {
 		opts.exports = exports
-		return nil
-	})
-}
-
-// MapIdent returns an [Option] that maps a [WIT] identifier to a Go identifier.
-//
-// Acceptable values for from include: package names like "wasi:clocks",
-// qualified interface or world names like "wasi:clocks/wall-clock",
-// or fully-qualified identifiers like "wasi:clocks/wall-clock.datetime".
-//
-// Acceptable values for to include: Go package paths like "wasi/clocks/wallclock",
-// qualified package names like "wasi/clocks/wall#wallclock", or
-// qualified identifier names like "wasi/clocks/wallclock#DateTime".
-//
-// [WIT]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md
-func MapIdent(from, to string) Option {
-	return optionFunc(func(opts *options) error {
-		if opts.idents == nil {
-			opts.idents = make(map[string]string)
-		}
-		opts.idents[from] = to
-		return nil
-	})
-}
-
-// MapIdents returns an [Option] that maps [WIT] identifiers to Go identifiers.
-// See [MapIdent] for more information.
-//
-// [WIT]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md
-func MapIdents(idents map[string]string) Option {
-	return optionFunc(func(opts *options) error {
-		for from, to := range idents {
-			err := MapIdent(from, to).applyOption(opts)
-			if err != nil {
-				return err
-			}
-		}
 		return nil
 	})
 }


### PR DESCRIPTION
- **cmd/wit-bindgen-go/cmd/generate, wit/bindgen: remove ident mapping options**
- **cmd/wit-bindgen-go/cmd/generate: trim space**
- **cmd/wit-bindgen-go/cmd/generate: --package-root argument**
