### PR TITLE
wit: align Canonical ABI flattening rules with the spec

### DIFF
--- a/testdata/example/flat-variant.wit
+++ b/testdata/example/flat-variant.wit
@@ -1,0 +1,18 @@
+package example:flat-variant;
+
+interface a {
+	variant numbers {
+		one,
+		two(string),
+		three(float64),
+		four(option<string>),
+	}
+
+	f0: func(f: float64);
+
+	f1: func(v: numbers);
+}
+
+world imports {
+	import a;
+}

--- a/testdata/example/flat-variant.wit
+++ b/testdata/example/flat-variant.wit
@@ -11,6 +11,8 @@ interface a {
 	f0: func(f: float64);
 
 	f1: func(v: numbers);
+
+	type optional-float = option<float64>;
 }
 
 world imports {

--- a/testdata/example/flat-variant.wit.json
+++ b/testdata/example/flat-variant.wit.json
@@ -15,7 +15,8 @@
     {
       "name": "a",
       "types": {
-        "numbers": 1
+        "numbers": 1,
+        "optional-float": 2
       },
       "functions": {
         "f0": {
@@ -75,6 +76,15 @@
             }
           ]
         }
+      },
+      "owner": {
+        "interface": 0
+      }
+    },
+    {
+      "name": "optional-float",
+      "kind": {
+        "option": "f64"
       },
       "owner": {
         "interface": 0

--- a/testdata/example/flat-variant.wit.json
+++ b/testdata/example/flat-variant.wit.json
@@ -1,0 +1,95 @@
+{
+  "worlds": [
+    {
+      "name": "imports",
+      "imports": {
+        "interface-0": {
+          "interface": 0
+        }
+      },
+      "exports": {},
+      "package": 0
+    }
+  ],
+  "interfaces": [
+    {
+      "name": "a",
+      "types": {
+        "numbers": 1
+      },
+      "functions": {
+        "f0": {
+          "name": "f0",
+          "kind": "freestanding",
+          "params": [
+            {
+              "name": "f",
+              "type": "f64"
+            }
+          ],
+          "results": []
+        },
+        "f1": {
+          "name": "f1",
+          "kind": "freestanding",
+          "params": [
+            {
+              "name": "v",
+              "type": 1
+            }
+          ],
+          "results": []
+        }
+      },
+      "package": 0
+    }
+  ],
+  "types": [
+    {
+      "name": null,
+      "kind": {
+        "option": "string"
+      },
+      "owner": null
+    },
+    {
+      "name": "numbers",
+      "kind": {
+        "variant": {
+          "cases": [
+            {
+              "name": "one",
+              "type": null
+            },
+            {
+              "name": "two",
+              "type": "string"
+            },
+            {
+              "name": "three",
+              "type": "f64"
+            },
+            {
+              "name": "four",
+              "type": 0
+            }
+          ]
+        }
+      },
+      "owner": {
+        "interface": 0
+      }
+    }
+  ],
+  "packages": [
+    {
+      "name": "example:flat-variant",
+      "interfaces": {
+        "a": 0
+      },
+      "worlds": {
+        "imports": 0
+      }
+    }
+  ]
+}

--- a/testdata/example/flat-variant.wit.json.golden.wit
+++ b/testdata/example/flat-variant.wit.json.golden.wit
@@ -1,0 +1,16 @@
+package example:flat-variant;
+
+interface a {
+	variant numbers {
+		one,
+		two(string),
+		three(f64),
+		four(option<string>),
+	}
+	f0: func(f: f64);
+	f1: func(v: numbers);
+}
+
+world imports {
+	import a;
+}

--- a/testdata/example/flat-variant.wit.json.golden.wit
+++ b/testdata/example/flat-variant.wit.json.golden.wit
@@ -7,6 +7,7 @@ interface a {
 		three(f64),
 		four(option<string>),
 	}
+	type optional-float = option<f64>;
 	f0: func(f: f64);
 	f1: func(v: numbers);
 }

--- a/wit/abi_test.go
+++ b/wit/abi_test.go
@@ -3,6 +3,7 @@ package wit
 import (
 	"fmt"
 	"math"
+	"reflect"
 	"testing"
 )
 
@@ -123,11 +124,44 @@ func TestTypeSize(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			size := tt.v.Size()
 			if size != tt.size {
-				t.Errorf("(Type).Size(): expected %d, got %d", tt.size, size)
+				t.Errorf("(Type).Size(): %d, expected %d", size, tt.size)
 			}
 			align := tt.v.Align()
 			if align != tt.align {
-				t.Errorf("(Type).Align(): expected %d, got %d", tt.align, align)
+				t.Errorf("(Type).Align(): %d, expected %d", align, tt.align)
+			}
+		})
+	}
+}
+
+func TestTypeFlat(t *testing.T) {
+	tests := []struct {
+		name string
+		v    Type
+		want []Type
+	}{
+		{"bool", Bool{}, []Type{U32{}}},
+		{"s8", S8{}, []Type{U32{}}},
+		{"u8", U8{}, []Type{U32{}}},
+		{"s16", S16{}, []Type{U32{}}},
+		{"u16", U16{}, []Type{U32{}}},
+		{"s32", S32{}, []Type{U32{}}},
+		{"u32", U32{}, []Type{U32{}}},
+		{"s64", S64{}, []Type{U64{}}},
+		{"u64", U64{}, []Type{U64{}}},
+		{"f32", F32{}, []Type{F32{}}},
+		{"f64", F64{}, []Type{F64{}}},
+		{"char", Char{}, []Type{U32{}}},
+		{"string", String{}, []Type{U32{}, U32{}}},
+		{"option<string>", &TypeDef{Kind: &Option{Type: String{}}}, []Type{U32{}, U32{}, U32{}}},
+		{"option<f32>", &TypeDef{Kind: &Option{Type: F32{}}}, []Type{U32{}, F32{}}},
+		{"variant", &TypeDef{Kind: &Variant{Cases: []Case{{Type: String{}}, {Type: F64{}}}}}, []Type{U32{}, U64{}, U32{}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.v.Flat()
+			if !reflect.DeepEqual(tt.want, got) {
+				t.Errorf("(Type).Flat(): %v, expected %v", got, tt.want)
 			}
 		})
 	}

--- a/wit/resolve.go
+++ b/wit/resolve.go
@@ -652,7 +652,7 @@ func (v *Variant) Flat() []Type {
 	for _, t := range v.Types() {
 		for i, f := range t.Flat() {
 			if i >= len(flat) {
-				flat = append(flat, t)
+				flat = append(flat, f)
 			} else if f.Size() > flat[i].Size() {
 				flat[i] = f
 			}

--- a/wit/resolve.go
+++ b/wit/resolve.go
@@ -653,12 +653,22 @@ func (v *Variant) Flat() []Type {
 		for i, f := range t.Flat() {
 			if i >= len(flat) {
 				flat = append(flat, f)
-			} else if f.Size() > flat[i].Size() {
-				flat[i] = f
+			} else {
+				flat[i] = flatJoin(flat[i], f)
 			}
 		}
 	}
 	return append(Discriminant(len(v.Cases)).Flat(), flat...)
+}
+
+func flatJoin(a, b Type) Type {
+	if a == b {
+		return a
+	}
+	if a.Size() == 4 && b.Size() == 4 {
+		return U32{}
+	}
+	return U64{}
 }
 
 func (v *Variant) maxCaseSize() uintptr {
@@ -1152,6 +1162,9 @@ func (_primitive[T]) TypeName() string {
 		panic(fmt.Sprintf("BUG: unknown primitive type %T", v)) // should never reach here
 	}
 }
+
+// String implements the [io.Stringer] interface. Used for debugging.
+func (p _primitive[T]) String() string { return p.TypeName() }
 
 // Bool represents the WIT [primitive type] bool, a boolean value either true or false.
 // It is equivalent to the Go type [bool].


### PR DESCRIPTION
This correctly implements the Canonical ABI [flattening rules](https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#flattening) for `variant`, `option`, and `result` types (which despecialize into `variant`). Namely overlapping types are replaced with either `uint32` or `uint64`, even if one of the overlapping types is a `float32` or `float64`.

Related to #97 and #98.