### PR TITLE
wit: return pointers in Flat

### DIFF
--- a/wit/abi_test.go
+++ b/wit/abi_test.go
@@ -152,8 +152,8 @@ func TestTypeFlat(t *testing.T) {
 		{"f32", F32{}, []Type{F32{}}},
 		{"f64", F64{}, []Type{F64{}}},
 		{"char", Char{}, []Type{U32{}}},
-		{"string", String{}, []Type{U32{}, U32{}}},
-		{"option<string>", &TypeDef{Kind: &Option{Type: String{}}}, []Type{U32{}, U32{}, U32{}}},
+		{"string", String{}, []Type{PointerTo(U8{}), U32{}}},
+		{"option<string>", &TypeDef{Kind: &Option{Type: String{}}}, []Type{U32{}, PointerTo(U8{}), U32{}}},
 		{"option<f32>", &TypeDef{Kind: &Option{Type: F32{}}}, []Type{U32{}, F32{}}},
 		{"variant", &TypeDef{Kind: &Variant{Cases: []Case{{Type: String{}}, {Type: F64{}}}}}, []Type{U32{}, U64{}, U32{}}},
 	}

--- a/wit/abi_test.go
+++ b/wit/abi_test.go
@@ -161,8 +161,16 @@ func TestTypeFlat(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.v.Flat()
 			if !reflect.DeepEqual(tt.want, got) {
-				t.Errorf("(Type).Flat(): %v, expected %v", got, tt.want)
+				t.Errorf("(Type).Flat(): %v, expected %v", witFor(got...), witFor(tt.want...))
 			}
 		})
 	}
+}
+
+func witFor[T Node](nodes ...T) []string {
+	out := make([]string, len(nodes))
+	for i, node := range nodes {
+		out[i] = node.WIT(nil, "")
+	}
+	return out
 }

--- a/wit/resolve.go
+++ b/wit/resolve.go
@@ -284,6 +284,12 @@ type Pointer struct {
 	Type Type
 }
 
+// TypeName returns the type name for [Pointer].
+// This is somewhat of a fiction, since [WIT] does not have pointer types.
+//
+// [WIT]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md
+func (*Pointer) TypeName() string { return "pointer" }
+
 // Size returns the [ABI byte size] for [Pointer].
 //
 // [ABI byte size]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#size

--- a/wit/resolve.go
+++ b/wit/resolve.go
@@ -910,7 +910,7 @@ func (*List) Align() uintptr { return 8 } // [2]int32
 // Flat returns the [flattened] ABI representation of [List].
 //
 // [flattened]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#flattening
-func (*List) Flat() []Type { return []Type{U32{}, U32{}} }
+func (l *List) Flat() []Type { return []Type{PointerTo(l.Type), U32{}} }
 
 func (*List) hasPointer() bool    { return true }
 func (l *List) hasBorrow() bool   { return HasBorrow(l.Type) }
@@ -1124,7 +1124,7 @@ func (_primitive[T]) Flat() []Type {
 	case float64:
 		return []Type{F64{}}
 	case string:
-		return []Type{U32{}, U32{}}
+		return []Type{PointerTo(U8{}), U32{}}
 	default:
 		panic(fmt.Sprintf("BUG: unknown primitive type %T", v)) // should never reach here
 	}

--- a/wit/resolve.go
+++ b/wit/resolve.go
@@ -277,6 +277,11 @@ func KindOf[K TypeDefKind](t Type) (kind K) {
 	return zero
 }
 
+// PointerTo returns a [Pointer] to [Type] t.
+func PointerTo(t Type) *TypeDef {
+	return &TypeDef{Kind: &Pointer{Type: t}}
+}
+
 // Pointer represents a pointer to a WIT type.
 // It is only used for ABI representation, e.g. pointers to function parameters or return values.
 type Pointer struct {

--- a/wit/resolve.go
+++ b/wit/resolve.go
@@ -284,12 +284,6 @@ type Pointer struct {
 	Type Type
 }
 
-// TypeName returns the type name for [Pointer].
-// This is somewhat of a fiction, since [WIT] does not have pointer types.
-//
-// [WIT]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md
-func (*Pointer) TypeName() string { return "pointer" }
-
 // Size returns the [ABI byte size] for [Pointer].
 //
 // [ABI byte size]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#size
@@ -1168,9 +1162,6 @@ func (_primitive[T]) TypeName() string {
 		panic(fmt.Sprintf("BUG: unknown primitive type %T", v)) // should never reach here
 	}
 }
-
-// String implements the [io.Stringer] interface. Used for debugging.
-func (p _primitive[T]) String() string { return p.TypeName() }
 
 // Bool represents the WIT [primitive type] bool, a boolean value either true or false.
 // It is equivalent to the Go type [bool].

--- a/wit/wit.go
+++ b/wit/wit.go
@@ -397,8 +397,9 @@ func (p *Pointer) WIT(_ Node, name string) string {
 		b.WriteString(escape(name))
 		b.WriteString(" = ")
 	}
-	b.WriteRune('*')
+	b.WriteString("pointer<")
 	b.WriteString(p.Type.WIT(p, ""))
+	b.WriteRune('>')
 	return b.String()
 }
 


### PR DESCRIPTION
`(*List).Flat` and `String.Flat` now return `Pointer` types instead of `U32` for their data field.

This will allow `wasmimport` and `wasmexport` functions to include `*T`, `unsafe.Pointer`, (or worst-case) `uintptr` in params.