### PR TITLE
all: add --world argument to limit generating Go bindings to a specific WIT world

### DIFF
--- a/cmd/wit-bindgen-go/cmd/generate/generate.go
+++ b/cmd/wit-bindgen-go/cmd/generate/generate.go
@@ -21,6 +21,14 @@ var Command = &cli.Command{
 	Usage:   "generates Go from a fully-resolved WIT JSON file",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
+			Name:     "world",
+			Aliases:  []string{"w"},
+			Value:    "",
+			OnlyOnce: true,
+			Config:   cli.StringConfig{TrimSpace: true},
+			Usage:    "WIT world to generate, otherwise generate all worlds",
+		},
+		&cli.StringFlag{
 			Name:      "out",
 			Aliases:   []string{"o"},
 			Value:     ".",
@@ -83,6 +91,7 @@ func action(ctx context.Context, cmd *cli.Command) error {
 
 	packages, err := bindgen.Go(res,
 		bindgen.GeneratedBy(cmd.Root().Name),
+		bindgen.World(cmd.String("world")),
 		bindgen.PackageRoot(pkgRoot),
 		bindgen.Versioned(cmd.Bool("versioned")),
 		bindgen.GenerateExports(cmd.Bool("exports")),

--- a/cmd/wit-bindgen-go/cmd/generate/generate.go
+++ b/cmd/wit-bindgen-go/cmd/generate/generate.go
@@ -18,7 +18,7 @@ import (
 var Command = &cli.Command{
 	Name:    "generate",
 	Aliases: []string{"go"},
-	Usage:   "generates Go from a fully-resolved WIT JSON file",
+	Usage:   "generate Go bindings from from WIT (WebAssembly Interface Types)",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:     "world",

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -209,14 +209,14 @@ func (g *generator) defineInterfaces() error {
 func (g *generator) defineWorlds() error {
 	// fmt.Fprintf(os.Stderr, "Generating Go for %d world(s)\n", len(g.res.Worlds))
 	for _, w := range g.res.Worlds {
-		if g.opts.world == "" || worldNameEquals(w, g.opts.world) {
+		if g.opts.world == "" || matchWorld(w, g.opts.world) {
 			g.defineWorld(w)
 		}
 	}
 	return nil
 }
 
-func worldNameEquals(w *wit.World, name string) bool {
+func matchWorld(w *wit.World, name string) bool {
 	if name == w.Name {
 		return true
 	}

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -103,9 +103,11 @@ func (g *generator) generate() ([]*gen.Package, error) {
 		return nil, err
 	}
 
-	err = g.defineInterfaces()
-	if err != nil {
-		return nil, err
+	if g.opts.world == "" {
+		err = g.defineInterfaces()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	err = g.defineWorlds()
@@ -207,9 +209,24 @@ func (g *generator) defineInterfaces() error {
 func (g *generator) defineWorlds() error {
 	// fmt.Fprintf(os.Stderr, "Generating Go for %d world(s)\n", len(g.res.Worlds))
 	for _, w := range g.res.Worlds {
-		g.defineWorld(w)
+		if g.opts.world == "" || worldNameEquals(w, g.opts.world) {
+			g.defineWorld(w)
+		}
 	}
 	return nil
+}
+
+func worldNameEquals(w *wit.World, name string) bool {
+	if name == w.Name {
+		return true
+	}
+	id := w.Package.Name
+	id.Extension = w.Name
+	if name == id.String() {
+		return true
+	}
+	id.Version = nil
+	return name == id.String()
 }
 
 func (g *generator) defineWorld(w *wit.World) error {

--- a/wit/bindgen/options.go
+++ b/wit/bindgen/options.go
@@ -15,6 +15,10 @@ type options struct {
 	// generatedBy is the name of the program that generates code with this package.
 	generatedBy string
 
+	// world is the name of the WIT world to generate, e.g. "command" or "wasi:cli/command".
+	// Default: all worlds in the Resolve will be generated.
+	world string
+
 	// packageRoot is the root Go package or module path used in generated code.
 	packageRoot string
 
@@ -44,6 +48,14 @@ func (opts *options) apply(o ...Option) error {
 func GeneratedBy(name string) Option {
 	return optionFunc(func(opts *options) error {
 		opts.generatedBy = name
+		return nil
+	})
+}
+
+// World returns an [Option] that specifies the WIT world to generate.
+func World(world string) Option {
+	return optionFunc(func(opts *options) error {
+		opts.world = world
 		return nil
 	})
 }


### PR DESCRIPTION
This PR adds a `--world` argument to `wit-bindgen-go generate`, which limits Go code generation to a specific WIT world.

The argument may be a single name like `proxy` or a partially or fully-qualified WIT identifier:

- `proxy`
- `wasi:http/proxy`
- `wasi:http/proxy@0.2.0`

This mimics the behavior of `wit-bindgen`, with the caveat that `wit-bindgen-go` will generate Go bindings for *all* worlds in the resolved WIT by default.

Todo in future PR:

- [ ] Limit generated functions to those *imported* or *exported* by a WIT world.
- [ ] Distinguish between imported and exported types in `bindgen.generator` structure.
    - [ ] This only really matters for `resource` types, which are distinct if imported or exported. Structural types like `enum`, `record`, `enum`, and scalar types can be defined once in Go.