### PR TITLE
all: only emit own<T> in type alias statements

### DIFF
--- a/testdata/wasi/cli.wit.json.golden.wit
+++ b/testdata/wasi/cli.wit.json.golden.wit
@@ -140,7 +140,7 @@ interface streams {
 		/// The created `pollable` is a child resource of the `input-stream`.
 		/// Implementations may trap if the `input-stream` is dropped before
 		/// all derived `pollable`s created with this function are dropped.
-		subscribe: func() -> own<pollable>;
+		subscribe: func() -> pollable;
 	}
 
 	/// An output bytestream.
@@ -264,7 +264,7 @@ interface streams {
 		/// The created `pollable` is a child resource of the `output-stream`.
 		/// Implementations may trap if the `output-stream` is dropped before
 		/// all derived `pollable`s created with this function are dropped.
-		subscribe: func() -> own<pollable>;
+		subscribe: func() -> pollable;
 
 		/// Perform a write. This function never blocks.
 		///
@@ -295,7 +295,7 @@ interface streams {
 		/// The last operation (a write or flush) failed before completion.
 		///
 		/// More information is available in the `error` payload.
-		last-operation-failed(own<error>),
+		last-operation-failed(error),
 		/// The stream is closed: no more input will be accepted by the
 		/// stream. A closed output-stream will return this error on all
 		/// future operations.
@@ -346,11 +346,11 @@ interface monotonic-clock {
 	/// Create a `pollable` which will resolve once the given duration has
 	/// elapsed, starting at the time at which this function was called.
 	/// occured.
-	subscribe-duration: func(when: duration) -> own<pollable>;
+	subscribe-duration: func(when: duration) -> pollable;
 
 	/// Create a `pollable` which will resolve once the specified instant
 	/// occured.
-	subscribe-instant: func(when: instant) -> own<pollable>;
+	subscribe-instant: func(when: instant) -> pollable;
 }
 
 /// WASI Wall Clock is a clock API intended to let users query the current
@@ -408,7 +408,7 @@ interface preopens {
 	use types.{descriptor};
 
 	/// Return the set of preopened directories, and their path.
-	get-directories: func() -> list<tuple<own<descriptor>, string>>;
+	get-directories: func() -> list<tuple<descriptor, string>>;
 }
 
 /// WASI filesystem is a filesystem API primarily intended to let users run WASI
@@ -479,7 +479,7 @@ interface types {
 		///
 		/// Note: This allows using `write-stream`, which is similar to `write` with
 		/// `O_APPEND` in in POSIX.
-		append-via-stream: func() -> result<own<output-stream>, error-code>;
+		append-via-stream: func() -> result<output-stream, error-code>;
 
 		/// Create a directory.
 		///
@@ -564,7 +564,7 @@ interface types {
 		/// `error-code::read-only`.
 		///
 		/// Note: This is similar to `openat` in POSIX.
-		open-at: func(path-flags: path-flags, path: string, open-flags: open-flags, flags: descriptor-flags) -> result<own<descriptor>, error-code>;
+		open-at: func(path-flags: path-flags, path: string, open-flags: open-flags, flags: descriptor-flags) -> result<descriptor, error-code>;
 
 		/// Read from a descriptor, without using and updating the descriptor's offset.
 		///
@@ -588,7 +588,7 @@ interface types {
 		/// This always returns a new stream which starts at the beginning of the
 		/// directory. Multiple streams may be active on the same directory, and they
 		/// do not interfere with each other.
-		read-directory: func() -> result<own<directory-entry-stream>, error-code>;
+		read-directory: func() -> result<directory-entry-stream, error-code>;
 
 		/// Return a stream for reading from a file, if available.
 		///
@@ -598,7 +598,7 @@ interface types {
 		/// file and they do not interfere with each other.
 		///
 		/// Note: This allows using `read-stream`, which is similar to `read` in POSIX.
-		read-via-stream: func(offset: filesize) -> result<own<input-stream>, error-code>;
+		read-via-stream: func(offset: filesize) -> result<input-stream, error-code>;
 
 		/// Read the contents of a symbolic link.
 		///
@@ -708,7 +708,7 @@ interface types {
 		///
 		/// Note: This allows using `write-stream`, which is similar to `write` in
 		/// POSIX.
-		write-via-stream: func(offset: filesize) -> result<own<output-stream>, error-code>;
+		write-via-stream: func(offset: filesize) -> result<output-stream, error-code>;
 	}
 
 	/// Descriptor flags.
@@ -1059,7 +1059,7 @@ interface instance-network {
 	use network.{network};
 
 	/// Get a handle to the default network.
-	instance-network: func() -> own<network>;
+	instance-network: func() -> network;
 }
 
 interface ip-name-lookup {
@@ -1091,7 +1091,7 @@ interface ip-name-lookup {
 		///
 		/// Note: this function is here for WASI Preview2 only.
 		/// It's planned to be removed when `future` is natively supported in Preview3.
-		subscribe: func() -> own<pollable>;
+		subscribe: func() -> pollable;
 	}
 
 	/// Resolve an internet host name to a list of IP addresses.
@@ -1114,7 +1114,7 @@ interface ip-name-lookup {
 	/// - <https://man7.org/linux/man-pages/man3/getaddrinfo.3.html>
 	/// - <https://learn.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-getaddrinfo>
 	/// - <https://man.freebsd.org/cgi/man.cgi?query=getaddrinfo&sektion=3>
-	resolve-addresses: func(network: borrow<network>, name: string) -> result<own<resolve-address-stream>, error-code>;
+	resolve-addresses: func(network: borrow<network>, name: string) -> result<resolve-address-stream, error-code>;
 }
 
 interface network {
@@ -1305,14 +1305,14 @@ interface tcp {
 		/// - <https://man7.org/linux/man-pages/man2/accept.2.html>
 		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept>
 		/// - <https://man.freebsd.org/cgi/man.cgi?query=accept&sektion=2>
-		accept: func() -> result<tuple<own<tcp-socket>, own<input-stream>, own<output-stream>>, error-code>;
+		accept: func() -> result<tuple<tcp-socket, input-stream, output-stream>, error-code>;
 
 		/// Whether this is a IPv4 or IPv6 socket.
 		///
 		/// Equivalent to the SO_DOMAIN socket option.
 		address-family: func() -> ip-address-family;
 		finish-bind: func() -> result<_, error-code>;
-		finish-connect: func() -> result<tuple<own<input-stream>, own<output-stream>>, error-code>;
+		finish-connect: func() -> result<tuple<input-stream, output-stream>, error-code>;
 		finish-listen: func() -> result<_, error-code>;
 
 		/// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
@@ -1626,7 +1626,7 @@ interface tcp {
 		///
 		/// Note: this function is here for WASI Preview2 only.
 		/// It's planned to be removed when `future` is natively supported in Preview3.
-		subscribe: func() -> own<pollable>;
+		subscribe: func() -> pollable;
 	}
 }
 
@@ -1661,7 +1661,7 @@ interface tcp-create-socket {
 	/// - <https://man7.org/linux/man-pages/man2/socket.2.html>
 	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
 	/// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
-	create-tcp-socket: func(address-family: ip-address-family) -> result<own<tcp-socket>, error-code>;
+	create-tcp-socket: func(address-family: ip-address-family) -> result<tcp-socket, error-code>;
 }
 
 interface udp {
@@ -1718,7 +1718,7 @@ interface udp {
 		///
 		/// Note: this function is here for WASI Preview2 only.
 		/// It's planned to be removed when `future` is natively supported in Preview3.
-		subscribe: func() -> own<pollable>;
+		subscribe: func() -> pollable;
 	}
 
 	/// A datagram to be sent out.
@@ -1805,7 +1805,7 @@ interface udp {
 		///
 		/// Note: this function is here for WASI Preview2 only.
 		/// It's planned to be removed when `future` is natively supported in Preview3.
-		subscribe: func() -> own<pollable>;
+		subscribe: func() -> pollable;
 	}
 
 	/// A UDP socket handle.
@@ -1950,13 +1950,13 @@ interface udp {
 		/// - <https://man7.org/linux/man-pages/man2/connect.2.html>
 		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
 		/// - <https://man.freebsd.org/cgi/man.cgi?connect>
-		stream: func(remote-address: option<ip-socket-address>) -> result<tuple<own<incoming-datagram-stream>, own<outgoing-datagram-stream>>, error-code>;
+		stream: func(remote-address: option<ip-socket-address>) -> result<tuple<incoming-datagram-stream, outgoing-datagram-stream>, error-code>;
 
 		/// Create a `pollable` which will resolve once the socket is ready for I/O.
 		///
 		/// Note: this function is here for WASI Preview2 only.
 		/// It's planned to be removed when `future` is natively supported in Preview3.
-		subscribe: func() -> own<pollable>;
+		subscribe: func() -> pollable;
 
 		/// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
 		///
@@ -1999,7 +1999,7 @@ interface udp-create-socket {
 	/// - <https://man7.org/linux/man-pages/man2/socket.2.html>
 	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
 	/// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
-	create-udp-socket: func(address-family: ip-address-family) -> result<own<udp-socket>, error-code>;
+	create-udp-socket: func(address-family: ip-address-family) -> result<udp-socket, error-code>;
 }
 
 world imports {
@@ -2050,17 +2050,17 @@ interface run {
 
 interface stderr {
 	use wasi:io/streams@0.2.0.{output-stream};
-	get-stderr: func() -> own<output-stream>;
+	get-stderr: func() -> output-stream;
 }
 
 interface stdin {
 	use wasi:io/streams@0.2.0.{input-stream};
-	get-stdin: func() -> own<input-stream>;
+	get-stdin: func() -> input-stream;
 }
 
 interface stdout {
 	use wasi:io/streams@0.2.0.{output-stream};
-	get-stdout: func() -> own<output-stream>;
+	get-stdout: func() -> output-stream;
 }
 
 /// Terminal input.
@@ -2090,7 +2090,7 @@ interface terminal-stderr {
 
 	/// If stderr is connected to a terminal, return a `terminal-output` handle
 	/// allowing further interaction with it.
-	get-terminal-stderr: func() -> option<own<terminal-output>>;
+	get-terminal-stderr: func() -> option<terminal-output>;
 }
 
 /// An interface providing an optional `terminal-input` for stdin as a
@@ -2100,7 +2100,7 @@ interface terminal-stdin {
 
 	/// If stdin is connected to a terminal, return a `terminal-input` handle
 	/// allowing further interaction with it.
-	get-terminal-stdin: func() -> option<own<terminal-input>>;
+	get-terminal-stdin: func() -> option<terminal-input>;
 }
 
 /// An interface providing an optional `terminal-output` for stdout as a
@@ -2110,7 +2110,7 @@ interface terminal-stdout {
 
 	/// If stdout is connected to a terminal, return a `terminal-output` handle
 	/// allowing further interaction with it.
-	get-terminal-stdout: func() -> option<own<terminal-output>>;
+	get-terminal-stdout: func() -> option<terminal-output>;
 }
 
 world command {

--- a/testdata/wasi/http.wit.json.golden.wit
+++ b/testdata/wasi/http.wit.json.golden.wit
@@ -140,7 +140,7 @@ interface streams {
 		/// The created `pollable` is a child resource of the `input-stream`.
 		/// Implementations may trap if the `input-stream` is dropped before
 		/// all derived `pollable`s created with this function are dropped.
-		subscribe: func() -> own<pollable>;
+		subscribe: func() -> pollable;
 	}
 
 	/// An output bytestream.
@@ -264,7 +264,7 @@ interface streams {
 		/// The created `pollable` is a child resource of the `output-stream`.
 		/// Implementations may trap if the `output-stream` is dropped before
 		/// all derived `pollable`s created with this function are dropped.
-		subscribe: func() -> own<pollable>;
+		subscribe: func() -> pollable;
 
 		/// Perform a write. This function never blocks.
 		///
@@ -295,7 +295,7 @@ interface streams {
 		/// The last operation (a write or flush) failed before completion.
 		///
 		/// More information is available in the `error` payload.
-		last-operation-failed(own<error>),
+		last-operation-failed(error),
 		/// The stream is closed: no more input will be accepted by the
 		/// stream. A closed output-stream will return this error on all
 		/// future operations.
@@ -346,11 +346,11 @@ interface monotonic-clock {
 	/// Create a `pollable` which will resolve once the given duration has
 	/// elapsed, starting at the time at which this function was called.
 	/// occured.
-	subscribe-duration: func(when: duration) -> own<pollable>;
+	subscribe-duration: func(when: duration) -> pollable;
 
 	/// Create a `pollable` which will resolve once the specified instant
 	/// occured.
-	subscribe-instant: func(when: instant) -> own<pollable>;
+	subscribe-instant: func(when: instant) -> pollable;
 }
 
 /// WASI Wall Clock is a clock API intended to let users query the current
@@ -408,7 +408,7 @@ interface preopens {
 	use types.{descriptor};
 
 	/// Return the set of preopened directories, and their path.
-	get-directories: func() -> list<tuple<own<descriptor>, string>>;
+	get-directories: func() -> list<tuple<descriptor, string>>;
 }
 
 /// WASI filesystem is a filesystem API primarily intended to let users run WASI
@@ -479,7 +479,7 @@ interface types {
 		///
 		/// Note: This allows using `write-stream`, which is similar to `write` with
 		/// `O_APPEND` in in POSIX.
-		append-via-stream: func() -> result<own<output-stream>, error-code>;
+		append-via-stream: func() -> result<output-stream, error-code>;
 
 		/// Create a directory.
 		///
@@ -564,7 +564,7 @@ interface types {
 		/// `error-code::read-only`.
 		///
 		/// Note: This is similar to `openat` in POSIX.
-		open-at: func(path-flags: path-flags, path: string, open-flags: open-flags, flags: descriptor-flags) -> result<own<descriptor>, error-code>;
+		open-at: func(path-flags: path-flags, path: string, open-flags: open-flags, flags: descriptor-flags) -> result<descriptor, error-code>;
 
 		/// Read from a descriptor, without using and updating the descriptor's offset.
 		///
@@ -588,7 +588,7 @@ interface types {
 		/// This always returns a new stream which starts at the beginning of the
 		/// directory. Multiple streams may be active on the same directory, and they
 		/// do not interfere with each other.
-		read-directory: func() -> result<own<directory-entry-stream>, error-code>;
+		read-directory: func() -> result<directory-entry-stream, error-code>;
 
 		/// Return a stream for reading from a file, if available.
 		///
@@ -598,7 +598,7 @@ interface types {
 		/// file and they do not interfere with each other.
 		///
 		/// Note: This allows using `read-stream`, which is similar to `read` in POSIX.
-		read-via-stream: func(offset: filesize) -> result<own<input-stream>, error-code>;
+		read-via-stream: func(offset: filesize) -> result<input-stream, error-code>;
 
 		/// Read the contents of a symbolic link.
 		///
@@ -708,7 +708,7 @@ interface types {
 		///
 		/// Note: This allows using `write-stream`, which is similar to `write` in
 		/// POSIX.
-		write-via-stream: func(offset: filesize) -> result<own<output-stream>, error-code>;
+		write-via-stream: func(offset: filesize) -> result<output-stream, error-code>;
 	}
 
 	/// Descriptor flags.
@@ -977,7 +977,7 @@ interface instance-network {
 	use network.{network};
 
 	/// Get a handle to the default network.
-	instance-network: func() -> own<network>;
+	instance-network: func() -> network;
 }
 
 interface ip-name-lookup {
@@ -1009,7 +1009,7 @@ interface ip-name-lookup {
 		///
 		/// Note: this function is here for WASI Preview2 only.
 		/// It's planned to be removed when `future` is natively supported in Preview3.
-		subscribe: func() -> own<pollable>;
+		subscribe: func() -> pollable;
 	}
 
 	/// Resolve an internet host name to a list of IP addresses.
@@ -1032,7 +1032,7 @@ interface ip-name-lookup {
 	/// - <https://man7.org/linux/man-pages/man3/getaddrinfo.3.html>
 	/// - <https://learn.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-getaddrinfo>
 	/// - <https://man.freebsd.org/cgi/man.cgi?query=getaddrinfo&sektion=3>
-	resolve-addresses: func(network: borrow<network>, name: string) -> result<own<resolve-address-stream>, error-code>;
+	resolve-addresses: func(network: borrow<network>, name: string) -> result<resolve-address-stream, error-code>;
 }
 
 interface network {
@@ -1223,14 +1223,14 @@ interface tcp {
 		/// - <https://man7.org/linux/man-pages/man2/accept.2.html>
 		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept>
 		/// - <https://man.freebsd.org/cgi/man.cgi?query=accept&sektion=2>
-		accept: func() -> result<tuple<own<tcp-socket>, own<input-stream>, own<output-stream>>, error-code>;
+		accept: func() -> result<tuple<tcp-socket, input-stream, output-stream>, error-code>;
 
 		/// Whether this is a IPv4 or IPv6 socket.
 		///
 		/// Equivalent to the SO_DOMAIN socket option.
 		address-family: func() -> ip-address-family;
 		finish-bind: func() -> result<_, error-code>;
-		finish-connect: func() -> result<tuple<own<input-stream>, own<output-stream>>, error-code>;
+		finish-connect: func() -> result<tuple<input-stream, output-stream>, error-code>;
 		finish-listen: func() -> result<_, error-code>;
 
 		/// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
@@ -1544,7 +1544,7 @@ interface tcp {
 		///
 		/// Note: this function is here for WASI Preview2 only.
 		/// It's planned to be removed when `future` is natively supported in Preview3.
-		subscribe: func() -> own<pollable>;
+		subscribe: func() -> pollable;
 	}
 }
 
@@ -1579,7 +1579,7 @@ interface tcp-create-socket {
 	/// - <https://man7.org/linux/man-pages/man2/socket.2.html>
 	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
 	/// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
-	create-tcp-socket: func(address-family: ip-address-family) -> result<own<tcp-socket>, error-code>;
+	create-tcp-socket: func(address-family: ip-address-family) -> result<tcp-socket, error-code>;
 }
 
 interface udp {
@@ -1636,7 +1636,7 @@ interface udp {
 		///
 		/// Note: this function is here for WASI Preview2 only.
 		/// It's planned to be removed when `future` is natively supported in Preview3.
-		subscribe: func() -> own<pollable>;
+		subscribe: func() -> pollable;
 	}
 
 	/// A datagram to be sent out.
@@ -1723,7 +1723,7 @@ interface udp {
 		///
 		/// Note: this function is here for WASI Preview2 only.
 		/// It's planned to be removed when `future` is natively supported in Preview3.
-		subscribe: func() -> own<pollable>;
+		subscribe: func() -> pollable;
 	}
 
 	/// A UDP socket handle.
@@ -1868,13 +1868,13 @@ interface udp {
 		/// - <https://man7.org/linux/man-pages/man2/connect.2.html>
 		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
 		/// - <https://man.freebsd.org/cgi/man.cgi?connect>
-		stream: func(remote-address: option<ip-socket-address>) -> result<tuple<own<incoming-datagram-stream>, own<outgoing-datagram-stream>>, error-code>;
+		stream: func(remote-address: option<ip-socket-address>) -> result<tuple<incoming-datagram-stream, outgoing-datagram-stream>, error-code>;
 
 		/// Create a `pollable` which will resolve once the socket is ready for I/O.
 		///
 		/// Note: this function is here for WASI Preview2 only.
 		/// It's planned to be removed when `future` is natively supported in Preview3.
-		subscribe: func() -> own<pollable>;
+		subscribe: func() -> pollable;
 
 		/// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
 		///
@@ -1917,7 +1917,7 @@ interface udp-create-socket {
 	/// - <https://man7.org/linux/man-pages/man2/socket.2.html>
 	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
 	/// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
-	create-udp-socket: func(address-family: ip-address-family) -> result<own<udp-socket>, error-code>;
+	create-udp-socket: func(address-family: ip-address-family) -> result<udp-socket, error-code>;
 }
 
 world imports {
@@ -2050,17 +2050,17 @@ interface run {
 
 interface stderr {
 	use wasi:io/streams@0.2.0.{output-stream};
-	get-stderr: func() -> own<output-stream>;
+	get-stderr: func() -> output-stream;
 }
 
 interface stdin {
 	use wasi:io/streams@0.2.0.{input-stream};
-	get-stdin: func() -> own<input-stream>;
+	get-stdin: func() -> input-stream;
 }
 
 interface stdout {
 	use wasi:io/streams@0.2.0.{output-stream};
-	get-stdout: func() -> own<output-stream>;
+	get-stdout: func() -> output-stream;
 }
 
 /// Terminal input.
@@ -2090,7 +2090,7 @@ interface terminal-stderr {
 
 	/// If stderr is connected to a terminal, return a `terminal-output` handle
 	/// allowing further interaction with it.
-	get-terminal-stderr: func() -> option<own<terminal-output>>;
+	get-terminal-stderr: func() -> option<terminal-output>;
 }
 
 /// An interface providing an optional `terminal-input` for stdin as a
@@ -2100,7 +2100,7 @@ interface terminal-stdin {
 
 	/// If stdin is connected to a terminal, return a `terminal-input` handle
 	/// allowing further interaction with it.
-	get-terminal-stdin: func() -> option<own<terminal-input>>;
+	get-terminal-stdin: func() -> option<terminal-input>;
 }
 
 /// An interface providing an optional `terminal-output` for stdout as a
@@ -2110,7 +2110,7 @@ interface terminal-stdout {
 
 	/// If stdout is connected to a terminal, return a `terminal-output` handle
 	/// allowing further interaction with it.
-	get-terminal-stdout: func() -> option<own<terminal-output>>;
+	get-terminal-stdout: func() -> option<terminal-output>;
 }
 
 world command {
@@ -2193,7 +2193,7 @@ interface incoming-handler {
 	/// The implementor of this function must write a response to the
 	/// `response-outparam` before returning, or else the caller will respond
 	/// with an error on its behalf.
-	handle: func(request: own<incoming-request>, response-out: own<response-outparam>);
+	handle: func(request: incoming-request, response-out: response-outparam);
 }
 
 /// This interface defines a handler of outgoing HTTP Requests. It should be
@@ -2214,7 +2214,7 @@ interface outgoing-handler {
 	/// This function may return an error if the `outgoing-request` is invalid
 	/// or not allowed to be made. Otherwise, protocol errors are reported
 	/// through the `future-incoming-response`.
-	handle: func(request: own<outgoing-request>, options: option<own<request-options>>) -> result<own<future-incoming-response>, error-code>;
+	handle: func(request: outgoing-request, options: option<request-options>) -> result<future-incoming-response, error-code>;
 }
 
 /// This interface defines all of the types and methods for implementing
@@ -2330,7 +2330,7 @@ interface types {
 		/// Make a deep copy of the Fields. Equivelant in behavior to calling the
 		/// `fields` constructor on the return value of `entries`. The resulting
 		/// `fields` is mutable.
-		clone: func() -> own<fields>;
+		clone: func() -> fields;
 
 		/// Delete all values for a key. Does nothing if no values for the key
 		/// exist.
@@ -2381,7 +2381,7 @@ interface types {
 		///
 		/// An error result will be returned if any `field-key` or `field-value` is
 		/// syntactically invalid, or if a field is forbidden.
-		from-list: static func(entries: list<tuple<field-key, field-value>>) -> result<own<fields>, header-error>;
+		from-list: static func(entries: list<tuple<field-key, field-value>>) -> result<fields, header-error>;
 	}
 
 	/// Represents a future which may eventaully return an incoming HTTP
@@ -2405,12 +2405,12 @@ interface types {
 		/// occured. Errors may also occur while consuming the response body,
 		/// but those will be reported by the `incoming-body` and its
 		/// `output-stream` child.
-		get: func() -> option<result<result<own<incoming-response>, error-code>>>;
+		get: func() -> option<result<result<incoming-response, error-code>>>;
 
 		/// Returns a pollable which becomes ready when either the Response has
 		/// been received, or an error has occured. When this pollable is ready,
 		/// the `get` method will return `some`.
-		subscribe: func() -> own<pollable>;
+		subscribe: func() -> pollable;
 	}
 
 	/// Represents a future which may eventaully return trailers, or an error.
@@ -2439,12 +2439,12 @@ interface types {
 		/// resource is immutable, and a child. Use of the `set`, `append`, or
 		/// `delete` methods will return an error, and the resource must be
 		/// dropped before the parent `future-trailers` is dropped.
-		get: func() -> option<result<result<option<own<trailers>>, error-code>>>;
+		get: func() -> option<result<result<option<trailers>, error-code>>>;
 
 		/// Returns a pollable which becomes ready when either the trailers have
 		/// been received, or an error has occured. When this pollable is ready,
 		/// the `get` method will return `some`.
-		subscribe: func() -> own<pollable>;
+		subscribe: func() -> pollable;
 	}
 
 	/// This type enumerates the different kinds of errors that may occur when
@@ -2490,11 +2490,11 @@ interface types {
 		/// backpressure is to be applied when the user is consuming the body,
 		/// and for that backpressure to not inhibit delivery of the trailers if
 		/// the user does not read the entire body.
-		stream: func() -> result<own<input-stream>>;
+		stream: func() -> result<input-stream>;
 
 		/// Takes ownership of `incoming-body`, and returns a `future-trailers`.
 		/// This function will trap if the `input-stream` child is still alive.
-		finish: static func(this: own<incoming-body>) -> own<future-trailers>;
+		finish: static func(this: incoming-body) -> future-trailers;
 	}
 
 	/// Represents an incoming HTTP Request.
@@ -2505,7 +2505,7 @@ interface types {
 
 		/// Gives the `incoming-body` associated with this request. Will only
 		/// return success at most once, and subsequent calls will return error.
-		consume: func() -> result<own<incoming-body>>;
+		consume: func() -> result<incoming-body>;
 
 		/// Get the `headers` associated with the request.
 		///
@@ -2515,7 +2515,7 @@ interface types {
 		/// The `headers` returned are a child resource: it must be dropped before
 		/// the parent `incoming-request` is dropped. Dropping this
 		/// `incoming-request` before all children are dropped will trap.
-		headers: func() -> own<headers>;
+		headers: func() -> headers;
 
 		/// Returns the method of the incoming request.
 		method: func() -> method;
@@ -2532,7 +2532,7 @@ interface types {
 
 		/// Returns the incoming body. May be called at most once. Returns error
 		/// if called additional times.
-		consume: func() -> result<own<incoming-body>>;
+		consume: func() -> result<incoming-body>;
 
 		/// Returns the headers from the incoming response.
 		///
@@ -2541,7 +2541,7 @@ interface types {
 		///
 		/// This headers resource is a child: it must be dropped before the parent
 		/// `incoming-response` is dropped.
-		headers: func() -> own<headers>;
+		headers: func() -> headers;
 
 		/// Returns the status code from the incoming response.
 		status: func() -> status-code;
@@ -2588,7 +2588,7 @@ interface types {
 		/// Returns success on the first call: the `output-stream` resource for
 		/// this `outgoing-body` may be retrieved at most once. Subsequent calls
 		/// will return error.
-		write: func() -> result<own<output-stream>>;
+		write: func() -> result<output-stream>;
 
 		/// Finalize an outgoing body, optionally providing trailers. This must be
 		/// called to signal that the response is complete. If the `outgoing-body`
@@ -2599,7 +2599,7 @@ interface types {
 		/// constructed with a Content-Length header, and the contents written
 		/// to the body (via `write`) does not match the value given in the
 		/// Content-Length.
-		finish: static func(this: own<outgoing-body>, trailers: option<own<trailers>>) -> result<_, error-code>;
+		finish: static func(this: outgoing-body, trailers: option<trailers>) -> result<_, error-code>;
 	}
 
 	/// Represents an outgoing HTTP Request.
@@ -2614,7 +2614,7 @@ interface types {
 		/// and `authority`, or `headers` which are not permitted to be sent.
 		/// It is the obligation of the `outgoing-handler.handle` implementation
 		/// to reject invalid constructions of `outgoing-request`.
-		constructor(headers: own<headers>);
+		constructor(headers: headers);
 
 		/// Get the HTTP Authority for the Request. A value of `none` may be used
 		/// with Related Schemes which do not require an Authority. The HTTP and
@@ -2627,7 +2627,7 @@ interface types {
 		/// Returns success on the first call: the `outgoing-body` resource for
 		/// this `outgoing-request` can be retrieved at most once. Subsequent
 		/// calls will return error.
-		body: func() -> result<own<outgoing-body>>;
+		body: func() -> result<outgoing-body>;
 
 		/// Get the headers associated with the Request.
 		///
@@ -2637,7 +2637,7 @@ interface types {
 		/// This headers resource is a child: it must be dropped before the parent
 		/// `outgoing-request` is dropped, or its ownership is transfered to
 		/// another component by e.g. `outgoing-handler.handle`.
-		headers: func() -> own<headers>;
+		headers: func() -> headers;
 
 		/// Get the Method for the Request.
 		method: func() -> method;
@@ -2678,14 +2678,14 @@ interface types {
 		/// `set-status-code` method.
 		///
 		/// * `headers` is the HTTP Headers for the Response.
-		constructor(headers: own<headers>);
+		constructor(headers: headers);
 
 		/// Returns the resource corresponding to the outgoing Body for this Response.
 		///
 		/// Returns success on the first call: the `outgoing-body` resource for
 		/// this `outgoing-response` can be retrieved at most once. Subsequent
 		/// calls will return error.
-		body: func() -> result<own<outgoing-body>>;
+		body: func() -> result<outgoing-body>;
 
 		/// Get the headers associated with the Request.
 		///
@@ -2695,7 +2695,7 @@ interface types {
 		/// This headers resource is a child: it must be dropped before the parent
 		/// `outgoing-request` is dropped, or its ownership is transfered to
 		/// another component by e.g. `outgoing-handler.handle`.
-		headers: func() -> own<headers>;
+		headers: func() -> headers;
 
 		/// Set the HTTP Status Code for the Response. Fails if the status-code
 		/// given is not a valid http status code.
@@ -2755,7 +2755,7 @@ interface types {
 		///
 		/// The user may provide an `error` to `response` to allow the
 		/// implementation determine how to respond with an HTTP error response.
-		set: static func(param: own<response-outparam>, response: result<own<outgoing-response>, error-code>);
+		set: static func(param: response-outparam, response: result<outgoing-response, error-code>);
 	}
 
 	/// This type corresponds to HTTP standard Related Schemes.

--- a/testdata/wit-parser/resources-empty.wit.json.golden.wit
+++ b/testdata/wit-parser/resources-empty.wit.json.golden.wit
@@ -2,6 +2,6 @@ package foo:resources-empty;
 
 interface resources-empty {
 	resource r1;
-	t1: func(a: own<r1>);
+	t1: func(a: r1);
 	t2: func(a: borrow<r1>);
 }

--- a/testdata/wit-parser/resources-multiple-returns-own.wit.json.golden.wit
+++ b/testdata/wit-parser/resources-multiple-returns-own.wit.json.golden.wit
@@ -2,7 +2,7 @@ package foo:resources1;
 
 interface resources1 {
 	resource r1 {
-		f1: func() -> (a: s32, handle: own<r1>);
+		f1: func() -> (a: s32, handle: r1);
 	}
-	t1: func(a: own<r1>);
+	t1: func(a: r1);
 }

--- a/testdata/wit-parser/resources-multiple.wit.json.golden.wit
+++ b/testdata/wit-parser/resources-multiple.wit.json.golden.wit
@@ -14,5 +14,5 @@ interface resources-multiple {
 		f9: func() -> (u: u32, f: f32);
 	}
 	t1: func(a: borrow<r1>);
-	t2: func(a: own<r1>);
+	t2: func(a: r1);
 }

--- a/testdata/wit-parser/resources-return-own.wit.json.golden.wit
+++ b/testdata/wit-parser/resources-return-own.wit.json.golden.wit
@@ -2,7 +2,7 @@ package foo:resources1;
 
 interface resources1 {
 	resource r1 {
-		f1: func() -> own<r1>;
+		f1: func() -> r1;
 	}
-	t1: func(a: own<r1>);
+	t1: func(a: r1);
 }

--- a/testdata/wit-parser/resources.wit.json.golden.wit
+++ b/testdata/wit-parser/resources.wit.json.golden.wit
@@ -14,8 +14,8 @@ interface foo {
 		b: static func();
 	}
 	resource e {
-		constructor(other: own<e>, other2: borrow<e>);
-		method: func(thing: own<e>, thing2: borrow<e>);
+		constructor(other: e, other2: borrow<e>);
+		method: func(thing: e, thing2: borrow<e>);
 	}
 }
 

--- a/testdata/wit-parser/resources1.wit.json.golden.wit
+++ b/testdata/wit-parser/resources1.wit.json.golden.wit
@@ -5,6 +5,6 @@ interface resources1 {
 		f1: func();
 	}
 	t1: func(a: borrow<r1>);
-	t2: func(a: own<r1>);
-	t3: func(a: own<r1>);
+	t2: func(a: r1);
+	t3: func(a: r1);
 }

--- a/testdata/wit-parser/world-top-level-resources.wit.json.golden.wit
+++ b/testdata/wit-parser/world-top-level-resources.wit.json.golden.wit
@@ -3,8 +3,8 @@ package foo:foo;
 interface handler {
 	use types.{request};
 	use types.{response};
-	handle: func(some: borrow<request>) -> own<response>;
-	handle-owned: func(some: own<request>) -> own<response>;
+	handle: func(some: borrow<request>) -> response;
+	handle-owned: func(some: request) -> response;
 }
 
 interface types {

--- a/wit/wit.go
+++ b/wit/wit.go
@@ -76,7 +76,7 @@ func (d *Docs) WIT(_ Node, _ string) string {
 		return ""
 	}
 	var b strings.Builder
-	var lineLength = 0
+	lineLength := 0
 	for _, c := range d.Contents {
 		if lineLength == 0 {
 			b.WriteString(DocPrefix)
@@ -459,10 +459,12 @@ func (o *Own) WIT(ctx Node, name string) string {
 		b.WriteString("type ")
 		b.WriteString(escape(name))
 		b.WriteString(" = ")
+		b.WriteString("own<")
 	}
-	b.WriteString("own<")
 	b.WriteString(o.Type.WIT(o, ""))
-	b.WriteRune('>')
+	if name != "" {
+		b.WriteRune('>')
+	}
 	return b.String()
 }
 


### PR DESCRIPTION
- **wit: only emit own<T> handles in type alias statements**
- **testdata: only emit own<T> in type alias statements**
