### PR TITLE
wit: support @since and @unstable directives in WIT

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up wasm-tools
         uses: bytecodealliance/actions/wasm-tools/setup@v1.1.0
         with:
-          version: v1.205.0
+          version: v1.209.1
 
       - name: Set up Go
         uses: actions/setup-go@v5.0.1
@@ -82,7 +82,7 @@ jobs:
       - name: Set up wasm-tools
         uses: bytecodealliance/actions/wasm-tools/setup@v1.1.0
         with:
-          version: v1.205.0
+          version: v1.209.1
 
       - name: Set up Go
         uses: actions/setup-go@v5.0.1
@@ -119,7 +119,7 @@ jobs:
       - name: Set up wasm-tools
         uses: bytecodealliance/actions/wasm-tools/setup@v1.1.0
         with:
-          version: v1.205.0
+          version: v1.209.1
 
       - name: Set up Wasmtime
         uses: bytecodealliance/actions/wasmtime/setup@v1.1.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up wasm-tools
         uses: bytecodealliance/actions/wasm-tools/setup@v1.1.0
         with:
-          version: v1.209.1
+          version: v1.210.0
 
       - name: Set up Go
         uses: actions/setup-go@v5.0.1
@@ -82,7 +82,7 @@ jobs:
       - name: Set up wasm-tools
         uses: bytecodealliance/actions/wasm-tools/setup@v1.1.0
         with:
-          version: v1.209.1
+          version: v1.210.0
 
       - name: Set up Go
         uses: actions/setup-go@v5.0.1
@@ -119,7 +119,7 @@ jobs:
       - name: Set up wasm-tools
         uses: bytecodealliance/actions/wasm-tools/setup@v1.1.0
         with:
-          version: v1.209.1
+          version: v1.210.0
 
       - name: Set up Wasmtime
         uses: bytecodealliance/actions/wasmtime/setup@v1.1.0

--- a/Makefile
+++ b/Makefile
@@ -5,4 +5,4 @@ json: $(wit_files)
 
 .PHONY: $(wit_files)
 $(wit_files):
-	wasm-tools component wit -j --features active $@ > $@.json
+	wasm-tools component wit -j --all-features $@ > $@.json

--- a/Makefile
+++ b/Makefile
@@ -5,4 +5,4 @@ json: $(wit_files)
 
 .PHONY: $(wit_files)
 $(wit_files):
-	wasm-tools component wit -j $@ > $@.json
+	wasm-tools component wit -j --features active $@ > $@.json

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+wit_files = $(sort $(shell find testdata -name '*.wit' ! -name '*.golden.*'))
+
+.PHONY: json
+json: $(wit_files)
+
+.PHONY: $(wit_files)
+$(wit_files):
+	wasm-tools component wit -j $@ > $@.json

--- a/testdata/escape/escaped-names.wit.json
+++ b/testdata/escape/escaped-names.wit.json
@@ -4,12 +4,16 @@
       "name": "world",
       "imports": {
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         }
       },
       "exports": {
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         }
       },
       "package": 0
@@ -22,7 +26,8 @@
         "error": 0,
         "export": 4,
         "enum": 5,
-        "record": 7
+        "record": 7,
+        "variant": 8
       },
       "functions": {
         "func": {
@@ -36,7 +41,7 @@
           ],
           "results": [
             {
-              "type": 8
+              "type": 9
             }
           ]
         }
@@ -185,6 +190,74 @@
             {
               "name": "result",
               "type": 6
+            }
+          ]
+        }
+      },
+      "owner": {
+        "interface": 0
+      }
+    },
+    {
+      "name": "variant",
+      "kind": {
+        "variant": {
+          "cases": [
+            {
+              "name": "enum",
+              "type": 7
+            },
+            {
+              "name": "export",
+              "type": 7
+            },
+            {
+              "name": "flags",
+              "type": 7
+            },
+            {
+              "name": "func",
+              "type": 7
+            },
+            {
+              "name": "import",
+              "type": 7
+            },
+            {
+              "name": "include",
+              "type": 7
+            },
+            {
+              "name": "interface",
+              "type": 7
+            },
+            {
+              "name": "package",
+              "type": 7
+            },
+            {
+              "name": "record",
+              "type": 7
+            },
+            {
+              "name": "resource",
+              "type": 7
+            },
+            {
+              "name": "static",
+              "type": 7
+            },
+            {
+              "name": "type",
+              "type": 7
+            },
+            {
+              "name": "variant",
+              "type": 7
+            },
+            {
+              "name": "world",
+              "type": 7
             }
           ]
         }

--- a/testdata/escape/escaped-names.wit.json.golden.wit
+++ b/testdata/escape/escaped-names.wit.json.golden.wit
@@ -26,6 +26,22 @@ interface %interface {
 		%enum: %enum,
 		%result: result<string, error>,
 	}
+	variant %variant {
+		%enum(%record),
+		%export(%record),
+		%flags(%record),
+		%func(%record),
+		%import(%record),
+		%include(%record),
+		%interface(%record),
+		%package(%record),
+		%record(%record),
+		%resource(%record),
+		%static(%record),
+		%type(%record),
+		%variant(%record),
+		%world(%record),
+	}
 	%func: func(rec: %record) -> result<%export, error>;
 }
 

--- a/testdata/example/aqua.wit.json
+++ b/testdata/example/aqua.wit.json
@@ -5,7 +5,9 @@
       "imports": {},
       "exports": {
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         }
       },
       "package": 0

--- a/testdata/example/exported-list.wit.json
+++ b/testdata/example/exported-list.wit.json
@@ -5,7 +5,9 @@
       "imports": {},
       "exports": {
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         }
       },
       "package": 0

--- a/testdata/example/exported-resource.wit.json
+++ b/testdata/example/exported-resource.wit.json
@@ -5,7 +5,9 @@
       "imports": {},
       "exports": {
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         }
       },
       "package": 0

--- a/testdata/example/flat-variant.wit.json
+++ b/testdata/example/flat-variant.wit.json
@@ -4,7 +4,9 @@
       "name": "imports",
       "imports": {
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         }
       },
       "exports": {},

--- a/testdata/example/non-flat-params.wit.json
+++ b/testdata/example/non-flat-params.wit.json
@@ -4,12 +4,16 @@
       "name": "imports",
       "imports": {
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         }
       },
       "exports": {
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         }
       },
       "package": 0

--- a/testdata/example/post-return.wit.json
+++ b/testdata/example/post-return.wit.json
@@ -5,7 +5,9 @@
       "imports": {},
       "exports": {
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         }
       },
       "package": 0

--- a/testdata/example/resource-in-world.wit.json
+++ b/testdata/example/resource-in-world.wit.json
@@ -4,12 +4,16 @@
       "name": "imports",
       "imports": {
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         }
       },
       "exports": {
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         }
       },
       "package": 0

--- a/testdata/example/use-of-export.wit.json
+++ b/testdata/example/use-of-export.wit.json
@@ -5,10 +5,14 @@
       "imports": {},
       "exports": {
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         },
         "interface-1": {
-          "interface": 1
+          "interface": {
+            "id": 1
+          }
         }
       },
       "package": 0
@@ -20,13 +24,27 @@
       "types": {
         "res": 0
       },
-      "functions": {},
+      "functions": {
+        "[method]res.do": {
+          "name": "[method]res.do",
+          "kind": {
+            "method": 0
+          },
+          "params": [
+            {
+              "name": "self",
+              "type": 1
+            }
+          ],
+          "results": []
+        }
+      },
       "package": 0
     },
     {
       "name": "f",
       "types": {
-        "res": 1
+        "res": 2
       },
       "functions": {
         "report": {
@@ -35,7 +53,7 @@
           "params": [
             {
               "name": "r",
-              "type": 2
+              "type": 3
             }
           ],
           "results": []
@@ -53,6 +71,15 @@
       }
     },
     {
+      "name": null,
+      "kind": {
+        "handle": {
+          "borrow": 0
+        }
+      },
+      "owner": null
+    },
+    {
       "name": "res",
       "kind": {
         "type": 0
@@ -65,7 +92,7 @@
       "name": null,
       "kind": {
         "handle": {
-          "own": 1
+          "own": 2
         }
       },
       "owner": null

--- a/testdata/example/use-of-export.wit.json.golden.wit
+++ b/testdata/example/use-of-export.wit.json.golden.wit
@@ -1,7 +1,9 @@
 package example:uses;
 
 interface a {
-	resource res;
+	resource res {
+		do: func();
+	}
 }
 
 interface f {

--- a/testdata/example/use-of-import-or-export.wit.json
+++ b/testdata/example/use-of-import-or-export.wit.json
@@ -4,21 +4,31 @@
       "name": "default",
       "imports": {
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         },
         "interface-1": {
-          "interface": 1
+          "interface": {
+            "id": 1
+          }
         }
       },
       "exports": {
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         },
         "interface-1": {
-          "interface": 1
+          "interface": {
+            "id": 1
+          }
         },
         "interface-2": {
-          "interface": 2
+          "interface": {
+            "id": 2
+          }
         }
       },
       "package": 0

--- a/testdata/example/use-of-import.wit.json
+++ b/testdata/example/use-of-import.wit.json
@@ -4,12 +4,16 @@
       "name": "default",
       "imports": {
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         }
       },
       "exports": {
         "interface-1": {
-          "interface": 1
+          "interface": {
+            "id": 1
+          }
         }
       },
       "package": 0
@@ -21,13 +25,27 @@
       "types": {
         "res": 0
       },
-      "functions": {},
+      "functions": {
+        "[method]res.do": {
+          "name": "[method]res.do",
+          "kind": {
+            "method": 0
+          },
+          "params": [
+            {
+              "name": "self",
+              "type": 1
+            }
+          ],
+          "results": []
+        }
+      },
       "package": 0
     },
     {
       "name": "f",
       "types": {
-        "res": 1
+        "res": 2
       },
       "functions": {
         "report": {
@@ -36,7 +54,7 @@
           "params": [
             {
               "name": "r",
-              "type": 2
+              "type": 3
             }
           ],
           "results": []
@@ -54,6 +72,15 @@
       }
     },
     {
+      "name": null,
+      "kind": {
+        "handle": {
+          "borrow": 0
+        }
+      },
+      "owner": null
+    },
+    {
       "name": "res",
       "kind": {
         "type": 0
@@ -66,7 +93,7 @@
       "name": null,
       "kind": {
         "handle": {
-          "own": 1
+          "own": 2
         }
       },
       "owner": null

--- a/testdata/example/use-of-import.wit.json.golden.wit
+++ b/testdata/example/use-of-import.wit.json.golden.wit
@@ -1,7 +1,9 @@
 package example:uses;
 
 interface a {
-	resource res;
+	resource res {
+		do: func();
+	}
 }
 
 interface f {

--- a/testdata/wasi/cli.wit.json
+++ b/testdata/wasi/cli.wit.json
@@ -4,13 +4,19 @@
       "name": "imports",
       "imports": {
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         },
         "interface-1": {
-          "interface": 1
+          "interface": {
+            "id": 1
+          }
         },
         "interface-2": {
-          "interface": 2
+          "interface": {
+            "id": 2
+          }
         }
       },
       "exports": {},
@@ -20,13 +26,19 @@
       "name": "imports",
       "imports": {
         "interface-1": {
-          "interface": 1
+          "interface": {
+            "id": 1
+          }
         },
         "interface-3": {
-          "interface": 3
+          "interface": {
+            "id": 3
+          }
         },
         "interface-4": {
-          "interface": 4
+          "interface": {
+            "id": 4
+          }
         }
       },
       "exports": {},
@@ -36,22 +48,34 @@
       "name": "imports",
       "imports": {
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         },
         "interface-1": {
-          "interface": 1
+          "interface": {
+            "id": 1
+          }
         },
         "interface-2": {
-          "interface": 2
+          "interface": {
+            "id": 2
+          }
         },
         "interface-4": {
-          "interface": 4
+          "interface": {
+            "id": 4
+          }
         },
         "interface-5": {
-          "interface": 5
+          "interface": {
+            "id": 5
+          }
         },
         "interface-6": {
-          "interface": 6
+          "interface": {
+            "id": 6
+          }
         }
       },
       "exports": {},
@@ -61,13 +85,19 @@
       "name": "imports",
       "imports": {
         "interface-9": {
-          "interface": 9
+          "interface": {
+            "id": 9
+          }
         },
         "interface-8": {
-          "interface": 8
+          "interface": {
+            "id": 8
+          }
         },
         "interface-7": {
-          "interface": 7
+          "interface": {
+            "id": 7
+          }
         }
       },
       "exports": {},
@@ -77,37 +107,59 @@
       "name": "imports",
       "imports": {
         "interface-10": {
-          "interface": 10
+          "interface": {
+            "id": 10
+          }
         },
         "interface-11": {
-          "interface": 11
+          "interface": {
+            "id": 11
+          }
         },
         "interface-1": {
-          "interface": 1
+          "interface": {
+            "id": 1
+          }
         },
         "interface-15": {
-          "interface": 15
+          "interface": {
+            "id": 15
+          }
         },
         "interface-16": {
-          "interface": 16
+          "interface": {
+            "id": 16
+          }
         },
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         },
         "interface-2": {
-          "interface": 2
+          "interface": {
+            "id": 2
+          }
         },
         "interface-3": {
-          "interface": 3
+          "interface": {
+            "id": 3
+          }
         },
         "interface-13": {
-          "interface": 13
+          "interface": {
+            "id": 13
+          }
         },
         "interface-14": {
-          "interface": 14
+          "interface": {
+            "id": 14
+          }
         },
         "interface-12": {
-          "interface": 12
+          "interface": {
+            "id": 12
+          }
         }
       },
       "exports": {},
@@ -117,85 +169,139 @@
       "name": "imports",
       "imports": {
         "interface-17": {
-          "interface": 17
+          "interface": {
+            "id": 17
+          }
         },
         "interface-18": {
-          "interface": 18
+          "interface": {
+            "id": 18
+          }
         },
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         },
         "interface-1": {
-          "interface": 1
+          "interface": {
+            "id": 1
+          }
         },
         "interface-2": {
-          "interface": 2
+          "interface": {
+            "id": 2
+          }
         },
         "interface-20": {
-          "interface": 20
+          "interface": {
+            "id": 20
+          }
         },
         "interface-21": {
-          "interface": 21
+          "interface": {
+            "id": 21
+          }
         },
         "interface-22": {
-          "interface": 22
+          "interface": {
+            "id": 22
+          }
         },
         "interface-23": {
-          "interface": 23
+          "interface": {
+            "id": 23
+          }
         },
         "interface-24": {
-          "interface": 24
+          "interface": {
+            "id": 24
+          }
         },
         "interface-25": {
-          "interface": 25
+          "interface": {
+            "id": 25
+          }
         },
         "interface-26": {
-          "interface": 26
+          "interface": {
+            "id": 26
+          }
         },
         "interface-27": {
-          "interface": 27
+          "interface": {
+            "id": 27
+          }
         },
         "interface-3": {
-          "interface": 3
+          "interface": {
+            "id": 3
+          }
         },
         "interface-4": {
-          "interface": 4
+          "interface": {
+            "id": 4
+          }
         },
         "interface-5": {
-          "interface": 5
+          "interface": {
+            "id": 5
+          }
         },
         "interface-6": {
-          "interface": 6
+          "interface": {
+            "id": 6
+          }
         },
         "interface-10": {
-          "interface": 10
+          "interface": {
+            "id": 10
+          }
         },
         "interface-11": {
-          "interface": 11
+          "interface": {
+            "id": 11
+          }
         },
         "interface-15": {
-          "interface": 15
+          "interface": {
+            "id": 15
+          }
         },
         "interface-16": {
-          "interface": 16
+          "interface": {
+            "id": 16
+          }
         },
         "interface-13": {
-          "interface": 13
+          "interface": {
+            "id": 13
+          }
         },
         "interface-14": {
-          "interface": 14
+          "interface": {
+            "id": 14
+          }
         },
         "interface-12": {
-          "interface": 12
+          "interface": {
+            "id": 12
+          }
         },
         "interface-9": {
-          "interface": 9
+          "interface": {
+            "id": 9
+          }
         },
         "interface-8": {
-          "interface": 8
+          "interface": {
+            "id": 8
+          }
         },
         "interface-7": {
-          "interface": 7
+          "interface": {
+            "id": 7
+          }
         }
       },
       "exports": {},
@@ -205,90 +311,146 @@
       "name": "command",
       "imports": {
         "interface-17": {
-          "interface": 17
+          "interface": {
+            "id": 17
+          }
         },
         "interface-18": {
-          "interface": 18
+          "interface": {
+            "id": 18
+          }
         },
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         },
         "interface-1": {
-          "interface": 1
+          "interface": {
+            "id": 1
+          }
         },
         "interface-2": {
-          "interface": 2
+          "interface": {
+            "id": 2
+          }
         },
         "interface-20": {
-          "interface": 20
+          "interface": {
+            "id": 20
+          }
         },
         "interface-21": {
-          "interface": 21
+          "interface": {
+            "id": 21
+          }
         },
         "interface-22": {
-          "interface": 22
+          "interface": {
+            "id": 22
+          }
         },
         "interface-23": {
-          "interface": 23
+          "interface": {
+            "id": 23
+          }
         },
         "interface-24": {
-          "interface": 24
+          "interface": {
+            "id": 24
+          }
         },
         "interface-25": {
-          "interface": 25
+          "interface": {
+            "id": 25
+          }
         },
         "interface-26": {
-          "interface": 26
+          "interface": {
+            "id": 26
+          }
         },
         "interface-27": {
-          "interface": 27
+          "interface": {
+            "id": 27
+          }
         },
         "interface-3": {
-          "interface": 3
+          "interface": {
+            "id": 3
+          }
         },
         "interface-4": {
-          "interface": 4
+          "interface": {
+            "id": 4
+          }
         },
         "interface-5": {
-          "interface": 5
+          "interface": {
+            "id": 5
+          }
         },
         "interface-6": {
-          "interface": 6
+          "interface": {
+            "id": 6
+          }
         },
         "interface-10": {
-          "interface": 10
+          "interface": {
+            "id": 10
+          }
         },
         "interface-11": {
-          "interface": 11
+          "interface": {
+            "id": 11
+          }
         },
         "interface-15": {
-          "interface": 15
+          "interface": {
+            "id": 15
+          }
         },
         "interface-16": {
-          "interface": 16
+          "interface": {
+            "id": 16
+          }
         },
         "interface-13": {
-          "interface": 13
+          "interface": {
+            "id": 13
+          }
         },
         "interface-14": {
-          "interface": 14
+          "interface": {
+            "id": 14
+          }
         },
         "interface-12": {
-          "interface": 12
+          "interface": {
+            "id": 12
+          }
         },
         "interface-9": {
-          "interface": 9
+          "interface": {
+            "id": 9
+          }
         },
         "interface-8": {
-          "interface": 8
+          "interface": {
+            "id": 8
+          }
         },
         "interface-7": {
-          "interface": 7
+          "interface": {
+            "id": 7
+          }
         }
       },
       "exports": {
         "interface-19": {
-          "interface": 19
+          "interface": {
+            "id": 19
+          }
         }
       },
       "package": 5

--- a/testdata/wasi/cli.wit.json.golden.wit
+++ b/testdata/wasi/cli.wit.json.golden.wit
@@ -1,312 +1,158 @@
-package wasi:io@0.2.0;
+package wasi:cli@0.2.0;
 
-interface error {
-	/// A resource which represents some error information.
+interface environment {
+	/// Get the POSIX-style environment variables.
 	///
-	/// The only method provided by this resource is `to-debug-string`,
-	/// which provides some human-readable information about the error.
+	/// Each environment variable is provided as a pair of string variable names
+	/// and string value.
 	///
-	/// In the `wasi:io` package, this resource is returned through the
-	/// `wasi:io/streams/stream-error` type.
-	///
-	/// To provide more specific error information, other interfaces may
-	/// provide functions to further "downcast" this error into more specific
-	/// error information. For example, `error`s returned in streams derived
-	/// from filesystem types to be described using the filesystem's own
-	/// error-code type, using the function
-	/// `wasi:filesystem/types/filesystem-error-code`, which takes a parameter
-	/// `borrow<error>` and returns
-	/// `option<wasi:filesystem/types/error-code>`.
-	///
-	/// The set of functions which can "downcast" an `error` into a more
-	/// concrete type is open.
-	resource error {
+	/// Morally, these are a value import, but until value imports are available
+	/// in the component model, this import function should return the same
+	/// values each time it is called.
+	get-environment: func() -> list<tuple<string, string>>;
 
-		/// Returns a string that is suitable to assist humans in debugging
-		/// this error.
-		///
-		/// WARNING: The returned string should not be consumed mechanically!
-		/// It may change across platforms, hosts, or other implementation
-		/// details. Parsing this string is a major platform-compatibility
-		/// hazard.
-		to-debug-string: func() -> string;
-	}
+	/// Get the POSIX-style arguments to the program.
+	get-arguments: func() -> list<string>;
+
+	/// Return a path that programs should use as their initial current working
+	/// directory, interpreting `.` as shorthand for this.
+	initial-cwd: func() -> option<string>;
 }
 
-/// A poll API intended to let users wait for I/O events on multiple handles
-/// at once.
-interface poll {
-	/// `pollable` represents a single I/O event which may be ready, or not.
-	resource pollable {
-
-		/// `block` returns immediately if the pollable is ready, and otherwise
-		/// blocks until ready.
-		///
-		/// This function is equivalent to calling `poll.poll` on a list
-		/// containing only this pollable.
-		block: func();
-
-		/// Return the readiness of a pollable. This function never blocks.
-		///
-		/// Returns `true` when the pollable is ready, and `false` otherwise.
-		ready: func() -> bool;
-	}
-
-	/// Poll for completion on a set of pollables.
-	///
-	/// This function takes a list of pollables, which identify I/O sources of
-	/// interest, and waits until one or more of the events is ready for I/O.
-	///
-	/// The result `list<u32>` contains one or more indices of handles in the
-	/// argument list that is ready for I/O.
-	///
-	/// If the list contains more elements than can be indexed with a `u32`
-	/// value, this function traps.
-	///
-	/// A timeout can be implemented by adding a pollable from the
-	/// wasi-clocks API to the list.
-	///
-	/// This function does not return a `result`; polling in itself does not
-	/// do any I/O so it doesn't fail. If any of the I/O sources identified by
-	/// the pollables has an error, it is indicated by marking the source as
-	/// being reaedy for I/O.
-	poll: func(in: list<borrow<pollable>>) -> list<u32>;
+interface exit {
+	/// Exit the current instance and any linked instances.
+	exit: func(status: result);
 }
 
-/// WASI I/O is an I/O abstraction API which is currently focused on providing
-/// stream types.
+interface run {
+	/// Run the program.
+	run: func() -> result;
+}
+
+interface stdin {
+	use wasi:io/streams@0.2.0.{input-stream};
+	get-stdin: func() -> input-stream;
+}
+
+interface stdout {
+	use wasi:io/streams@0.2.0.{output-stream};
+	get-stdout: func() -> output-stream;
+}
+
+interface stderr {
+	use wasi:io/streams@0.2.0.{output-stream};
+	get-stderr: func() -> output-stream;
+}
+
+/// Terminal input.
 ///
-/// In the future, the component model is expected to add built-in stream types;
-/// when it does, they are expected to subsume this API.
-interface streams {
-	use error.{error};
-	use poll.{pollable};
+/// In the future, this may include functions for disabling echoing,
+/// disabling input buffering so that keyboard events are sent through
+/// immediately, querying supported features, and so on.
+interface terminal-input {
+	/// The input side of a terminal.
+	resource terminal-input;
+}
 
-	/// An error for input-stream and output-stream operations.
-	variant stream-error {
-		/// The last operation (a write or flush) failed before completion.
-		///
-		/// More information is available in the `error` payload.
-		last-operation-failed(error),
-		/// The stream is closed: no more input will be accepted by the
-		/// stream. A closed output-stream will return this error on all
-		/// future operations.
-		closed,
-	}
+/// Terminal output.
+///
+/// In the future, this may include functions for querying the terminal
+/// size, being notified of terminal size changes, querying supported
+/// features, and so on.
+interface terminal-output {
+	/// The output side of a terminal.
+	resource terminal-output;
+}
 
-	/// An input bytestream.
-	///
-	/// `input-stream`s are *non-blocking* to the extent practical on underlying
-	/// platforms. I/O operations always return promptly; if fewer bytes are
-	/// promptly available than requested, they return the number of bytes promptly
-	/// available, which could even be zero. To wait for data to be available,
-	/// use the `subscribe` function to obtain a `pollable` which can be polled
-	/// for using `wasi:io/poll`.
-	resource input-stream {
+/// An interface providing an optional `terminal-input` for stdin as a
+/// link-time authority.
+interface terminal-stdin {
+	use terminal-input.{terminal-input};
 
-		/// Read bytes from a stream, after blocking until at least one byte can
-		/// be read. Except for blocking, behavior is identical to `read`.
-		blocking-read: func(len: u64) -> result<list<u8>, stream-error>;
+	/// If stdin is connected to a terminal, return a `terminal-input` handle
+	/// allowing further interaction with it.
+	get-terminal-stdin: func() -> option<terminal-input>;
+}
 
-		/// Skip bytes from a stream, after blocking until at least one byte
-		/// can be skipped. Except for blocking behavior, identical to `skip`.
-		blocking-skip: func(len: u64) -> result<u64, stream-error>;
+/// An interface providing an optional `terminal-output` for stdout as a
+/// link-time authority.
+interface terminal-stdout {
+	use terminal-output.{terminal-output};
 
-		/// Perform a non-blocking read from the stream.
-		///
-		/// When the source of a `read` is binary data, the bytes from the source
-		/// are returned verbatim. When the source of a `read` is known to the
-		/// implementation to be text, bytes containing the UTF-8 encoding of the
-		/// text are returned.
-		///
-		/// This function returns a list of bytes containing the read data,
-		/// when successful. The returned list will contain up to `len` bytes;
-		/// it may return fewer than requested, but not more. The list is
-		/// empty when no bytes are available for reading at this time. The
-		/// pollable given by `subscribe` will be ready when more bytes are
-		/// available.
-		///
-		/// This function fails with a `stream-error` when the operation
-		/// encounters an error, giving `last-operation-failed`, or when the
-		/// stream is closed, giving `closed`.
-		///
-		/// When the caller gives a `len` of 0, it represents a request to
-		/// read 0 bytes. If the stream is still open, this call should
-		/// succeed and return an empty list, or otherwise fail with `closed`.
-		///
-		/// The `len` parameter is a `u64`, which could represent a list of u8 which
-		/// is not possible to allocate in wasm32, or not desirable to allocate as
-		/// as a return value by the callee. The callee may return a list of bytes
-		/// less than `len` in size while more bytes are available for reading.
-		read: func(len: u64) -> result<list<u8>, stream-error>;
+	/// If stdout is connected to a terminal, return a `terminal-output` handle
+	/// allowing further interaction with it.
+	get-terminal-stdout: func() -> option<terminal-output>;
+}
 
-		/// Skip bytes from a stream. Returns number of bytes skipped.
-		///
-		/// Behaves identical to `read`, except instead of returning a list
-		/// of bytes, returns the number of bytes consumed from the stream.
-		skip: func(len: u64) -> result<u64, stream-error>;
+/// An interface providing an optional `terminal-output` for stderr as a
+/// link-time authority.
+interface terminal-stderr {
+	use terminal-output.{terminal-output};
 
-		/// Create a `pollable` which will resolve once either the specified stream
-		/// has bytes available to read or the other end of the stream has been
-		/// closed.
-		/// The created `pollable` is a child resource of the `input-stream`.
-		/// Implementations may trap if the `input-stream` is dropped before
-		/// all derived `pollable`s created with this function are dropped.
-		subscribe: func() -> pollable;
-	}
-
-	/// An output bytestream.
-	///
-	/// `output-stream`s are *non-blocking* to the extent practical on
-	/// underlying platforms. Except where specified otherwise, I/O operations also
-	/// always return promptly, after the number of bytes that can be written
-	/// promptly, which could even be zero. To wait for the stream to be ready to
-	/// accept data, the `subscribe` function to obtain a `pollable` which can be
-	/// polled for using `wasi:io/poll`.
-	resource output-stream {
-
-		/// Request to flush buffered output, and block until flush completes
-		/// and stream is ready for writing again.
-		blocking-flush: func() -> result<_, stream-error>;
-
-		/// Read from one stream and write to another, with blocking.
-		///
-		/// This is similar to `splice`, except that it blocks until the
-		/// `output-stream` is ready for writing, and the `input-stream`
-		/// is ready for reading, before performing the `splice`.
-		blocking-splice: func(src: borrow<input-stream>, len: u64) -> result<u64, stream-error>;
-
-		/// Perform a write of up to 4096 bytes, and then flush the stream. Block
-		/// until all of these operations are complete, or an error occurs.
-		///
-		/// This is a convenience wrapper around the use of `check-write`,
-		/// `subscribe`, `write`, and `flush`, and is implemented with the
-		/// following pseudo-code:
-		///
-		/// ```text
-		/// let pollable = this.subscribe();
-		/// while !contents.is_empty() {
-		/// // Wait for the stream to become writable
-		/// pollable.block();
-		/// let Ok(n) = this.check-write(); // eliding error handling
-		/// let len = min(n, contents.len());
-		/// let (chunk, rest) = contents.split_at(len);
-		/// this.write(chunk  );            // eliding error handling
-		/// contents = rest;
-		/// }
-		/// this.flush();
-		/// // Wait for completion of `flush`
-		/// pollable.block();
-		/// // Check for any errors that arose during `flush`
-		/// let _ = this.check-write();         // eliding error handling
-		/// ```
-		blocking-write-and-flush: func(contents: list<u8>) -> result<_, stream-error>;
-
-		/// Perform a write of up to 4096 zeroes, and then flush the stream.
-		/// Block until all of these operations are complete, or an error
-		/// occurs.
-		///
-		/// This is a convenience wrapper around the use of `check-write`,
-		/// `subscribe`, `write-zeroes`, and `flush`, and is implemented with
-		/// the following pseudo-code:
-		///
-		/// ```text
-		/// let pollable = this.subscribe();
-		/// while num_zeroes != 0 {
-		/// // Wait for the stream to become writable
-		/// pollable.block();
-		/// let Ok(n) = this.check-write(); // eliding error handling
-		/// let len = min(n, num_zeroes);
-		/// this.write-zeroes(len);         // eliding error handling
-		/// num_zeroes -= len;
-		/// }
-		/// this.flush();
-		/// // Wait for completion of `flush`
-		/// pollable.block();
-		/// // Check for any errors that arose during `flush`
-		/// let _ = this.check-write();         // eliding error handling
-		/// ```
-		blocking-write-zeroes-and-flush: func(len: u64) -> result<_, stream-error>;
-
-		/// Check readiness for writing. This function never blocks.
-		///
-		/// Returns the number of bytes permitted for the next call to `write`,
-		/// or an error. Calling `write` with more bytes than this function has
-		/// permitted will trap.
-		///
-		/// When this function returns 0 bytes, the `subscribe` pollable will
-		/// become ready when this function will report at least 1 byte, or an
-		/// error.
-		check-write: func() -> result<u64, stream-error>;
-
-		/// Request to flush buffered output. This function never blocks.
-		///
-		/// This tells the output-stream that the caller intends any buffered
-		/// output to be flushed. the output which is expected to be flushed
-		/// is all that has been passed to `write` prior to this call.
-		///
-		/// Upon calling this function, the `output-stream` will not accept any
-		/// writes (`check-write` will return `ok(0)`) until the flush has
-		/// completed. The `subscribe` pollable will become ready when the
-		/// flush has completed and the stream can accept more writes.
-		flush: func() -> result<_, stream-error>;
-
-		/// Read from one stream and write to another.
-		///
-		/// The behavior of splice is equivelant to:
-		/// 1. calling `check-write` on the `output-stream`
-		/// 2. calling `read` on the `input-stream` with the smaller of the
-		/// `check-write` permitted length and the `len` provided to `splice`
-		/// 3. calling `write` on the `output-stream` with that read data.
-		///
-		/// Any error reported by the call to `check-write`, `read`, or
-		/// `write` ends the splice and reports that error.
-		///
-		/// This function returns the number of bytes transferred; it may be less
-		/// than `len`.
-		splice: func(src: borrow<input-stream>, len: u64) -> result<u64, stream-error>;
-
-		/// Create a `pollable` which will resolve once the output-stream
-		/// is ready for more writing, or an error has occured. When this
-		/// pollable is ready, `check-write` will return `ok(n)` with n>0, or an
-		/// error.
-		///
-		/// If the stream is closed, this pollable is always ready immediately.
-		///
-		/// The created `pollable` is a child resource of the `output-stream`.
-		/// Implementations may trap if the `output-stream` is dropped before
-		/// all derived `pollable`s created with this function are dropped.
-		subscribe: func() -> pollable;
-
-		/// Perform a write. This function never blocks.
-		///
-		/// When the destination of a `write` is binary data, the bytes from
-		/// `contents` are written verbatim. When the destination of a `write` is
-		/// known to the implementation to be text, the bytes of `contents` are
-		/// transcoded from UTF-8 into the encoding of the destination and then
-		/// written.
-		///
-		/// Precondition: check-write gave permit of Ok(n) and contents has a
-		/// length of less than or equal to n. Otherwise, this function will trap.
-		///
-		/// returns Err(closed) without writing if the stream has closed since
-		/// the last call to check-write provided a permit.
-		write: func(contents: list<u8>) -> result<_, stream-error>;
-
-		/// Write zeroes to a stream.
-		///
-		/// This should be used precisely like `write` with the exact same
-		/// preconditions (must use check-write first), but instead of
-		/// passing a list of bytes, you simply pass the number of zero-bytes
-		/// that should be written.
-		write-zeroes: func(len: u64) -> result<_, stream-error>;
-	}
+	/// If stderr is connected to a terminal, return a `terminal-output` handle
+	/// allowing further interaction with it.
+	get-terminal-stderr: func() -> option<terminal-output>;
 }
 
 world imports {
-	import error;
-	import poll;
-	import streams;
+	import environment;
+	import exit;
+	import wasi:io/error@0.2.0;
+	import wasi:io/poll@0.2.0;
+	import wasi:io/streams@0.2.0;
+	import stdin;
+	import stdout;
+	import stderr;
+	import terminal-input;
+	import terminal-output;
+	import terminal-stdin;
+	import terminal-stdout;
+	import terminal-stderr;
+	import wasi:clocks/monotonic-clock@0.2.0;
+	import wasi:clocks/wall-clock@0.2.0;
+	import wasi:filesystem/types@0.2.0;
+	import wasi:filesystem/preopens@0.2.0;
+	import wasi:sockets/network@0.2.0;
+	import wasi:sockets/instance-network@0.2.0;
+	import wasi:sockets/udp@0.2.0;
+	import wasi:sockets/udp-create-socket@0.2.0;
+	import wasi:sockets/tcp@0.2.0;
+	import wasi:sockets/tcp-create-socket@0.2.0;
+	import wasi:sockets/ip-name-lookup@0.2.0;
+	import wasi:random/random@0.2.0;
+	import wasi:random/insecure@0.2.0;
+	import wasi:random/insecure-seed@0.2.0;
+}
+
+world command {
+	import environment;
+	import exit;
+	import wasi:io/error@0.2.0;
+	import wasi:io/poll@0.2.0;
+	import wasi:io/streams@0.2.0;
+	import stdin;
+	import stdout;
+	import stderr;
+	import terminal-input;
+	import terminal-output;
+	import terminal-stdin;
+	import terminal-stdout;
+	import terminal-stderr;
+	import wasi:clocks/monotonic-clock@0.2.0;
+	import wasi:clocks/wall-clock@0.2.0;
+	import wasi:filesystem/types@0.2.0;
+	import wasi:filesystem/preopens@0.2.0;
+	import wasi:sockets/network@0.2.0;
+	import wasi:sockets/instance-network@0.2.0;
+	import wasi:sockets/udp@0.2.0;
+	import wasi:sockets/udp-create-socket@0.2.0;
+	import wasi:sockets/tcp@0.2.0;
+	import wasi:sockets/tcp-create-socket@0.2.0;
+	import wasi:sockets/ip-name-lookup@0.2.0;
+	import wasi:random/random@0.2.0;
+	import wasi:random/insecure@0.2.0;
+	import wasi:random/insecure-seed@0.2.0;
+	export run;
 }
 
 
@@ -967,6 +813,318 @@ world imports {
 	import wasi:clocks/wall-clock@0.2.0;
 	import types;
 	import preopens;
+}
+
+
+package wasi:io@0.2.0;
+
+interface error {
+	/// A resource which represents some error information.
+	///
+	/// The only method provided by this resource is `to-debug-string`,
+	/// which provides some human-readable information about the error.
+	///
+	/// In the `wasi:io` package, this resource is returned through the
+	/// `wasi:io/streams/stream-error` type.
+	///
+	/// To provide more specific error information, other interfaces may
+	/// provide functions to further "downcast" this error into more specific
+	/// error information. For example, `error`s returned in streams derived
+	/// from filesystem types to be described using the filesystem's own
+	/// error-code type, using the function
+	/// `wasi:filesystem/types/filesystem-error-code`, which takes a parameter
+	/// `borrow<error>` and returns
+	/// `option<wasi:filesystem/types/error-code>`.
+	///
+	/// The set of functions which can "downcast" an `error` into a more
+	/// concrete type is open.
+	resource error {
+
+		/// Returns a string that is suitable to assist humans in debugging
+		/// this error.
+		///
+		/// WARNING: The returned string should not be consumed mechanically!
+		/// It may change across platforms, hosts, or other implementation
+		/// details. Parsing this string is a major platform-compatibility
+		/// hazard.
+		to-debug-string: func() -> string;
+	}
+}
+
+/// A poll API intended to let users wait for I/O events on multiple handles
+/// at once.
+interface poll {
+	/// `pollable` represents a single I/O event which may be ready, or not.
+	resource pollable {
+
+		/// `block` returns immediately if the pollable is ready, and otherwise
+		/// blocks until ready.
+		///
+		/// This function is equivalent to calling `poll.poll` on a list
+		/// containing only this pollable.
+		block: func();
+
+		/// Return the readiness of a pollable. This function never blocks.
+		///
+		/// Returns `true` when the pollable is ready, and `false` otherwise.
+		ready: func() -> bool;
+	}
+
+	/// Poll for completion on a set of pollables.
+	///
+	/// This function takes a list of pollables, which identify I/O sources of
+	/// interest, and waits until one or more of the events is ready for I/O.
+	///
+	/// The result `list<u32>` contains one or more indices of handles in the
+	/// argument list that is ready for I/O.
+	///
+	/// If the list contains more elements than can be indexed with a `u32`
+	/// value, this function traps.
+	///
+	/// A timeout can be implemented by adding a pollable from the
+	/// wasi-clocks API to the list.
+	///
+	/// This function does not return a `result`; polling in itself does not
+	/// do any I/O so it doesn't fail. If any of the I/O sources identified by
+	/// the pollables has an error, it is indicated by marking the source as
+	/// being reaedy for I/O.
+	poll: func(in: list<borrow<pollable>>) -> list<u32>;
+}
+
+/// WASI I/O is an I/O abstraction API which is currently focused on providing
+/// stream types.
+///
+/// In the future, the component model is expected to add built-in stream types;
+/// when it does, they are expected to subsume this API.
+interface streams {
+	use error.{error};
+	use poll.{pollable};
+
+	/// An error for input-stream and output-stream operations.
+	variant stream-error {
+		/// The last operation (a write or flush) failed before completion.
+		///
+		/// More information is available in the `error` payload.
+		last-operation-failed(error),
+		/// The stream is closed: no more input will be accepted by the
+		/// stream. A closed output-stream will return this error on all
+		/// future operations.
+		closed,
+	}
+
+	/// An input bytestream.
+	///
+	/// `input-stream`s are *non-blocking* to the extent practical on underlying
+	/// platforms. I/O operations always return promptly; if fewer bytes are
+	/// promptly available than requested, they return the number of bytes promptly
+	/// available, which could even be zero. To wait for data to be available,
+	/// use the `subscribe` function to obtain a `pollable` which can be polled
+	/// for using `wasi:io/poll`.
+	resource input-stream {
+
+		/// Read bytes from a stream, after blocking until at least one byte can
+		/// be read. Except for blocking, behavior is identical to `read`.
+		blocking-read: func(len: u64) -> result<list<u8>, stream-error>;
+
+		/// Skip bytes from a stream, after blocking until at least one byte
+		/// can be skipped. Except for blocking behavior, identical to `skip`.
+		blocking-skip: func(len: u64) -> result<u64, stream-error>;
+
+		/// Perform a non-blocking read from the stream.
+		///
+		/// When the source of a `read` is binary data, the bytes from the source
+		/// are returned verbatim. When the source of a `read` is known to the
+		/// implementation to be text, bytes containing the UTF-8 encoding of the
+		/// text are returned.
+		///
+		/// This function returns a list of bytes containing the read data,
+		/// when successful. The returned list will contain up to `len` bytes;
+		/// it may return fewer than requested, but not more. The list is
+		/// empty when no bytes are available for reading at this time. The
+		/// pollable given by `subscribe` will be ready when more bytes are
+		/// available.
+		///
+		/// This function fails with a `stream-error` when the operation
+		/// encounters an error, giving `last-operation-failed`, or when the
+		/// stream is closed, giving `closed`.
+		///
+		/// When the caller gives a `len` of 0, it represents a request to
+		/// read 0 bytes. If the stream is still open, this call should
+		/// succeed and return an empty list, or otherwise fail with `closed`.
+		///
+		/// The `len` parameter is a `u64`, which could represent a list of u8 which
+		/// is not possible to allocate in wasm32, or not desirable to allocate as
+		/// as a return value by the callee. The callee may return a list of bytes
+		/// less than `len` in size while more bytes are available for reading.
+		read: func(len: u64) -> result<list<u8>, stream-error>;
+
+		/// Skip bytes from a stream. Returns number of bytes skipped.
+		///
+		/// Behaves identical to `read`, except instead of returning a list
+		/// of bytes, returns the number of bytes consumed from the stream.
+		skip: func(len: u64) -> result<u64, stream-error>;
+
+		/// Create a `pollable` which will resolve once either the specified stream
+		/// has bytes available to read or the other end of the stream has been
+		/// closed.
+		/// The created `pollable` is a child resource of the `input-stream`.
+		/// Implementations may trap if the `input-stream` is dropped before
+		/// all derived `pollable`s created with this function are dropped.
+		subscribe: func() -> pollable;
+	}
+
+	/// An output bytestream.
+	///
+	/// `output-stream`s are *non-blocking* to the extent practical on
+	/// underlying platforms. Except where specified otherwise, I/O operations also
+	/// always return promptly, after the number of bytes that can be written
+	/// promptly, which could even be zero. To wait for the stream to be ready to
+	/// accept data, the `subscribe` function to obtain a `pollable` which can be
+	/// polled for using `wasi:io/poll`.
+	resource output-stream {
+
+		/// Request to flush buffered output, and block until flush completes
+		/// and stream is ready for writing again.
+		blocking-flush: func() -> result<_, stream-error>;
+
+		/// Read from one stream and write to another, with blocking.
+		///
+		/// This is similar to `splice`, except that it blocks until the
+		/// `output-stream` is ready for writing, and the `input-stream`
+		/// is ready for reading, before performing the `splice`.
+		blocking-splice: func(src: borrow<input-stream>, len: u64) -> result<u64, stream-error>;
+
+		/// Perform a write of up to 4096 bytes, and then flush the stream. Block
+		/// until all of these operations are complete, or an error occurs.
+		///
+		/// This is a convenience wrapper around the use of `check-write`,
+		/// `subscribe`, `write`, and `flush`, and is implemented with the
+		/// following pseudo-code:
+		///
+		/// ```text
+		/// let pollable = this.subscribe();
+		/// while !contents.is_empty() {
+		/// // Wait for the stream to become writable
+		/// pollable.block();
+		/// let Ok(n) = this.check-write(); // eliding error handling
+		/// let len = min(n, contents.len());
+		/// let (chunk, rest) = contents.split_at(len);
+		/// this.write(chunk  );            // eliding error handling
+		/// contents = rest;
+		/// }
+		/// this.flush();
+		/// // Wait for completion of `flush`
+		/// pollable.block();
+		/// // Check for any errors that arose during `flush`
+		/// let _ = this.check-write();         // eliding error handling
+		/// ```
+		blocking-write-and-flush: func(contents: list<u8>) -> result<_, stream-error>;
+
+		/// Perform a write of up to 4096 zeroes, and then flush the stream.
+		/// Block until all of these operations are complete, or an error
+		/// occurs.
+		///
+		/// This is a convenience wrapper around the use of `check-write`,
+		/// `subscribe`, `write-zeroes`, and `flush`, and is implemented with
+		/// the following pseudo-code:
+		///
+		/// ```text
+		/// let pollable = this.subscribe();
+		/// while num_zeroes != 0 {
+		/// // Wait for the stream to become writable
+		/// pollable.block();
+		/// let Ok(n) = this.check-write(); // eliding error handling
+		/// let len = min(n, num_zeroes);
+		/// this.write-zeroes(len);         // eliding error handling
+		/// num_zeroes -= len;
+		/// }
+		/// this.flush();
+		/// // Wait for completion of `flush`
+		/// pollable.block();
+		/// // Check for any errors that arose during `flush`
+		/// let _ = this.check-write();         // eliding error handling
+		/// ```
+		blocking-write-zeroes-and-flush: func(len: u64) -> result<_, stream-error>;
+
+		/// Check readiness for writing. This function never blocks.
+		///
+		/// Returns the number of bytes permitted for the next call to `write`,
+		/// or an error. Calling `write` with more bytes than this function has
+		/// permitted will trap.
+		///
+		/// When this function returns 0 bytes, the `subscribe` pollable will
+		/// become ready when this function will report at least 1 byte, or an
+		/// error.
+		check-write: func() -> result<u64, stream-error>;
+
+		/// Request to flush buffered output. This function never blocks.
+		///
+		/// This tells the output-stream that the caller intends any buffered
+		/// output to be flushed. the output which is expected to be flushed
+		/// is all that has been passed to `write` prior to this call.
+		///
+		/// Upon calling this function, the `output-stream` will not accept any
+		/// writes (`check-write` will return `ok(0)`) until the flush has
+		/// completed. The `subscribe` pollable will become ready when the
+		/// flush has completed and the stream can accept more writes.
+		flush: func() -> result<_, stream-error>;
+
+		/// Read from one stream and write to another.
+		///
+		/// The behavior of splice is equivelant to:
+		/// 1. calling `check-write` on the `output-stream`
+		/// 2. calling `read` on the `input-stream` with the smaller of the
+		/// `check-write` permitted length and the `len` provided to `splice`
+		/// 3. calling `write` on the `output-stream` with that read data.
+		///
+		/// Any error reported by the call to `check-write`, `read`, or
+		/// `write` ends the splice and reports that error.
+		///
+		/// This function returns the number of bytes transferred; it may be less
+		/// than `len`.
+		splice: func(src: borrow<input-stream>, len: u64) -> result<u64, stream-error>;
+
+		/// Create a `pollable` which will resolve once the output-stream
+		/// is ready for more writing, or an error has occured. When this
+		/// pollable is ready, `check-write` will return `ok(n)` with n>0, or an
+		/// error.
+		///
+		/// If the stream is closed, this pollable is always ready immediately.
+		///
+		/// The created `pollable` is a child resource of the `output-stream`.
+		/// Implementations may trap if the `output-stream` is dropped before
+		/// all derived `pollable`s created with this function are dropped.
+		subscribe: func() -> pollable;
+
+		/// Perform a write. This function never blocks.
+		///
+		/// When the destination of a `write` is binary data, the bytes from
+		/// `contents` are written verbatim. When the destination of a `write` is
+		/// known to the implementation to be text, the bytes of `contents` are
+		/// transcoded from UTF-8 into the encoding of the destination and then
+		/// written.
+		///
+		/// Precondition: check-write gave permit of Ok(n) and contents has a
+		/// length of less than or equal to n. Otherwise, this function will trap.
+		///
+		/// returns Err(closed) without writing if the stream has closed since
+		/// the last call to check-write provided a permit.
+		write: func(contents: list<u8>) -> result<_, stream-error>;
+
+		/// Write zeroes to a stream.
+		///
+		/// This should be used precisely like `write` with the exact same
+		/// preconditions (must use check-write first), but instead of
+		/// passing a list of bytes, you simply pass the number of zero-bytes
+		/// that should be written.
+		write-zeroes: func(len: u64) -> result<_, stream-error>;
+	}
+}
+
+world imports {
+	import error;
+	import poll;
+	import streams;
 }
 
 
@@ -2014,162 +2172,4 @@ world imports {
 	import tcp;
 	import tcp-create-socket;
 	import ip-name-lookup;
-}
-
-
-package wasi:cli@0.2.0;
-
-interface environment {
-	/// Get the POSIX-style environment variables.
-	///
-	/// Each environment variable is provided as a pair of string variable names
-	/// and string value.
-	///
-	/// Morally, these are a value import, but until value imports are available
-	/// in the component model, this import function should return the same
-	/// values each time it is called.
-	get-environment: func() -> list<tuple<string, string>>;
-
-	/// Get the POSIX-style arguments to the program.
-	get-arguments: func() -> list<string>;
-
-	/// Return a path that programs should use as their initial current working
-	/// directory, interpreting `.` as shorthand for this.
-	initial-cwd: func() -> option<string>;
-}
-
-interface exit {
-	/// Exit the current instance and any linked instances.
-	exit: func(status: result);
-}
-
-interface run {
-	/// Run the program.
-	run: func() -> result;
-}
-
-interface stdin {
-	use wasi:io/streams@0.2.0.{input-stream};
-	get-stdin: func() -> input-stream;
-}
-
-interface stdout {
-	use wasi:io/streams@0.2.0.{output-stream};
-	get-stdout: func() -> output-stream;
-}
-
-interface stderr {
-	use wasi:io/streams@0.2.0.{output-stream};
-	get-stderr: func() -> output-stream;
-}
-
-/// Terminal input.
-///
-/// In the future, this may include functions for disabling echoing,
-/// disabling input buffering so that keyboard events are sent through
-/// immediately, querying supported features, and so on.
-interface terminal-input {
-	/// The input side of a terminal.
-	resource terminal-input;
-}
-
-/// Terminal output.
-///
-/// In the future, this may include functions for querying the terminal
-/// size, being notified of terminal size changes, querying supported
-/// features, and so on.
-interface terminal-output {
-	/// The output side of a terminal.
-	resource terminal-output;
-}
-
-/// An interface providing an optional `terminal-input` for stdin as a
-/// link-time authority.
-interface terminal-stdin {
-	use terminal-input.{terminal-input};
-
-	/// If stdin is connected to a terminal, return a `terminal-input` handle
-	/// allowing further interaction with it.
-	get-terminal-stdin: func() -> option<terminal-input>;
-}
-
-/// An interface providing an optional `terminal-output` for stdout as a
-/// link-time authority.
-interface terminal-stdout {
-	use terminal-output.{terminal-output};
-
-	/// If stdout is connected to a terminal, return a `terminal-output` handle
-	/// allowing further interaction with it.
-	get-terminal-stdout: func() -> option<terminal-output>;
-}
-
-/// An interface providing an optional `terminal-output` for stderr as a
-/// link-time authority.
-interface terminal-stderr {
-	use terminal-output.{terminal-output};
-
-	/// If stderr is connected to a terminal, return a `terminal-output` handle
-	/// allowing further interaction with it.
-	get-terminal-stderr: func() -> option<terminal-output>;
-}
-
-world imports {
-	import environment;
-	import exit;
-	import wasi:io/error@0.2.0;
-	import wasi:io/poll@0.2.0;
-	import wasi:io/streams@0.2.0;
-	import stdin;
-	import stdout;
-	import stderr;
-	import terminal-input;
-	import terminal-output;
-	import terminal-stdin;
-	import terminal-stdout;
-	import terminal-stderr;
-	import wasi:clocks/monotonic-clock@0.2.0;
-	import wasi:clocks/wall-clock@0.2.0;
-	import wasi:filesystem/types@0.2.0;
-	import wasi:filesystem/preopens@0.2.0;
-	import wasi:sockets/network@0.2.0;
-	import wasi:sockets/instance-network@0.2.0;
-	import wasi:sockets/udp@0.2.0;
-	import wasi:sockets/udp-create-socket@0.2.0;
-	import wasi:sockets/tcp@0.2.0;
-	import wasi:sockets/tcp-create-socket@0.2.0;
-	import wasi:sockets/ip-name-lookup@0.2.0;
-	import wasi:random/random@0.2.0;
-	import wasi:random/insecure@0.2.0;
-	import wasi:random/insecure-seed@0.2.0;
-}
-
-world command {
-	import environment;
-	import exit;
-	import wasi:io/error@0.2.0;
-	import wasi:io/poll@0.2.0;
-	import wasi:io/streams@0.2.0;
-	import stdin;
-	import stdout;
-	import stderr;
-	import terminal-input;
-	import terminal-output;
-	import terminal-stdin;
-	import terminal-stdout;
-	import terminal-stderr;
-	import wasi:clocks/monotonic-clock@0.2.0;
-	import wasi:clocks/wall-clock@0.2.0;
-	import wasi:filesystem/types@0.2.0;
-	import wasi:filesystem/preopens@0.2.0;
-	import wasi:sockets/network@0.2.0;
-	import wasi:sockets/instance-network@0.2.0;
-	import wasi:sockets/udp@0.2.0;
-	import wasi:sockets/udp-create-socket@0.2.0;
-	import wasi:sockets/tcp@0.2.0;
-	import wasi:sockets/tcp-create-socket@0.2.0;
-	import wasi:sockets/ip-name-lookup@0.2.0;
-	import wasi:random/random@0.2.0;
-	import wasi:random/insecure@0.2.0;
-	import wasi:random/insecure-seed@0.2.0;
-	export run;
 }

--- a/testdata/wasi/http.wit.json
+++ b/testdata/wasi/http.wit.json
@@ -4,13 +4,19 @@
       "name": "imports",
       "imports": {
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         },
         "interface-1": {
-          "interface": 1
+          "interface": {
+            "id": 1
+          }
         },
         "interface-2": {
-          "interface": 2
+          "interface": {
+            "id": 2
+          }
         }
       },
       "exports": {},
@@ -20,13 +26,19 @@
       "name": "imports",
       "imports": {
         "interface-1": {
-          "interface": 1
+          "interface": {
+            "id": 1
+          }
         },
         "interface-3": {
-          "interface": 3
+          "interface": {
+            "id": 3
+          }
         },
         "interface-4": {
-          "interface": 4
+          "interface": {
+            "id": 4
+          }
         }
       },
       "exports": {},
@@ -36,22 +48,34 @@
       "name": "imports",
       "imports": {
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         },
         "interface-1": {
-          "interface": 1
+          "interface": {
+            "id": 1
+          }
         },
         "interface-2": {
-          "interface": 2
+          "interface": {
+            "id": 2
+          }
         },
         "interface-4": {
-          "interface": 4
+          "interface": {
+            "id": 4
+          }
         },
         "interface-5": {
-          "interface": 5
+          "interface": {
+            "id": 5
+          }
         },
         "interface-6": {
-          "interface": 6
+          "interface": {
+            "id": 6
+          }
         }
       },
       "exports": {},
@@ -61,37 +85,59 @@
       "name": "imports",
       "imports": {
         "interface-7": {
-          "interface": 7
+          "interface": {
+            "id": 7
+          }
         },
         "interface-8": {
-          "interface": 8
+          "interface": {
+            "id": 8
+          }
         },
         "interface-1": {
-          "interface": 1
+          "interface": {
+            "id": 1
+          }
         },
         "interface-12": {
-          "interface": 12
+          "interface": {
+            "id": 12
+          }
         },
         "interface-13": {
-          "interface": 13
+          "interface": {
+            "id": 13
+          }
         },
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         },
         "interface-2": {
-          "interface": 2
+          "interface": {
+            "id": 2
+          }
         },
         "interface-3": {
-          "interface": 3
+          "interface": {
+            "id": 3
+          }
         },
         "interface-10": {
-          "interface": 10
+          "interface": {
+            "id": 10
+          }
         },
         "interface-11": {
-          "interface": 11
+          "interface": {
+            "id": 11
+          }
         },
         "interface-9": {
-          "interface": 9
+          "interface": {
+            "id": 9
+          }
         }
       },
       "exports": {},
@@ -101,13 +147,19 @@
       "name": "imports",
       "imports": {
         "interface-16": {
-          "interface": 16
+          "interface": {
+            "id": 16
+          }
         },
         "interface-15": {
-          "interface": 15
+          "interface": {
+            "id": 15
+          }
         },
         "interface-14": {
-          "interface": 14
+          "interface": {
+            "id": 14
+          }
         }
       },
       "exports": {},
@@ -117,85 +169,139 @@
       "name": "imports",
       "imports": {
         "interface-17": {
-          "interface": 17
+          "interface": {
+            "id": 17
+          }
         },
         "interface-18": {
-          "interface": 18
+          "interface": {
+            "id": 18
+          }
         },
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         },
         "interface-1": {
-          "interface": 1
+          "interface": {
+            "id": 1
+          }
         },
         "interface-2": {
-          "interface": 2
+          "interface": {
+            "id": 2
+          }
         },
         "interface-20": {
-          "interface": 20
+          "interface": {
+            "id": 20
+          }
         },
         "interface-21": {
-          "interface": 21
+          "interface": {
+            "id": 21
+          }
         },
         "interface-22": {
-          "interface": 22
+          "interface": {
+            "id": 22
+          }
         },
         "interface-23": {
-          "interface": 23
+          "interface": {
+            "id": 23
+          }
         },
         "interface-24": {
-          "interface": 24
+          "interface": {
+            "id": 24
+          }
         },
         "interface-25": {
-          "interface": 25
+          "interface": {
+            "id": 25
+          }
         },
         "interface-26": {
-          "interface": 26
+          "interface": {
+            "id": 26
+          }
         },
         "interface-27": {
-          "interface": 27
+          "interface": {
+            "id": 27
+          }
         },
         "interface-3": {
-          "interface": 3
+          "interface": {
+            "id": 3
+          }
         },
         "interface-4": {
-          "interface": 4
+          "interface": {
+            "id": 4
+          }
         },
         "interface-5": {
-          "interface": 5
+          "interface": {
+            "id": 5
+          }
         },
         "interface-6": {
-          "interface": 6
+          "interface": {
+            "id": 6
+          }
         },
         "interface-7": {
-          "interface": 7
+          "interface": {
+            "id": 7
+          }
         },
         "interface-8": {
-          "interface": 8
+          "interface": {
+            "id": 8
+          }
         },
         "interface-12": {
-          "interface": 12
+          "interface": {
+            "id": 12
+          }
         },
         "interface-13": {
-          "interface": 13
+          "interface": {
+            "id": 13
+          }
         },
         "interface-10": {
-          "interface": 10
+          "interface": {
+            "id": 10
+          }
         },
         "interface-11": {
-          "interface": 11
+          "interface": {
+            "id": 11
+          }
         },
         "interface-9": {
-          "interface": 9
+          "interface": {
+            "id": 9
+          }
         },
         "interface-16": {
-          "interface": 16
+          "interface": {
+            "id": 16
+          }
         },
         "interface-15": {
-          "interface": 15
+          "interface": {
+            "id": 15
+          }
         },
         "interface-14": {
-          "interface": 14
+          "interface": {
+            "id": 14
+          }
         }
       },
       "exports": {},
@@ -205,90 +311,146 @@
       "name": "command",
       "imports": {
         "interface-17": {
-          "interface": 17
+          "interface": {
+            "id": 17
+          }
         },
         "interface-18": {
-          "interface": 18
+          "interface": {
+            "id": 18
+          }
         },
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         },
         "interface-1": {
-          "interface": 1
+          "interface": {
+            "id": 1
+          }
         },
         "interface-2": {
-          "interface": 2
+          "interface": {
+            "id": 2
+          }
         },
         "interface-20": {
-          "interface": 20
+          "interface": {
+            "id": 20
+          }
         },
         "interface-21": {
-          "interface": 21
+          "interface": {
+            "id": 21
+          }
         },
         "interface-22": {
-          "interface": 22
+          "interface": {
+            "id": 22
+          }
         },
         "interface-23": {
-          "interface": 23
+          "interface": {
+            "id": 23
+          }
         },
         "interface-24": {
-          "interface": 24
+          "interface": {
+            "id": 24
+          }
         },
         "interface-25": {
-          "interface": 25
+          "interface": {
+            "id": 25
+          }
         },
         "interface-26": {
-          "interface": 26
+          "interface": {
+            "id": 26
+          }
         },
         "interface-27": {
-          "interface": 27
+          "interface": {
+            "id": 27
+          }
         },
         "interface-3": {
-          "interface": 3
+          "interface": {
+            "id": 3
+          }
         },
         "interface-4": {
-          "interface": 4
+          "interface": {
+            "id": 4
+          }
         },
         "interface-5": {
-          "interface": 5
+          "interface": {
+            "id": 5
+          }
         },
         "interface-6": {
-          "interface": 6
+          "interface": {
+            "id": 6
+          }
         },
         "interface-7": {
-          "interface": 7
+          "interface": {
+            "id": 7
+          }
         },
         "interface-8": {
-          "interface": 8
+          "interface": {
+            "id": 8
+          }
         },
         "interface-12": {
-          "interface": 12
+          "interface": {
+            "id": 12
+          }
         },
         "interface-13": {
-          "interface": 13
+          "interface": {
+            "id": 13
+          }
         },
         "interface-10": {
-          "interface": 10
+          "interface": {
+            "id": 10
+          }
         },
         "interface-11": {
-          "interface": 11
+          "interface": {
+            "id": 11
+          }
         },
         "interface-9": {
-          "interface": 9
+          "interface": {
+            "id": 9
+          }
         },
         "interface-16": {
-          "interface": 16
+          "interface": {
+            "id": 16
+          }
         },
         "interface-15": {
-          "interface": 15
+          "interface": {
+            "id": 15
+          }
         },
         "interface-14": {
-          "interface": 14
+          "interface": {
+            "id": 14
+          }
         }
       },
       "exports": {
         "interface-19": {
-          "interface": 19
+          "interface": {
+            "id": 19
+          }
         }
       },
       "package": 5
@@ -297,37 +459,59 @@
       "name": "imports",
       "imports": {
         "interface-16": {
-          "interface": 16
+          "interface": {
+            "id": 16
+          }
         },
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         },
         "interface-1": {
-          "interface": 1
+          "interface": {
+            "id": 1
+          }
         },
         "interface-2": {
-          "interface": 2
+          "interface": {
+            "id": 2
+          }
         },
         "interface-21": {
-          "interface": 21
+          "interface": {
+            "id": 21
+          }
         },
         "interface-22": {
-          "interface": 22
+          "interface": {
+            "id": 22
+          }
         },
         "interface-20": {
-          "interface": 20
+          "interface": {
+            "id": 20
+          }
         },
         "interface-3": {
-          "interface": 3
+          "interface": {
+            "id": 3
+          }
         },
         "interface-28": {
-          "interface": 28
+          "interface": {
+            "id": 28
+          }
         },
         "interface-30": {
-          "interface": 30
+          "interface": {
+            "id": 30
+          }
         },
         "interface-4": {
-          "interface": 4
+          "interface": {
+            "id": 4
+          }
         }
       },
       "exports": {},
@@ -340,42 +524,66 @@
       "name": "proxy",
       "imports": {
         "interface-1": {
-          "interface": 1
+          "interface": {
+            "id": 1
+          }
         },
         "interface-3": {
-          "interface": 3
+          "interface": {
+            "id": 3
+          }
         },
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         },
         "interface-2": {
-          "interface": 2
+          "interface": {
+            "id": 2
+          }
         },
         "interface-28": {
-          "interface": 28
+          "interface": {
+            "id": 28
+          }
         },
         "interface-16": {
-          "interface": 16
+          "interface": {
+            "id": 16
+          }
         },
         "interface-21": {
-          "interface": 21
+          "interface": {
+            "id": 21
+          }
         },
         "interface-22": {
-          "interface": 22
+          "interface": {
+            "id": 22
+          }
         },
         "interface-20": {
-          "interface": 20
+          "interface": {
+            "id": 20
+          }
         },
         "interface-30": {
-          "interface": 30
+          "interface": {
+            "id": 30
+          }
         },
         "interface-4": {
-          "interface": 4
+          "interface": {
+            "id": 4
+          }
         }
       },
       "exports": {
         "interface-29": {
-          "interface": 29
+          "interface": {
+            "id": 29
+          }
         }
       },
       "package": 6,

--- a/testdata/wasi/http.wit.json.golden.wit
+++ b/testdata/wasi/http.wit.json.golden.wit
@@ -1,312 +1,158 @@
-package wasi:io@0.2.0;
+package wasi:cli@0.2.0;
 
-interface error {
-	/// A resource which represents some error information.
+interface environment {
+	/// Get the POSIX-style environment variables.
 	///
-	/// The only method provided by this resource is `to-debug-string`,
-	/// which provides some human-readable information about the error.
+	/// Each environment variable is provided as a pair of string variable names
+	/// and string value.
 	///
-	/// In the `wasi:io` package, this resource is returned through the
-	/// `wasi:io/streams/stream-error` type.
-	///
-	/// To provide more specific error information, other interfaces may
-	/// provide functions to further "downcast" this error into more specific
-	/// error information. For example, `error`s returned in streams derived
-	/// from filesystem types to be described using the filesystem's own
-	/// error-code type, using the function
-	/// `wasi:filesystem/types/filesystem-error-code`, which takes a parameter
-	/// `borrow<error>` and returns
-	/// `option<wasi:filesystem/types/error-code>`.
-	///
-	/// The set of functions which can "downcast" an `error` into a more
-	/// concrete type is open.
-	resource error {
+	/// Morally, these are a value import, but until value imports are available
+	/// in the component model, this import function should return the same
+	/// values each time it is called.
+	get-environment: func() -> list<tuple<string, string>>;
 
-		/// Returns a string that is suitable to assist humans in debugging
-		/// this error.
-		///
-		/// WARNING: The returned string should not be consumed mechanically!
-		/// It may change across platforms, hosts, or other implementation
-		/// details. Parsing this string is a major platform-compatibility
-		/// hazard.
-		to-debug-string: func() -> string;
-	}
+	/// Get the POSIX-style arguments to the program.
+	get-arguments: func() -> list<string>;
+
+	/// Return a path that programs should use as their initial current working
+	/// directory, interpreting `.` as shorthand for this.
+	initial-cwd: func() -> option<string>;
 }
 
-/// A poll API intended to let users wait for I/O events on multiple handles
-/// at once.
-interface poll {
-	/// `pollable` represents a single I/O event which may be ready, or not.
-	resource pollable {
-
-		/// `block` returns immediately if the pollable is ready, and otherwise
-		/// blocks until ready.
-		///
-		/// This function is equivalent to calling `poll.poll` on a list
-		/// containing only this pollable.
-		block: func();
-
-		/// Return the readiness of a pollable. This function never blocks.
-		///
-		/// Returns `true` when the pollable is ready, and `false` otherwise.
-		ready: func() -> bool;
-	}
-
-	/// Poll for completion on a set of pollables.
-	///
-	/// This function takes a list of pollables, which identify I/O sources of
-	/// interest, and waits until one or more of the events is ready for I/O.
-	///
-	/// The result `list<u32>` contains one or more indices of handles in the
-	/// argument list that is ready for I/O.
-	///
-	/// If the list contains more elements than can be indexed with a `u32`
-	/// value, this function traps.
-	///
-	/// A timeout can be implemented by adding a pollable from the
-	/// wasi-clocks API to the list.
-	///
-	/// This function does not return a `result`; polling in itself does not
-	/// do any I/O so it doesn't fail. If any of the I/O sources identified by
-	/// the pollables has an error, it is indicated by marking the source as
-	/// being reaedy for I/O.
-	poll: func(in: list<borrow<pollable>>) -> list<u32>;
+interface exit {
+	/// Exit the current instance and any linked instances.
+	exit: func(status: result);
 }
 
-/// WASI I/O is an I/O abstraction API which is currently focused on providing
-/// stream types.
+interface run {
+	/// Run the program.
+	run: func() -> result;
+}
+
+interface stdin {
+	use wasi:io/streams@0.2.0.{input-stream};
+	get-stdin: func() -> input-stream;
+}
+
+interface stdout {
+	use wasi:io/streams@0.2.0.{output-stream};
+	get-stdout: func() -> output-stream;
+}
+
+interface stderr {
+	use wasi:io/streams@0.2.0.{output-stream};
+	get-stderr: func() -> output-stream;
+}
+
+/// Terminal input.
 ///
-/// In the future, the component model is expected to add built-in stream types;
-/// when it does, they are expected to subsume this API.
-interface streams {
-	use error.{error};
-	use poll.{pollable};
+/// In the future, this may include functions for disabling echoing,
+/// disabling input buffering so that keyboard events are sent through
+/// immediately, querying supported features, and so on.
+interface terminal-input {
+	/// The input side of a terminal.
+	resource terminal-input;
+}
 
-	/// An error for input-stream and output-stream operations.
-	variant stream-error {
-		/// The last operation (a write or flush) failed before completion.
-		///
-		/// More information is available in the `error` payload.
-		last-operation-failed(error),
-		/// The stream is closed: no more input will be accepted by the
-		/// stream. A closed output-stream will return this error on all
-		/// future operations.
-		closed,
-	}
+/// Terminal output.
+///
+/// In the future, this may include functions for querying the terminal
+/// size, being notified of terminal size changes, querying supported
+/// features, and so on.
+interface terminal-output {
+	/// The output side of a terminal.
+	resource terminal-output;
+}
 
-	/// An input bytestream.
-	///
-	/// `input-stream`s are *non-blocking* to the extent practical on underlying
-	/// platforms. I/O operations always return promptly; if fewer bytes are
-	/// promptly available than requested, they return the number of bytes promptly
-	/// available, which could even be zero. To wait for data to be available,
-	/// use the `subscribe` function to obtain a `pollable` which can be polled
-	/// for using `wasi:io/poll`.
-	resource input-stream {
+/// An interface providing an optional `terminal-input` for stdin as a
+/// link-time authority.
+interface terminal-stdin {
+	use terminal-input.{terminal-input};
 
-		/// Read bytes from a stream, after blocking until at least one byte can
-		/// be read. Except for blocking, behavior is identical to `read`.
-		blocking-read: func(len: u64) -> result<list<u8>, stream-error>;
+	/// If stdin is connected to a terminal, return a `terminal-input` handle
+	/// allowing further interaction with it.
+	get-terminal-stdin: func() -> option<terminal-input>;
+}
 
-		/// Skip bytes from a stream, after blocking until at least one byte
-		/// can be skipped. Except for blocking behavior, identical to `skip`.
-		blocking-skip: func(len: u64) -> result<u64, stream-error>;
+/// An interface providing an optional `terminal-output` for stdout as a
+/// link-time authority.
+interface terminal-stdout {
+	use terminal-output.{terminal-output};
 
-		/// Perform a non-blocking read from the stream.
-		///
-		/// When the source of a `read` is binary data, the bytes from the source
-		/// are returned verbatim. When the source of a `read` is known to the
-		/// implementation to be text, bytes containing the UTF-8 encoding of the
-		/// text are returned.
-		///
-		/// This function returns a list of bytes containing the read data,
-		/// when successful. The returned list will contain up to `len` bytes;
-		/// it may return fewer than requested, but not more. The list is
-		/// empty when no bytes are available for reading at this time. The
-		/// pollable given by `subscribe` will be ready when more bytes are
-		/// available.
-		///
-		/// This function fails with a `stream-error` when the operation
-		/// encounters an error, giving `last-operation-failed`, or when the
-		/// stream is closed, giving `closed`.
-		///
-		/// When the caller gives a `len` of 0, it represents a request to
-		/// read 0 bytes. If the stream is still open, this call should
-		/// succeed and return an empty list, or otherwise fail with `closed`.
-		///
-		/// The `len` parameter is a `u64`, which could represent a list of u8 which
-		/// is not possible to allocate in wasm32, or not desirable to allocate as
-		/// as a return value by the callee. The callee may return a list of bytes
-		/// less than `len` in size while more bytes are available for reading.
-		read: func(len: u64) -> result<list<u8>, stream-error>;
+	/// If stdout is connected to a terminal, return a `terminal-output` handle
+	/// allowing further interaction with it.
+	get-terminal-stdout: func() -> option<terminal-output>;
+}
 
-		/// Skip bytes from a stream. Returns number of bytes skipped.
-		///
-		/// Behaves identical to `read`, except instead of returning a list
-		/// of bytes, returns the number of bytes consumed from the stream.
-		skip: func(len: u64) -> result<u64, stream-error>;
+/// An interface providing an optional `terminal-output` for stderr as a
+/// link-time authority.
+interface terminal-stderr {
+	use terminal-output.{terminal-output};
 
-		/// Create a `pollable` which will resolve once either the specified stream
-		/// has bytes available to read or the other end of the stream has been
-		/// closed.
-		/// The created `pollable` is a child resource of the `input-stream`.
-		/// Implementations may trap if the `input-stream` is dropped before
-		/// all derived `pollable`s created with this function are dropped.
-		subscribe: func() -> pollable;
-	}
-
-	/// An output bytestream.
-	///
-	/// `output-stream`s are *non-blocking* to the extent practical on
-	/// underlying platforms. Except where specified otherwise, I/O operations also
-	/// always return promptly, after the number of bytes that can be written
-	/// promptly, which could even be zero. To wait for the stream to be ready to
-	/// accept data, the `subscribe` function to obtain a `pollable` which can be
-	/// polled for using `wasi:io/poll`.
-	resource output-stream {
-
-		/// Request to flush buffered output, and block until flush completes
-		/// and stream is ready for writing again.
-		blocking-flush: func() -> result<_, stream-error>;
-
-		/// Read from one stream and write to another, with blocking.
-		///
-		/// This is similar to `splice`, except that it blocks until the
-		/// `output-stream` is ready for writing, and the `input-stream`
-		/// is ready for reading, before performing the `splice`.
-		blocking-splice: func(src: borrow<input-stream>, len: u64) -> result<u64, stream-error>;
-
-		/// Perform a write of up to 4096 bytes, and then flush the stream. Block
-		/// until all of these operations are complete, or an error occurs.
-		///
-		/// This is a convenience wrapper around the use of `check-write`,
-		/// `subscribe`, `write`, and `flush`, and is implemented with the
-		/// following pseudo-code:
-		///
-		/// ```text
-		/// let pollable = this.subscribe();
-		/// while !contents.is_empty() {
-		/// // Wait for the stream to become writable
-		/// pollable.block();
-		/// let Ok(n) = this.check-write(); // eliding error handling
-		/// let len = min(n, contents.len());
-		/// let (chunk, rest) = contents.split_at(len);
-		/// this.write(chunk  );            // eliding error handling
-		/// contents = rest;
-		/// }
-		/// this.flush();
-		/// // Wait for completion of `flush`
-		/// pollable.block();
-		/// // Check for any errors that arose during `flush`
-		/// let _ = this.check-write();         // eliding error handling
-		/// ```
-		blocking-write-and-flush: func(contents: list<u8>) -> result<_, stream-error>;
-
-		/// Perform a write of up to 4096 zeroes, and then flush the stream.
-		/// Block until all of these operations are complete, or an error
-		/// occurs.
-		///
-		/// This is a convenience wrapper around the use of `check-write`,
-		/// `subscribe`, `write-zeroes`, and `flush`, and is implemented with
-		/// the following pseudo-code:
-		///
-		/// ```text
-		/// let pollable = this.subscribe();
-		/// while num_zeroes != 0 {
-		/// // Wait for the stream to become writable
-		/// pollable.block();
-		/// let Ok(n) = this.check-write(); // eliding error handling
-		/// let len = min(n, num_zeroes);
-		/// this.write-zeroes(len);         // eliding error handling
-		/// num_zeroes -= len;
-		/// }
-		/// this.flush();
-		/// // Wait for completion of `flush`
-		/// pollable.block();
-		/// // Check for any errors that arose during `flush`
-		/// let _ = this.check-write();         // eliding error handling
-		/// ```
-		blocking-write-zeroes-and-flush: func(len: u64) -> result<_, stream-error>;
-
-		/// Check readiness for writing. This function never blocks.
-		///
-		/// Returns the number of bytes permitted for the next call to `write`,
-		/// or an error. Calling `write` with more bytes than this function has
-		/// permitted will trap.
-		///
-		/// When this function returns 0 bytes, the `subscribe` pollable will
-		/// become ready when this function will report at least 1 byte, or an
-		/// error.
-		check-write: func() -> result<u64, stream-error>;
-
-		/// Request to flush buffered output. This function never blocks.
-		///
-		/// This tells the output-stream that the caller intends any buffered
-		/// output to be flushed. the output which is expected to be flushed
-		/// is all that has been passed to `write` prior to this call.
-		///
-		/// Upon calling this function, the `output-stream` will not accept any
-		/// writes (`check-write` will return `ok(0)`) until the flush has
-		/// completed. The `subscribe` pollable will become ready when the
-		/// flush has completed and the stream can accept more writes.
-		flush: func() -> result<_, stream-error>;
-
-		/// Read from one stream and write to another.
-		///
-		/// The behavior of splice is equivelant to:
-		/// 1. calling `check-write` on the `output-stream`
-		/// 2. calling `read` on the `input-stream` with the smaller of the
-		/// `check-write` permitted length and the `len` provided to `splice`
-		/// 3. calling `write` on the `output-stream` with that read data.
-		///
-		/// Any error reported by the call to `check-write`, `read`, or
-		/// `write` ends the splice and reports that error.
-		///
-		/// This function returns the number of bytes transferred; it may be less
-		/// than `len`.
-		splice: func(src: borrow<input-stream>, len: u64) -> result<u64, stream-error>;
-
-		/// Create a `pollable` which will resolve once the output-stream
-		/// is ready for more writing, or an error has occured. When this
-		/// pollable is ready, `check-write` will return `ok(n)` with n>0, or an
-		/// error.
-		///
-		/// If the stream is closed, this pollable is always ready immediately.
-		///
-		/// The created `pollable` is a child resource of the `output-stream`.
-		/// Implementations may trap if the `output-stream` is dropped before
-		/// all derived `pollable`s created with this function are dropped.
-		subscribe: func() -> pollable;
-
-		/// Perform a write. This function never blocks.
-		///
-		/// When the destination of a `write` is binary data, the bytes from
-		/// `contents` are written verbatim. When the destination of a `write` is
-		/// known to the implementation to be text, the bytes of `contents` are
-		/// transcoded from UTF-8 into the encoding of the destination and then
-		/// written.
-		///
-		/// Precondition: check-write gave permit of Ok(n) and contents has a
-		/// length of less than or equal to n. Otherwise, this function will trap.
-		///
-		/// returns Err(closed) without writing if the stream has closed since
-		/// the last call to check-write provided a permit.
-		write: func(contents: list<u8>) -> result<_, stream-error>;
-
-		/// Write zeroes to a stream.
-		///
-		/// This should be used precisely like `write` with the exact same
-		/// preconditions (must use check-write first), but instead of
-		/// passing a list of bytes, you simply pass the number of zero-bytes
-		/// that should be written.
-		write-zeroes: func(len: u64) -> result<_, stream-error>;
-	}
+	/// If stderr is connected to a terminal, return a `terminal-output` handle
+	/// allowing further interaction with it.
+	get-terminal-stderr: func() -> option<terminal-output>;
 }
 
 world imports {
-	import error;
-	import poll;
-	import streams;
+	import environment;
+	import exit;
+	import wasi:io/error@0.2.0;
+	import wasi:io/poll@0.2.0;
+	import wasi:io/streams@0.2.0;
+	import stdin;
+	import stdout;
+	import stderr;
+	import terminal-input;
+	import terminal-output;
+	import terminal-stdin;
+	import terminal-stdout;
+	import terminal-stderr;
+	import wasi:clocks/monotonic-clock@0.2.0;
+	import wasi:clocks/wall-clock@0.2.0;
+	import wasi:filesystem/types@0.2.0;
+	import wasi:filesystem/preopens@0.2.0;
+	import wasi:sockets/network@0.2.0;
+	import wasi:sockets/instance-network@0.2.0;
+	import wasi:sockets/udp@0.2.0;
+	import wasi:sockets/udp-create-socket@0.2.0;
+	import wasi:sockets/tcp@0.2.0;
+	import wasi:sockets/tcp-create-socket@0.2.0;
+	import wasi:sockets/ip-name-lookup@0.2.0;
+	import wasi:random/random@0.2.0;
+	import wasi:random/insecure@0.2.0;
+	import wasi:random/insecure-seed@0.2.0;
+}
+
+world command {
+	import environment;
+	import exit;
+	import wasi:io/error@0.2.0;
+	import wasi:io/poll@0.2.0;
+	import wasi:io/streams@0.2.0;
+	import stdin;
+	import stdout;
+	import stderr;
+	import terminal-input;
+	import terminal-output;
+	import terminal-stdin;
+	import terminal-stdout;
+	import terminal-stderr;
+	import wasi:clocks/monotonic-clock@0.2.0;
+	import wasi:clocks/wall-clock@0.2.0;
+	import wasi:filesystem/types@0.2.0;
+	import wasi:filesystem/preopens@0.2.0;
+	import wasi:sockets/network@0.2.0;
+	import wasi:sockets/instance-network@0.2.0;
+	import wasi:sockets/udp@0.2.0;
+	import wasi:sockets/udp-create-socket@0.2.0;
+	import wasi:sockets/tcp@0.2.0;
+	import wasi:sockets/tcp-create-socket@0.2.0;
+	import wasi:sockets/ip-name-lookup@0.2.0;
+	import wasi:random/random@0.2.0;
+	import wasi:random/insecure@0.2.0;
+	import wasi:random/insecure-seed@0.2.0;
+	export run;
 }
 
 
@@ -967,6 +813,1042 @@ world imports {
 	import wasi:clocks/wall-clock@0.2.0;
 	import types;
 	import preopens;
+}
+
+
+package wasi:http@0.2.0;
+
+/// This interface defines all of the types and methods for implementing
+/// HTTP Requests and Responses, both incoming and outgoing, as well as
+/// their headers, trailers, and bodies.
+interface types {
+	use wasi:clocks/monotonic-clock@0.2.0.{duration};
+	use wasi:io/streams@0.2.0.{input-stream};
+	use wasi:io/streams@0.2.0.{output-stream};
+	use wasi:io/error@0.2.0.{error as io-error};
+	use wasi:io/poll@0.2.0.{pollable};
+
+	/// This type corresponds to HTTP standard Methods.
+	variant method {
+		get,
+		head,
+		post,
+		put,
+		delete,
+		connect,
+		options,
+		trace,
+		patch,
+		other(string),
+	}
+
+	/// This type corresponds to HTTP standard Related Schemes.
+	variant scheme { HTTP, HTTPS, other(string) }
+
+	/// Defines the case payload type for `DNS-error` above:
+	record DNS-error-payload {
+		rcode: option<string>,
+		info-code: option<u16>,
+	}
+
+	/// Defines the case payload type for `TLS-alert-received` above:
+	record TLS-alert-received-payload {
+		alert-id: option<u8>,
+		alert-message: option<string>,
+	}
+
+	/// Defines the case payload type for `HTTP-response-{header,trailer}-size` above:
+	record field-size-payload {
+		field-name: option<string>,
+		field-size: option<u32>,
+	}
+
+	/// These cases are inspired by the IANA HTTP Proxy Error Types:
+	/// https://www.iana.org/assignments/http-proxy-status/http-proxy-status.xhtml#table-http-proxy-error-types
+	variant error-code {
+		DNS-timeout,
+		DNS-error(DNS-error-payload),
+		destination-not-found,
+		destination-unavailable,
+		destination-IP-prohibited,
+		destination-IP-unroutable,
+		connection-refused,
+		connection-terminated,
+		connection-timeout,
+		connection-read-timeout,
+		connection-write-timeout,
+		connection-limit-reached,
+		TLS-protocol-error,
+		TLS-certificate-error,
+		TLS-alert-received(TLS-alert-received-payload),
+		HTTP-request-denied,
+		HTTP-request-length-required,
+		HTTP-request-body-size(option<u64>),
+		HTTP-request-method-invalid,
+		HTTP-request-URI-invalid,
+		HTTP-request-URI-too-long,
+		HTTP-request-header-section-size(option<u32>),
+		HTTP-request-header-size(option<field-size-payload>),
+		HTTP-request-trailer-section-size(option<u32>),
+		HTTP-request-trailer-size(field-size-payload),
+		HTTP-response-incomplete,
+		HTTP-response-header-section-size(option<u32>),
+		HTTP-response-header-size(field-size-payload),
+		HTTP-response-body-size(option<u64>),
+		HTTP-response-trailer-section-size(option<u32>),
+		HTTP-response-trailer-size(field-size-payload),
+		HTTP-response-transfer-coding(option<string>),
+		HTTP-response-content-coding(option<string>),
+		HTTP-response-timeout,
+		HTTP-upgrade-failed,
+		HTTP-protocol-error,
+		loop-detected,
+		configuration-error,
+		/// This is a catch-all error for anything that doesn't fit cleanly into a
+		/// more specific case. It also includes an optional string for an
+		/// unstructured description of the error. Users should not depend on the
+		/// string for diagnosing errors, as it's not required to be consistent
+		/// between implementations.
+		internal-error(option<string>),
+	}
+
+	/// This type enumerates the different kinds of errors that may occur when
+	/// setting or appending to a `fields` resource.
+	variant header-error {
+		/// This error indicates that a `field-key` or `field-value` was
+		/// syntactically invalid when used with an operation that sets headers in a
+		/// `fields`.
+		invalid-syntax,
+		/// This error indicates that a forbidden `field-key` was used when trying
+		/// to set a header in a `fields`.
+		forbidden,
+		/// This error indicates that the operation on the `fields` was not
+		/// permitted because the fields are immutable.
+		immutable,
+	}
+
+	/// Field keys are always strings.
+	type field-key = string;
+
+	/// Field values should always be ASCII strings. However, in
+	/// reality, HTTP implementations often have to interpret malformed values,
+	/// so they are provided as a list of bytes.
+	type field-value = list<u8>;
+
+	/// This following block defines the `fields` resource which corresponds to
+	/// HTTP standard Fields. Fields are a common representation used for both
+	/// Headers and Trailers.
+	///
+	/// A `fields` may be mutable or immutable. A `fields` created using the
+	/// constructor, `from-list`, or `clone` will be mutable, but a `fields`
+	/// resource given by other means (including, but not limited to,
+	/// `incoming-request.headers`, `outgoing-request.headers`) might be be
+	/// immutable. In an immutable fields, the `set`, `append`, and `delete`
+	/// operations will fail with `header-error.immutable`.
+	resource fields {
+		/// Construct an empty HTTP Fields.
+		///
+		/// The resulting `fields` is mutable.
+		constructor();
+
+		/// Append a value for a key. Does not change or delete any existing
+		/// values for that key.
+		///
+		/// Fails with `header-error.immutable` if the `fields` are immutable.
+		///
+		/// Fails with `header-error.invalid-syntax` if the `field-key` or
+		/// `field-value` are syntactically invalid.
+		append: func(name: field-key, value: field-value) -> result<_, header-error>;
+
+		/// Make a deep copy of the Fields. Equivelant in behavior to calling the
+		/// `fields` constructor on the return value of `entries`. The resulting
+		/// `fields` is mutable.
+		clone: func() -> fields;
+
+		/// Delete all values for a key. Does nothing if no values for the key
+		/// exist.
+		///
+		/// Fails with `header-error.immutable` if the `fields` are immutable.
+		///
+		/// Fails with `header-error.invalid-syntax` if the `field-key` is
+		/// syntactically invalid.
+		delete: func(name: field-key) -> result<_, header-error>;
+
+		/// Retrieve the full set of keys and values in the Fields. Like the
+		/// constructor, the list represents each key-value pair.
+		///
+		/// The outer list represents each key-value pair in the Fields. Keys
+		/// which have multiple values are represented by multiple entries in this
+		/// list with the same key.
+		entries: func() -> list<tuple<field-key, field-value>>;
+
+		/// Get all of the values corresponding to a key. If the key is not present
+		/// in this `fields` or is syntactically invalid, an empty list is returned.
+		/// However, if the key is present but empty, this is represented by a list
+		/// with one or more empty field-values present.
+		get: func(name: field-key) -> list<field-value>;
+
+		/// Returns `true` when the key is present in this `fields`. If the key is
+		/// syntactically invalid, `false` is returned.
+		has: func(name: field-key) -> bool;
+
+		/// Set all of the values for a key. Clears any existing values for that
+		/// key, if they have been set.
+		///
+		/// Fails with `header-error.immutable` if the `fields` are immutable.
+		///
+		/// Fails with `header-error.invalid-syntax` if the `field-key` or any of
+		/// the `field-value`s are syntactically invalid.
+		set: func(name: field-key, value: list<field-value>) -> result<_, header-error>;
+
+		/// Construct an HTTP Fields.
+		///
+		/// The resulting `fields` is mutable.
+		///
+		/// The list represents each key-value pair in the Fields. Keys
+		/// which have multiple values are represented by multiple entries in this
+		/// list with the same key.
+		///
+		/// The tuple is a pair of the field key, represented as a string, and
+		/// Value, represented as a list of bytes.
+		///
+		/// An error result will be returned if any `field-key` or `field-value` is
+		/// syntactically invalid, or if a field is forbidden.
+		from-list: static func(entries: list<tuple<field-key, field-value>>) -> result<fields, header-error>;
+	}
+
+	/// Headers is an alias for Fields.
+	type headers = fields;
+
+	/// Trailers is an alias for Fields.
+	type trailers = fields;
+
+	/// Represents an incoming HTTP Request.
+	resource incoming-request {
+
+		/// Returns the authority from the request, if it was present.
+		authority: func() -> option<string>;
+
+		/// Gives the `incoming-body` associated with this request. Will only
+		/// return success at most once, and subsequent calls will return error.
+		consume: func() -> result<incoming-body>;
+
+		/// Get the `headers` associated with the request.
+		///
+		/// The returned `headers` resource is immutable: `set`, `append`, and
+		/// `delete` operations will fail with `header-error.immutable`.
+		///
+		/// The `headers` returned are a child resource: it must be dropped before
+		/// the parent `incoming-request` is dropped. Dropping this
+		/// `incoming-request` before all children are dropped will trap.
+		headers: func() -> headers;
+
+		/// Returns the method of the incoming request.
+		method: func() -> method;
+
+		/// Returns the path with query parameters from the request, as a string.
+		path-with-query: func() -> option<string>;
+
+		/// Returns the protocol scheme from the request.
+		scheme: func() -> option<scheme>;
+	}
+
+	/// Represents an outgoing HTTP Request.
+	resource outgoing-request {
+		/// Construct a new `outgoing-request` with a default `method` of `GET`, and
+		/// `none` values for `path-with-query`, `scheme`, and `authority`.
+		///
+		/// * `headers` is the HTTP Headers for the Request.
+		///
+		/// It is possible to construct, or manipulate with the accessor functions
+		/// below, an `outgoing-request` with an invalid combination of `scheme`
+		/// and `authority`, or `headers` which are not permitted to be sent.
+		/// It is the obligation of the `outgoing-handler.handle` implementation
+		/// to reject invalid constructions of `outgoing-request`.
+		constructor(headers: headers);
+
+		/// Get the HTTP Authority for the Request. A value of `none` may be used
+		/// with Related Schemes which do not require an Authority. The HTTP and
+		/// HTTPS schemes always require an authority.
+		authority: func() -> option<string>;
+
+		/// Returns the resource corresponding to the outgoing Body for this
+		/// Request.
+		///
+		/// Returns success on the first call: the `outgoing-body` resource for
+		/// this `outgoing-request` can be retrieved at most once. Subsequent
+		/// calls will return error.
+		body: func() -> result<outgoing-body>;
+
+		/// Get the headers associated with the Request.
+		///
+		/// The returned `headers` resource is immutable: `set`, `append`, and
+		/// `delete` operations will fail with `header-error.immutable`.
+		///
+		/// This headers resource is a child: it must be dropped before the parent
+		/// `outgoing-request` is dropped, or its ownership is transfered to
+		/// another component by e.g. `outgoing-handler.handle`.
+		headers: func() -> headers;
+
+		/// Get the Method for the Request.
+		method: func() -> method;
+
+		/// Get the combination of the HTTP Path and Query for the Request.
+		/// When `none`, this represents an empty Path and empty Query.
+		path-with-query: func() -> option<string>;
+
+		/// Get the HTTP Related Scheme for the Request. When `none`, the
+		/// implementation may choose an appropriate default scheme.
+		scheme: func() -> option<scheme>;
+
+		/// Set the HTTP Authority for the Request. A value of `none` may be used
+		/// with Related Schemes which do not require an Authority. The HTTP and
+		/// HTTPS schemes always require an authority. Fails if the string given is
+		/// not a syntactically valid uri authority.
+		set-authority: func(authority: option<string>) -> result;
+
+		/// Set the Method for the Request. Fails if the string present in a
+		/// `method.other` argument is not a syntactically valid method.
+		set-method: func(method: method) -> result;
+
+		/// Set the combination of the HTTP Path and Query for the Request.
+		/// When `none`, this represents an empty Path and empty Query. Fails is the
+		/// string given is not a syntactically valid path and query uri component.
+		set-path-with-query: func(path-with-query: option<string>) -> result;
+
+		/// Set the HTTP Related Scheme for the Request. When `none`, the
+		/// implementation may choose an appropriate default scheme. Fails if the
+		/// string given is not a syntactically valid uri scheme.
+		set-scheme: func(scheme: option<scheme>) -> result;
+	}
+
+	/// Parameters for making an HTTP Request. Each of these parameters is
+	/// currently an optional timeout applicable to the transport layer of the
+	/// HTTP protocol.
+	///
+	/// These timeouts are separate from any the user may use to bound a
+	/// blocking call to `wasi:io/poll.poll`.
+	resource request-options {
+		/// Construct a default `request-options` value.
+		constructor();
+
+		/// The timeout for receiving subsequent chunks of bytes in the Response
+		/// body stream.
+		between-bytes-timeout: func() -> option<duration>;
+
+		/// The timeout for the initial connect to the HTTP Server.
+		connect-timeout: func() -> option<duration>;
+
+		/// The timeout for receiving the first byte of the Response body.
+		first-byte-timeout: func() -> option<duration>;
+
+		/// Set the timeout for receiving subsequent chunks of bytes in the Response
+		/// body stream. An error return value indicates that this timeout is not
+		/// supported.
+		set-between-bytes-timeout: func(duration: option<duration>) -> result;
+
+		/// Set the timeout for the initial connect to the HTTP Server. An error
+		/// return value indicates that this timeout is not supported.
+		set-connect-timeout: func(duration: option<duration>) -> result;
+
+		/// Set the timeout for receiving the first byte of the Response body. An
+		/// error return value indicates that this timeout is not supported.
+		set-first-byte-timeout: func(duration: option<duration>) -> result;
+	}
+
+	/// Represents the ability to send an HTTP Response.
+	///
+	/// This resource is used by the `wasi:http/incoming-handler` interface to
+	/// allow a Response to be sent corresponding to the Request provided as the
+	/// other argument to `incoming-handler.handle`.
+	resource response-outparam {
+
+		/// Set the value of the `response-outparam` to either send a response,
+		/// or indicate an error.
+		///
+		/// This method consumes the `response-outparam` to ensure that it is
+		/// called at most once. If it is never called, the implementation
+		/// will respond with an error.
+		///
+		/// The user may provide an `error` to `response` to allow the
+		/// implementation determine how to respond with an HTTP error response.
+		set: static func(param: response-outparam, response: result<outgoing-response, error-code>);
+	}
+
+	/// This type corresponds to the HTTP standard Status Code.
+	type status-code = u16;
+
+	/// Represents an incoming HTTP Response.
+	resource incoming-response {
+
+		/// Returns the incoming body. May be called at most once. Returns error
+		/// if called additional times.
+		consume: func() -> result<incoming-body>;
+
+		/// Returns the headers from the incoming response.
+		///
+		/// The returned `headers` resource is immutable: `set`, `append`, and
+		/// `delete` operations will fail with `header-error.immutable`.
+		///
+		/// This headers resource is a child: it must be dropped before the parent
+		/// `incoming-response` is dropped.
+		headers: func() -> headers;
+
+		/// Returns the status code from the incoming response.
+		status: func() -> status-code;
+	}
+
+	/// Represents an incoming HTTP Request or Response's Body.
+	///
+	/// A body has both its contents - a stream of bytes - and a (possibly
+	/// empty) set of trailers, indicating that the full contents of the
+	/// body have been received. This resource represents the contents as
+	/// an `input-stream` and the delivery of trailers as a `future-trailers`,
+	/// and ensures that the user of this interface may only be consuming either
+	/// the body contents or waiting on trailers at any given time.
+	resource incoming-body {
+
+		/// Returns the contents of the body, as a stream of bytes.
+		///
+		/// Returns success on first call: the stream representing the contents
+		/// can be retrieved at most once. Subsequent calls will return error.
+		///
+		/// The returned `input-stream` resource is a child: it must be dropped
+		/// before the parent `incoming-body` is dropped, or consumed by
+		/// `incoming-body.finish`.
+		///
+		/// This invariant ensures that the implementation can determine whether
+		/// the user is consuming the contents of the body, waiting on the
+		/// `future-trailers` to be ready, or neither. This allows for network
+		/// backpressure is to be applied when the user is consuming the body,
+		/// and for that backpressure to not inhibit delivery of the trailers if
+		/// the user does not read the entire body.
+		%stream: func() -> result<input-stream>;
+
+		/// Takes ownership of `incoming-body`, and returns a `future-trailers`.
+		/// This function will trap if the `input-stream` child is still alive.
+		finish: static func(this: incoming-body) -> future-trailers;
+	}
+
+	/// Represents a future which may eventaully return trailers, or an error.
+	///
+	/// In the case that the incoming HTTP Request or Response did not have any
+	/// trailers, this future will resolve to the empty set of trailers once the
+	/// complete Request or Response body has been received.
+	resource future-trailers {
+
+		/// Returns the contents of the trailers, or an error which occured,
+		/// once the future is ready.
+		///
+		/// The outer `option` represents future readiness. Users can wait on this
+		/// `option` to become `some` using the `subscribe` method.
+		///
+		/// The outer `result` is used to retrieve the trailers or error at most
+		/// once. It will be success on the first call in which the outer option
+		/// is `some`, and error on subsequent calls.
+		///
+		/// The inner `result` represents that either the HTTP Request or Response
+		/// body, as well as any trailers, were received successfully, or that an
+		/// error occured receiving them. The optional `trailers` indicates whether
+		/// or not trailers were present in the body.
+		///
+		/// When some `trailers` are returned by this method, the `trailers`
+		/// resource is immutable, and a child. Use of the `set`, `append`, or
+		/// `delete` methods will return an error, and the resource must be
+		/// dropped before the parent `future-trailers` is dropped.
+		get: func() -> option<result<result<option<trailers>, error-code>>>;
+
+		/// Returns a pollable which becomes ready when either the trailers have
+		/// been received, or an error has occured. When this pollable is ready,
+		/// the `get` method will return `some`.
+		subscribe: func() -> pollable;
+	}
+
+	/// Represents an outgoing HTTP Response.
+	resource outgoing-response {
+		/// Construct an `outgoing-response`, with a default `status-code` of `200`.
+		/// If a different `status-code` is needed, it must be set via the
+		/// `set-status-code` method.
+		///
+		/// * `headers` is the HTTP Headers for the Response.
+		constructor(headers: headers);
+
+		/// Returns the resource corresponding to the outgoing Body for this Response.
+		///
+		/// Returns success on the first call: the `outgoing-body` resource for
+		/// this `outgoing-response` can be retrieved at most once. Subsequent
+		/// calls will return error.
+		body: func() -> result<outgoing-body>;
+
+		/// Get the headers associated with the Request.
+		///
+		/// The returned `headers` resource is immutable: `set`, `append`, and
+		/// `delete` operations will fail with `header-error.immutable`.
+		///
+		/// This headers resource is a child: it must be dropped before the parent
+		/// `outgoing-request` is dropped, or its ownership is transfered to
+		/// another component by e.g. `outgoing-handler.handle`.
+		headers: func() -> headers;
+
+		/// Set the HTTP Status Code for the Response. Fails if the status-code
+		/// given is not a valid http status code.
+		set-status-code: func(status-code: status-code) -> result;
+
+		/// Get the HTTP Status Code for the Response.
+		status-code: func() -> status-code;
+	}
+
+	/// Represents an outgoing HTTP Request or Response's Body.
+	///
+	/// A body has both its contents - a stream of bytes - and a (possibly
+	/// empty) set of trailers, inducating the full contents of the body
+	/// have been sent. This resource represents the contents as an
+	/// `output-stream` child resource, and the completion of the body (with
+	/// optional trailers) with a static function that consumes the
+	/// `outgoing-body` resource, and ensures that the user of this interface
+	/// may not write to the body contents after the body has been finished.
+	///
+	/// If the user code drops this resource, as opposed to calling the static
+	/// method `finish`, the implementation should treat the body as incomplete,
+	/// and that an error has occured. The implementation should propogate this
+	/// error to the HTTP protocol by whatever means it has available,
+	/// including: corrupting the body on the wire, aborting the associated
+	/// Request, or sending a late status code for the Response.
+	resource outgoing-body {
+
+		/// Returns a stream for writing the body contents.
+		///
+		/// The returned `output-stream` is a child resource: it must be dropped
+		/// before the parent `outgoing-body` resource is dropped (or finished),
+		/// otherwise the `outgoing-body` drop or `finish` will trap.
+		///
+		/// Returns success on the first call: the `output-stream` resource for
+		/// this `outgoing-body` may be retrieved at most once. Subsequent calls
+		/// will return error.
+		write: func() -> result<output-stream>;
+
+		/// Finalize an outgoing body, optionally providing trailers. This must be
+		/// called to signal that the response is complete. If the `outgoing-body`
+		/// is dropped without calling `outgoing-body.finalize`, the implementation
+		/// should treat the body as corrupted.
+		///
+		/// Fails if the body's `outgoing-request` or `outgoing-response` was
+		/// constructed with a Content-Length header, and the contents written
+		/// to the body (via `write`) does not match the value given in the
+		/// Content-Length.
+		finish: static func(this: outgoing-body, trailers: option<trailers>) -> result<_, error-code>;
+	}
+
+	/// Represents a future which may eventaully return an incoming HTTP
+	/// Response, or an error.
+	///
+	/// This resource is returned by the `wasi:http/outgoing-handler` interface to
+	/// provide the HTTP Response corresponding to the sent Request.
+	resource future-incoming-response {
+
+		/// Returns the incoming HTTP Response, or an error, once one is ready.
+		///
+		/// The outer `option` represents future readiness. Users can wait on this
+		/// `option` to become `some` using the `subscribe` method.
+		///
+		/// The outer `result` is used to retrieve the response or error at most
+		/// once. It will be success on the first call in which the outer option
+		/// is `some`, and error on subsequent calls.
+		///
+		/// The inner `result` represents that either the incoming HTTP Response
+		/// status and headers have recieved successfully, or that an error
+		/// occured. Errors may also occur while consuming the response body,
+		/// but those will be reported by the `incoming-body` and its
+		/// `output-stream` child.
+		get: func() -> option<result<result<incoming-response, error-code>>>;
+
+		/// Returns a pollable which becomes ready when either the Response has
+		/// been received, or an error has occured. When this pollable is ready,
+		/// the `get` method will return `some`.
+		subscribe: func() -> pollable;
+	}
+
+	/// Attempts to extract a http-related `error` from the wasi:io `error`
+	/// provided.
+	///
+	/// Stream operations which return
+	/// `wasi:io/stream/stream-error::last-operation-failed` have a payload of
+	/// type `wasi:io/error/error` with more information about the operation
+	/// that failed. This payload can be passed through to this function to see
+	/// if there's http-related information about the error to return.
+	///
+	/// Note that this function is fallible because not all io-errors are
+	/// http-related errors.
+	http-error-code: func(err: borrow<io-error>) -> option<error-code>;
+}
+
+/// This interface defines a handler of incoming HTTP Requests. It should
+/// be exported by components which can respond to HTTP Requests.
+interface incoming-handler {
+	use types.{incoming-request};
+	use types.{response-outparam};
+
+	/// This function is invoked with an incoming HTTP Request, and a resource
+	/// `response-outparam` which provides the capability to reply with an HTTP
+	/// Response. The response is sent by calling the `response-outparam.set`
+	/// method, which allows execution to continue after the response has been
+	/// sent. This enables both streaming to the response body, and performing other
+	/// work.
+	///
+	/// The implementor of this function must write a response to the
+	/// `response-outparam` before returning, or else the caller will respond
+	/// with an error on its behalf.
+	handle: func(request: incoming-request, response-out: response-outparam);
+}
+
+/// This interface defines a handler of outgoing HTTP Requests. It should be
+/// imported by components which wish to make HTTP Requests.
+interface outgoing-handler {
+	use types.{outgoing-request};
+	use types.{request-options};
+	use types.{future-incoming-response};
+	use types.{error-code};
+
+	/// This function is invoked with an outgoing HTTP Request, and it returns
+	/// a resource `future-incoming-response` which represents an HTTP Response
+	/// which may arrive in the future.
+	///
+	/// The `options` argument accepts optional parameters for the HTTP
+	/// protocol's transport layer.
+	///
+	/// This function may return an error if the `outgoing-request` is invalid
+	/// or not allowed to be made. Otherwise, protocol errors are reported
+	/// through the `future-incoming-response`.
+	handle: func(request: outgoing-request, options: option<request-options>) -> result<future-incoming-response, error-code>;
+}
+
+/// The `wasi:http/imports` world imports all the APIs for HTTP proxies.
+/// It is intended to be `include`d in other worlds.
+world imports {
+	import wasi:random/random@0.2.0;
+	import wasi:io/error@0.2.0;
+	import wasi:io/poll@0.2.0;
+	import wasi:io/streams@0.2.0;
+	import wasi:cli/stdout@0.2.0;
+	import wasi:cli/stderr@0.2.0;
+	import wasi:cli/stdin@0.2.0;
+	import wasi:clocks/monotonic-clock@0.2.0;
+	import types;
+	import outgoing-handler;
+	import wasi:clocks/wall-clock@0.2.0;
+}
+
+/// The `wasi:http/proxy` world captures a widely-implementable intersection of
+/// hosts that includes HTTP forward and reverse proxies. Components targeting
+/// this world may concurrently stream in and out any number of incoming and
+/// outgoing HTTP requests.
+world proxy {
+	import wasi:io/poll@0.2.0;
+	import wasi:clocks/monotonic-clock@0.2.0;
+	import wasi:io/error@0.2.0;
+	import wasi:io/streams@0.2.0;
+	import types;
+	import wasi:random/random@0.2.0;
+	import wasi:cli/stdout@0.2.0;
+	import wasi:cli/stderr@0.2.0;
+	import wasi:cli/stdin@0.2.0;
+	import outgoing-handler;
+	import wasi:clocks/wall-clock@0.2.0;
+	export incoming-handler;
+}
+
+
+package wasi:io@0.2.0;
+
+interface error {
+	/// A resource which represents some error information.
+	///
+	/// The only method provided by this resource is `to-debug-string`,
+	/// which provides some human-readable information about the error.
+	///
+	/// In the `wasi:io` package, this resource is returned through the
+	/// `wasi:io/streams/stream-error` type.
+	///
+	/// To provide more specific error information, other interfaces may
+	/// provide functions to further "downcast" this error into more specific
+	/// error information. For example, `error`s returned in streams derived
+	/// from filesystem types to be described using the filesystem's own
+	/// error-code type, using the function
+	/// `wasi:filesystem/types/filesystem-error-code`, which takes a parameter
+	/// `borrow<error>` and returns
+	/// `option<wasi:filesystem/types/error-code>`.
+	///
+	/// The set of functions which can "downcast" an `error` into a more
+	/// concrete type is open.
+	resource error {
+
+		/// Returns a string that is suitable to assist humans in debugging
+		/// this error.
+		///
+		/// WARNING: The returned string should not be consumed mechanically!
+		/// It may change across platforms, hosts, or other implementation
+		/// details. Parsing this string is a major platform-compatibility
+		/// hazard.
+		to-debug-string: func() -> string;
+	}
+}
+
+/// A poll API intended to let users wait for I/O events on multiple handles
+/// at once.
+interface poll {
+	/// `pollable` represents a single I/O event which may be ready, or not.
+	resource pollable {
+
+		/// `block` returns immediately if the pollable is ready, and otherwise
+		/// blocks until ready.
+		///
+		/// This function is equivalent to calling `poll.poll` on a list
+		/// containing only this pollable.
+		block: func();
+
+		/// Return the readiness of a pollable. This function never blocks.
+		///
+		/// Returns `true` when the pollable is ready, and `false` otherwise.
+		ready: func() -> bool;
+	}
+
+	/// Poll for completion on a set of pollables.
+	///
+	/// This function takes a list of pollables, which identify I/O sources of
+	/// interest, and waits until one or more of the events is ready for I/O.
+	///
+	/// The result `list<u32>` contains one or more indices of handles in the
+	/// argument list that is ready for I/O.
+	///
+	/// If the list contains more elements than can be indexed with a `u32`
+	/// value, this function traps.
+	///
+	/// A timeout can be implemented by adding a pollable from the
+	/// wasi-clocks API to the list.
+	///
+	/// This function does not return a `result`; polling in itself does not
+	/// do any I/O so it doesn't fail. If any of the I/O sources identified by
+	/// the pollables has an error, it is indicated by marking the source as
+	/// being reaedy for I/O.
+	poll: func(in: list<borrow<pollable>>) -> list<u32>;
+}
+
+/// WASI I/O is an I/O abstraction API which is currently focused on providing
+/// stream types.
+///
+/// In the future, the component model is expected to add built-in stream types;
+/// when it does, they are expected to subsume this API.
+interface streams {
+	use error.{error};
+	use poll.{pollable};
+
+	/// An error for input-stream and output-stream operations.
+	variant stream-error {
+		/// The last operation (a write or flush) failed before completion.
+		///
+		/// More information is available in the `error` payload.
+		last-operation-failed(error),
+		/// The stream is closed: no more input will be accepted by the
+		/// stream. A closed output-stream will return this error on all
+		/// future operations.
+		closed,
+	}
+
+	/// An input bytestream.
+	///
+	/// `input-stream`s are *non-blocking* to the extent practical on underlying
+	/// platforms. I/O operations always return promptly; if fewer bytes are
+	/// promptly available than requested, they return the number of bytes promptly
+	/// available, which could even be zero. To wait for data to be available,
+	/// use the `subscribe` function to obtain a `pollable` which can be polled
+	/// for using `wasi:io/poll`.
+	resource input-stream {
+
+		/// Read bytes from a stream, after blocking until at least one byte can
+		/// be read. Except for blocking, behavior is identical to `read`.
+		blocking-read: func(len: u64) -> result<list<u8>, stream-error>;
+
+		/// Skip bytes from a stream, after blocking until at least one byte
+		/// can be skipped. Except for blocking behavior, identical to `skip`.
+		blocking-skip: func(len: u64) -> result<u64, stream-error>;
+
+		/// Perform a non-blocking read from the stream.
+		///
+		/// When the source of a `read` is binary data, the bytes from the source
+		/// are returned verbatim. When the source of a `read` is known to the
+		/// implementation to be text, bytes containing the UTF-8 encoding of the
+		/// text are returned.
+		///
+		/// This function returns a list of bytes containing the read data,
+		/// when successful. The returned list will contain up to `len` bytes;
+		/// it may return fewer than requested, but not more. The list is
+		/// empty when no bytes are available for reading at this time. The
+		/// pollable given by `subscribe` will be ready when more bytes are
+		/// available.
+		///
+		/// This function fails with a `stream-error` when the operation
+		/// encounters an error, giving `last-operation-failed`, or when the
+		/// stream is closed, giving `closed`.
+		///
+		/// When the caller gives a `len` of 0, it represents a request to
+		/// read 0 bytes. If the stream is still open, this call should
+		/// succeed and return an empty list, or otherwise fail with `closed`.
+		///
+		/// The `len` parameter is a `u64`, which could represent a list of u8 which
+		/// is not possible to allocate in wasm32, or not desirable to allocate as
+		/// as a return value by the callee. The callee may return a list of bytes
+		/// less than `len` in size while more bytes are available for reading.
+		read: func(len: u64) -> result<list<u8>, stream-error>;
+
+		/// Skip bytes from a stream. Returns number of bytes skipped.
+		///
+		/// Behaves identical to `read`, except instead of returning a list
+		/// of bytes, returns the number of bytes consumed from the stream.
+		skip: func(len: u64) -> result<u64, stream-error>;
+
+		/// Create a `pollable` which will resolve once either the specified stream
+		/// has bytes available to read or the other end of the stream has been
+		/// closed.
+		/// The created `pollable` is a child resource of the `input-stream`.
+		/// Implementations may trap if the `input-stream` is dropped before
+		/// all derived `pollable`s created with this function are dropped.
+		subscribe: func() -> pollable;
+	}
+
+	/// An output bytestream.
+	///
+	/// `output-stream`s are *non-blocking* to the extent practical on
+	/// underlying platforms. Except where specified otherwise, I/O operations also
+	/// always return promptly, after the number of bytes that can be written
+	/// promptly, which could even be zero. To wait for the stream to be ready to
+	/// accept data, the `subscribe` function to obtain a `pollable` which can be
+	/// polled for using `wasi:io/poll`.
+	resource output-stream {
+
+		/// Request to flush buffered output, and block until flush completes
+		/// and stream is ready for writing again.
+		blocking-flush: func() -> result<_, stream-error>;
+
+		/// Read from one stream and write to another, with blocking.
+		///
+		/// This is similar to `splice`, except that it blocks until the
+		/// `output-stream` is ready for writing, and the `input-stream`
+		/// is ready for reading, before performing the `splice`.
+		blocking-splice: func(src: borrow<input-stream>, len: u64) -> result<u64, stream-error>;
+
+		/// Perform a write of up to 4096 bytes, and then flush the stream. Block
+		/// until all of these operations are complete, or an error occurs.
+		///
+		/// This is a convenience wrapper around the use of `check-write`,
+		/// `subscribe`, `write`, and `flush`, and is implemented with the
+		/// following pseudo-code:
+		///
+		/// ```text
+		/// let pollable = this.subscribe();
+		/// while !contents.is_empty() {
+		/// // Wait for the stream to become writable
+		/// pollable.block();
+		/// let Ok(n) = this.check-write(); // eliding error handling
+		/// let len = min(n, contents.len());
+		/// let (chunk, rest) = contents.split_at(len);
+		/// this.write(chunk  );            // eliding error handling
+		/// contents = rest;
+		/// }
+		/// this.flush();
+		/// // Wait for completion of `flush`
+		/// pollable.block();
+		/// // Check for any errors that arose during `flush`
+		/// let _ = this.check-write();         // eliding error handling
+		/// ```
+		blocking-write-and-flush: func(contents: list<u8>) -> result<_, stream-error>;
+
+		/// Perform a write of up to 4096 zeroes, and then flush the stream.
+		/// Block until all of these operations are complete, or an error
+		/// occurs.
+		///
+		/// This is a convenience wrapper around the use of `check-write`,
+		/// `subscribe`, `write-zeroes`, and `flush`, and is implemented with
+		/// the following pseudo-code:
+		///
+		/// ```text
+		/// let pollable = this.subscribe();
+		/// while num_zeroes != 0 {
+		/// // Wait for the stream to become writable
+		/// pollable.block();
+		/// let Ok(n) = this.check-write(); // eliding error handling
+		/// let len = min(n, num_zeroes);
+		/// this.write-zeroes(len);         // eliding error handling
+		/// num_zeroes -= len;
+		/// }
+		/// this.flush();
+		/// // Wait for completion of `flush`
+		/// pollable.block();
+		/// // Check for any errors that arose during `flush`
+		/// let _ = this.check-write();         // eliding error handling
+		/// ```
+		blocking-write-zeroes-and-flush: func(len: u64) -> result<_, stream-error>;
+
+		/// Check readiness for writing. This function never blocks.
+		///
+		/// Returns the number of bytes permitted for the next call to `write`,
+		/// or an error. Calling `write` with more bytes than this function has
+		/// permitted will trap.
+		///
+		/// When this function returns 0 bytes, the `subscribe` pollable will
+		/// become ready when this function will report at least 1 byte, or an
+		/// error.
+		check-write: func() -> result<u64, stream-error>;
+
+		/// Request to flush buffered output. This function never blocks.
+		///
+		/// This tells the output-stream that the caller intends any buffered
+		/// output to be flushed. the output which is expected to be flushed
+		/// is all that has been passed to `write` prior to this call.
+		///
+		/// Upon calling this function, the `output-stream` will not accept any
+		/// writes (`check-write` will return `ok(0)`) until the flush has
+		/// completed. The `subscribe` pollable will become ready when the
+		/// flush has completed and the stream can accept more writes.
+		flush: func() -> result<_, stream-error>;
+
+		/// Read from one stream and write to another.
+		///
+		/// The behavior of splice is equivelant to:
+		/// 1. calling `check-write` on the `output-stream`
+		/// 2. calling `read` on the `input-stream` with the smaller of the
+		/// `check-write` permitted length and the `len` provided to `splice`
+		/// 3. calling `write` on the `output-stream` with that read data.
+		///
+		/// Any error reported by the call to `check-write`, `read`, or
+		/// `write` ends the splice and reports that error.
+		///
+		/// This function returns the number of bytes transferred; it may be less
+		/// than `len`.
+		splice: func(src: borrow<input-stream>, len: u64) -> result<u64, stream-error>;
+
+		/// Create a `pollable` which will resolve once the output-stream
+		/// is ready for more writing, or an error has occured. When this
+		/// pollable is ready, `check-write` will return `ok(n)` with n>0, or an
+		/// error.
+		///
+		/// If the stream is closed, this pollable is always ready immediately.
+		///
+		/// The created `pollable` is a child resource of the `output-stream`.
+		/// Implementations may trap if the `output-stream` is dropped before
+		/// all derived `pollable`s created with this function are dropped.
+		subscribe: func() -> pollable;
+
+		/// Perform a write. This function never blocks.
+		///
+		/// When the destination of a `write` is binary data, the bytes from
+		/// `contents` are written verbatim. When the destination of a `write` is
+		/// known to the implementation to be text, the bytes of `contents` are
+		/// transcoded from UTF-8 into the encoding of the destination and then
+		/// written.
+		///
+		/// Precondition: check-write gave permit of Ok(n) and contents has a
+		/// length of less than or equal to n. Otherwise, this function will trap.
+		///
+		/// returns Err(closed) without writing if the stream has closed since
+		/// the last call to check-write provided a permit.
+		write: func(contents: list<u8>) -> result<_, stream-error>;
+
+		/// Write zeroes to a stream.
+		///
+		/// This should be used precisely like `write` with the exact same
+		/// preconditions (must use check-write first), but instead of
+		/// passing a list of bytes, you simply pass the number of zero-bytes
+		/// that should be written.
+		write-zeroes: func(len: u64) -> result<_, stream-error>;
+	}
+}
+
+world imports {
+	import error;
+	import poll;
+	import streams;
+}
+
+
+package wasi:random@0.2.0;
+
+/// The insecure-seed interface for seeding hash-map DoS resistance.
+///
+/// It is intended to be portable at least between Unix-family platforms and
+/// Windows.
+interface insecure-seed {
+	/// Return a 128-bit value that may contain a pseudo-random value.
+	///
+	/// The returned value is not required to be computed from a CSPRNG, and may
+	/// even be entirely deterministic. Host implementations are encouraged to
+	/// provide pseudo-random values to any program exposed to
+	/// attacker-controlled content, to enable DoS protection built into many
+	/// languages' hash-map implementations.
+	///
+	/// This function is intended to only be called once, by a source language
+	/// to initialize Denial Of Service (DoS) protection in its hash-map
+	/// implementation.
+	///
+	/// # Expected future evolution
+	///
+	/// This will likely be changed to a value import, to prevent it from being
+	/// called multiple times and potentially used for purposes other than DoS
+	/// protection.
+	insecure-seed: func() -> tuple<u64, u64>;
+}
+
+/// The insecure interface for insecure pseudo-random numbers.
+///
+/// It is intended to be portable at least between Unix-family platforms and
+/// Windows.
+interface insecure {
+	/// Return `len` insecure pseudo-random bytes.
+	///
+	/// This function is not cryptographically secure. Do not use it for
+	/// anything related to security.
+	///
+	/// There are no requirements on the values of the returned bytes, however
+	/// implementations are encouraged to return evenly distributed values with
+	/// a long period.
+	get-insecure-random-bytes: func(len: u64) -> list<u8>;
+
+	/// Return an insecure pseudo-random `u64` value.
+	///
+	/// This function returns the same type of pseudo-random data as
+	/// `get-insecure-random-bytes`, represented as a `u64`.
+	get-insecure-random-u64: func() -> u64;
+}
+
+/// WASI Random is a random data API.
+///
+/// It is intended to be portable at least between Unix-family platforms and
+/// Windows.
+interface random {
+	/// Return `len` cryptographically-secure random or pseudo-random bytes.
+	///
+	/// This function must produce data at least as cryptographically secure and
+	/// fast as an adequately seeded cryptographically-secure pseudo-random
+	/// number generator (CSPRNG). It must not block, from the perspective of
+	/// the calling program, under any circumstances, including on the first
+	/// request and on requests for numbers of bytes. The returned data must
+	/// always be unpredictable.
+	///
+	/// This function must always return fresh data. Deterministic environments
+	/// must omit this function, rather than implementing it with deterministic
+	/// data.
+	get-random-bytes: func(len: u64) -> list<u8>;
+
+	/// Return a cryptographically-secure random or pseudo-random `u64` value.
+	///
+	/// This function returns the same type of data as `get-random-bytes`,
+	/// represented as a `u64`.
+	get-random-u64: func() -> u64;
+}
+
+world imports {
+	import random;
+	import insecure;
+	import insecure-seed;
 }
 
 
@@ -1932,886 +2814,4 @@ world imports {
 	import tcp;
 	import tcp-create-socket;
 	import ip-name-lookup;
-}
-
-
-package wasi:random@0.2.0;
-
-/// The insecure-seed interface for seeding hash-map DoS resistance.
-///
-/// It is intended to be portable at least between Unix-family platforms and
-/// Windows.
-interface insecure-seed {
-	/// Return a 128-bit value that may contain a pseudo-random value.
-	///
-	/// The returned value is not required to be computed from a CSPRNG, and may
-	/// even be entirely deterministic. Host implementations are encouraged to
-	/// provide pseudo-random values to any program exposed to
-	/// attacker-controlled content, to enable DoS protection built into many
-	/// languages' hash-map implementations.
-	///
-	/// This function is intended to only be called once, by a source language
-	/// to initialize Denial Of Service (DoS) protection in its hash-map
-	/// implementation.
-	///
-	/// # Expected future evolution
-	///
-	/// This will likely be changed to a value import, to prevent it from being
-	/// called multiple times and potentially used for purposes other than DoS
-	/// protection.
-	insecure-seed: func() -> tuple<u64, u64>;
-}
-
-/// The insecure interface for insecure pseudo-random numbers.
-///
-/// It is intended to be portable at least between Unix-family platforms and
-/// Windows.
-interface insecure {
-	/// Return `len` insecure pseudo-random bytes.
-	///
-	/// This function is not cryptographically secure. Do not use it for
-	/// anything related to security.
-	///
-	/// There are no requirements on the values of the returned bytes, however
-	/// implementations are encouraged to return evenly distributed values with
-	/// a long period.
-	get-insecure-random-bytes: func(len: u64) -> list<u8>;
-
-	/// Return an insecure pseudo-random `u64` value.
-	///
-	/// This function returns the same type of pseudo-random data as
-	/// `get-insecure-random-bytes`, represented as a `u64`.
-	get-insecure-random-u64: func() -> u64;
-}
-
-/// WASI Random is a random data API.
-///
-/// It is intended to be portable at least between Unix-family platforms and
-/// Windows.
-interface random {
-	/// Return `len` cryptographically-secure random or pseudo-random bytes.
-	///
-	/// This function must produce data at least as cryptographically secure and
-	/// fast as an adequately seeded cryptographically-secure pseudo-random
-	/// number generator (CSPRNG). It must not block, from the perspective of
-	/// the calling program, under any circumstances, including on the first
-	/// request and on requests for numbers of bytes. The returned data must
-	/// always be unpredictable.
-	///
-	/// This function must always return fresh data. Deterministic environments
-	/// must omit this function, rather than implementing it with deterministic
-	/// data.
-	get-random-bytes: func(len: u64) -> list<u8>;
-
-	/// Return a cryptographically-secure random or pseudo-random `u64` value.
-	///
-	/// This function returns the same type of data as `get-random-bytes`,
-	/// represented as a `u64`.
-	get-random-u64: func() -> u64;
-}
-
-world imports {
-	import random;
-	import insecure;
-	import insecure-seed;
-}
-
-
-package wasi:cli@0.2.0;
-
-interface environment {
-	/// Get the POSIX-style environment variables.
-	///
-	/// Each environment variable is provided as a pair of string variable names
-	/// and string value.
-	///
-	/// Morally, these are a value import, but until value imports are available
-	/// in the component model, this import function should return the same
-	/// values each time it is called.
-	get-environment: func() -> list<tuple<string, string>>;
-
-	/// Get the POSIX-style arguments to the program.
-	get-arguments: func() -> list<string>;
-
-	/// Return a path that programs should use as their initial current working
-	/// directory, interpreting `.` as shorthand for this.
-	initial-cwd: func() -> option<string>;
-}
-
-interface exit {
-	/// Exit the current instance and any linked instances.
-	exit: func(status: result);
-}
-
-interface run {
-	/// Run the program.
-	run: func() -> result;
-}
-
-interface stdin {
-	use wasi:io/streams@0.2.0.{input-stream};
-	get-stdin: func() -> input-stream;
-}
-
-interface stdout {
-	use wasi:io/streams@0.2.0.{output-stream};
-	get-stdout: func() -> output-stream;
-}
-
-interface stderr {
-	use wasi:io/streams@0.2.0.{output-stream};
-	get-stderr: func() -> output-stream;
-}
-
-/// Terminal input.
-///
-/// In the future, this may include functions for disabling echoing,
-/// disabling input buffering so that keyboard events are sent through
-/// immediately, querying supported features, and so on.
-interface terminal-input {
-	/// The input side of a terminal.
-	resource terminal-input;
-}
-
-/// Terminal output.
-///
-/// In the future, this may include functions for querying the terminal
-/// size, being notified of terminal size changes, querying supported
-/// features, and so on.
-interface terminal-output {
-	/// The output side of a terminal.
-	resource terminal-output;
-}
-
-/// An interface providing an optional `terminal-input` for stdin as a
-/// link-time authority.
-interface terminal-stdin {
-	use terminal-input.{terminal-input};
-
-	/// If stdin is connected to a terminal, return a `terminal-input` handle
-	/// allowing further interaction with it.
-	get-terminal-stdin: func() -> option<terminal-input>;
-}
-
-/// An interface providing an optional `terminal-output` for stdout as a
-/// link-time authority.
-interface terminal-stdout {
-	use terminal-output.{terminal-output};
-
-	/// If stdout is connected to a terminal, return a `terminal-output` handle
-	/// allowing further interaction with it.
-	get-terminal-stdout: func() -> option<terminal-output>;
-}
-
-/// An interface providing an optional `terminal-output` for stderr as a
-/// link-time authority.
-interface terminal-stderr {
-	use terminal-output.{terminal-output};
-
-	/// If stderr is connected to a terminal, return a `terminal-output` handle
-	/// allowing further interaction with it.
-	get-terminal-stderr: func() -> option<terminal-output>;
-}
-
-world imports {
-	import environment;
-	import exit;
-	import wasi:io/error@0.2.0;
-	import wasi:io/poll@0.2.0;
-	import wasi:io/streams@0.2.0;
-	import stdin;
-	import stdout;
-	import stderr;
-	import terminal-input;
-	import terminal-output;
-	import terminal-stdin;
-	import terminal-stdout;
-	import terminal-stderr;
-	import wasi:clocks/monotonic-clock@0.2.0;
-	import wasi:clocks/wall-clock@0.2.0;
-	import wasi:filesystem/types@0.2.0;
-	import wasi:filesystem/preopens@0.2.0;
-	import wasi:sockets/network@0.2.0;
-	import wasi:sockets/instance-network@0.2.0;
-	import wasi:sockets/udp@0.2.0;
-	import wasi:sockets/udp-create-socket@0.2.0;
-	import wasi:sockets/tcp@0.2.0;
-	import wasi:sockets/tcp-create-socket@0.2.0;
-	import wasi:sockets/ip-name-lookup@0.2.0;
-	import wasi:random/random@0.2.0;
-	import wasi:random/insecure@0.2.0;
-	import wasi:random/insecure-seed@0.2.0;
-}
-
-world command {
-	import environment;
-	import exit;
-	import wasi:io/error@0.2.0;
-	import wasi:io/poll@0.2.0;
-	import wasi:io/streams@0.2.0;
-	import stdin;
-	import stdout;
-	import stderr;
-	import terminal-input;
-	import terminal-output;
-	import terminal-stdin;
-	import terminal-stdout;
-	import terminal-stderr;
-	import wasi:clocks/monotonic-clock@0.2.0;
-	import wasi:clocks/wall-clock@0.2.0;
-	import wasi:filesystem/types@0.2.0;
-	import wasi:filesystem/preopens@0.2.0;
-	import wasi:sockets/network@0.2.0;
-	import wasi:sockets/instance-network@0.2.0;
-	import wasi:sockets/udp@0.2.0;
-	import wasi:sockets/udp-create-socket@0.2.0;
-	import wasi:sockets/tcp@0.2.0;
-	import wasi:sockets/tcp-create-socket@0.2.0;
-	import wasi:sockets/ip-name-lookup@0.2.0;
-	import wasi:random/random@0.2.0;
-	import wasi:random/insecure@0.2.0;
-	import wasi:random/insecure-seed@0.2.0;
-	export run;
-}
-
-
-package wasi:http@0.2.0;
-
-/// This interface defines all of the types and methods for implementing
-/// HTTP Requests and Responses, both incoming and outgoing, as well as
-/// their headers, trailers, and bodies.
-interface types {
-	use wasi:clocks/monotonic-clock@0.2.0.{duration};
-	use wasi:io/streams@0.2.0.{input-stream};
-	use wasi:io/streams@0.2.0.{output-stream};
-	use wasi:io/error@0.2.0.{error as io-error};
-	use wasi:io/poll@0.2.0.{pollable};
-
-	/// This type corresponds to HTTP standard Methods.
-	variant method {
-		get,
-		head,
-		post,
-		put,
-		delete,
-		connect,
-		options,
-		trace,
-		patch,
-		other(string),
-	}
-
-	/// This type corresponds to HTTP standard Related Schemes.
-	variant scheme { HTTP, HTTPS, other(string) }
-
-	/// Defines the case payload type for `DNS-error` above:
-	record DNS-error-payload {
-		rcode: option<string>,
-		info-code: option<u16>,
-	}
-
-	/// Defines the case payload type for `TLS-alert-received` above:
-	record TLS-alert-received-payload {
-		alert-id: option<u8>,
-		alert-message: option<string>,
-	}
-
-	/// Defines the case payload type for `HTTP-response-{header,trailer}-size` above:
-	record field-size-payload {
-		field-name: option<string>,
-		field-size: option<u32>,
-	}
-
-	/// These cases are inspired by the IANA HTTP Proxy Error Types:
-	/// https://www.iana.org/assignments/http-proxy-status/http-proxy-status.xhtml#table-http-proxy-error-types
-	variant error-code {
-		DNS-timeout,
-		DNS-error(DNS-error-payload),
-		destination-not-found,
-		destination-unavailable,
-		destination-IP-prohibited,
-		destination-IP-unroutable,
-		connection-refused,
-		connection-terminated,
-		connection-timeout,
-		connection-read-timeout,
-		connection-write-timeout,
-		connection-limit-reached,
-		TLS-protocol-error,
-		TLS-certificate-error,
-		TLS-alert-received(TLS-alert-received-payload),
-		HTTP-request-denied,
-		HTTP-request-length-required,
-		HTTP-request-body-size(option<u64>),
-		HTTP-request-method-invalid,
-		HTTP-request-URI-invalid,
-		HTTP-request-URI-too-long,
-		HTTP-request-header-section-size(option<u32>),
-		HTTP-request-header-size(option<field-size-payload>),
-		HTTP-request-trailer-section-size(option<u32>),
-		HTTP-request-trailer-size(field-size-payload),
-		HTTP-response-incomplete,
-		HTTP-response-header-section-size(option<u32>),
-		HTTP-response-header-size(field-size-payload),
-		HTTP-response-body-size(option<u64>),
-		HTTP-response-trailer-section-size(option<u32>),
-		HTTP-response-trailer-size(field-size-payload),
-		HTTP-response-transfer-coding(option<string>),
-		HTTP-response-content-coding(option<string>),
-		HTTP-response-timeout,
-		HTTP-upgrade-failed,
-		HTTP-protocol-error,
-		loop-detected,
-		configuration-error,
-		/// This is a catch-all error for anything that doesn't fit cleanly into a
-		/// more specific case. It also includes an optional string for an
-		/// unstructured description of the error. Users should not depend on the
-		/// string for diagnosing errors, as it's not required to be consistent
-		/// between implementations.
-		internal-error(option<string>),
-	}
-
-	/// This type enumerates the different kinds of errors that may occur when
-	/// setting or appending to a `fields` resource.
-	variant header-error {
-		/// This error indicates that a `field-key` or `field-value` was
-		/// syntactically invalid when used with an operation that sets headers in a
-		/// `fields`.
-		invalid-syntax,
-		/// This error indicates that a forbidden `field-key` was used when trying
-		/// to set a header in a `fields`.
-		forbidden,
-		/// This error indicates that the operation on the `fields` was not
-		/// permitted because the fields are immutable.
-		immutable,
-	}
-
-	/// Field keys are always strings.
-	type field-key = string;
-
-	/// Field values should always be ASCII strings. However, in
-	/// reality, HTTP implementations often have to interpret malformed values,
-	/// so they are provided as a list of bytes.
-	type field-value = list<u8>;
-
-	/// This following block defines the `fields` resource which corresponds to
-	/// HTTP standard Fields. Fields are a common representation used for both
-	/// Headers and Trailers.
-	///
-	/// A `fields` may be mutable or immutable. A `fields` created using the
-	/// constructor, `from-list`, or `clone` will be mutable, but a `fields`
-	/// resource given by other means (including, but not limited to,
-	/// `incoming-request.headers`, `outgoing-request.headers`) might be be
-	/// immutable. In an immutable fields, the `set`, `append`, and `delete`
-	/// operations will fail with `header-error.immutable`.
-	resource fields {
-		/// Construct an empty HTTP Fields.
-		///
-		/// The resulting `fields` is mutable.
-		constructor();
-
-		/// Append a value for a key. Does not change or delete any existing
-		/// values for that key.
-		///
-		/// Fails with `header-error.immutable` if the `fields` are immutable.
-		///
-		/// Fails with `header-error.invalid-syntax` if the `field-key` or
-		/// `field-value` are syntactically invalid.
-		append: func(name: field-key, value: field-value) -> result<_, header-error>;
-
-		/// Make a deep copy of the Fields. Equivelant in behavior to calling the
-		/// `fields` constructor on the return value of `entries`. The resulting
-		/// `fields` is mutable.
-		clone: func() -> fields;
-
-		/// Delete all values for a key. Does nothing if no values for the key
-		/// exist.
-		///
-		/// Fails with `header-error.immutable` if the `fields` are immutable.
-		///
-		/// Fails with `header-error.invalid-syntax` if the `field-key` is
-		/// syntactically invalid.
-		delete: func(name: field-key) -> result<_, header-error>;
-
-		/// Retrieve the full set of keys and values in the Fields. Like the
-		/// constructor, the list represents each key-value pair.
-		///
-		/// The outer list represents each key-value pair in the Fields. Keys
-		/// which have multiple values are represented by multiple entries in this
-		/// list with the same key.
-		entries: func() -> list<tuple<field-key, field-value>>;
-
-		/// Get all of the values corresponding to a key. If the key is not present
-		/// in this `fields` or is syntactically invalid, an empty list is returned.
-		/// However, if the key is present but empty, this is represented by a list
-		/// with one or more empty field-values present.
-		get: func(name: field-key) -> list<field-value>;
-
-		/// Returns `true` when the key is present in this `fields`. If the key is
-		/// syntactically invalid, `false` is returned.
-		has: func(name: field-key) -> bool;
-
-		/// Set all of the values for a key. Clears any existing values for that
-		/// key, if they have been set.
-		///
-		/// Fails with `header-error.immutable` if the `fields` are immutable.
-		///
-		/// Fails with `header-error.invalid-syntax` if the `field-key` or any of
-		/// the `field-value`s are syntactically invalid.
-		set: func(name: field-key, value: list<field-value>) -> result<_, header-error>;
-
-		/// Construct an HTTP Fields.
-		///
-		/// The resulting `fields` is mutable.
-		///
-		/// The list represents each key-value pair in the Fields. Keys
-		/// which have multiple values are represented by multiple entries in this
-		/// list with the same key.
-		///
-		/// The tuple is a pair of the field key, represented as a string, and
-		/// Value, represented as a list of bytes.
-		///
-		/// An error result will be returned if any `field-key` or `field-value` is
-		/// syntactically invalid, or if a field is forbidden.
-		from-list: static func(entries: list<tuple<field-key, field-value>>) -> result<fields, header-error>;
-	}
-
-	/// Headers is an alias for Fields.
-	type headers = fields;
-
-	/// Trailers is an alias for Fields.
-	type trailers = fields;
-
-	/// Represents an incoming HTTP Request.
-	resource incoming-request {
-
-		/// Returns the authority from the request, if it was present.
-		authority: func() -> option<string>;
-
-		/// Gives the `incoming-body` associated with this request. Will only
-		/// return success at most once, and subsequent calls will return error.
-		consume: func() -> result<incoming-body>;
-
-		/// Get the `headers` associated with the request.
-		///
-		/// The returned `headers` resource is immutable: `set`, `append`, and
-		/// `delete` operations will fail with `header-error.immutable`.
-		///
-		/// The `headers` returned are a child resource: it must be dropped before
-		/// the parent `incoming-request` is dropped. Dropping this
-		/// `incoming-request` before all children are dropped will trap.
-		headers: func() -> headers;
-
-		/// Returns the method of the incoming request.
-		method: func() -> method;
-
-		/// Returns the path with query parameters from the request, as a string.
-		path-with-query: func() -> option<string>;
-
-		/// Returns the protocol scheme from the request.
-		scheme: func() -> option<scheme>;
-	}
-
-	/// Represents an outgoing HTTP Request.
-	resource outgoing-request {
-		/// Construct a new `outgoing-request` with a default `method` of `GET`, and
-		/// `none` values for `path-with-query`, `scheme`, and `authority`.
-		///
-		/// * `headers` is the HTTP Headers for the Request.
-		///
-		/// It is possible to construct, or manipulate with the accessor functions
-		/// below, an `outgoing-request` with an invalid combination of `scheme`
-		/// and `authority`, or `headers` which are not permitted to be sent.
-		/// It is the obligation of the `outgoing-handler.handle` implementation
-		/// to reject invalid constructions of `outgoing-request`.
-		constructor(headers: headers);
-
-		/// Get the HTTP Authority for the Request. A value of `none` may be used
-		/// with Related Schemes which do not require an Authority. The HTTP and
-		/// HTTPS schemes always require an authority.
-		authority: func() -> option<string>;
-
-		/// Returns the resource corresponding to the outgoing Body for this
-		/// Request.
-		///
-		/// Returns success on the first call: the `outgoing-body` resource for
-		/// this `outgoing-request` can be retrieved at most once. Subsequent
-		/// calls will return error.
-		body: func() -> result<outgoing-body>;
-
-		/// Get the headers associated with the Request.
-		///
-		/// The returned `headers` resource is immutable: `set`, `append`, and
-		/// `delete` operations will fail with `header-error.immutable`.
-		///
-		/// This headers resource is a child: it must be dropped before the parent
-		/// `outgoing-request` is dropped, or its ownership is transfered to
-		/// another component by e.g. `outgoing-handler.handle`.
-		headers: func() -> headers;
-
-		/// Get the Method for the Request.
-		method: func() -> method;
-
-		/// Get the combination of the HTTP Path and Query for the Request.
-		/// When `none`, this represents an empty Path and empty Query.
-		path-with-query: func() -> option<string>;
-
-		/// Get the HTTP Related Scheme for the Request. When `none`, the
-		/// implementation may choose an appropriate default scheme.
-		scheme: func() -> option<scheme>;
-
-		/// Set the HTTP Authority for the Request. A value of `none` may be used
-		/// with Related Schemes which do not require an Authority. The HTTP and
-		/// HTTPS schemes always require an authority. Fails if the string given is
-		/// not a syntactically valid uri authority.
-		set-authority: func(authority: option<string>) -> result;
-
-		/// Set the Method for the Request. Fails if the string present in a
-		/// `method.other` argument is not a syntactically valid method.
-		set-method: func(method: method) -> result;
-
-		/// Set the combination of the HTTP Path and Query for the Request.
-		/// When `none`, this represents an empty Path and empty Query. Fails is the
-		/// string given is not a syntactically valid path and query uri component.
-		set-path-with-query: func(path-with-query: option<string>) -> result;
-
-		/// Set the HTTP Related Scheme for the Request. When `none`, the
-		/// implementation may choose an appropriate default scheme. Fails if the
-		/// string given is not a syntactically valid uri scheme.
-		set-scheme: func(scheme: option<scheme>) -> result;
-	}
-
-	/// Parameters for making an HTTP Request. Each of these parameters is
-	/// currently an optional timeout applicable to the transport layer of the
-	/// HTTP protocol.
-	///
-	/// These timeouts are separate from any the user may use to bound a
-	/// blocking call to `wasi:io/poll.poll`.
-	resource request-options {
-		/// Construct a default `request-options` value.
-		constructor();
-
-		/// The timeout for receiving subsequent chunks of bytes in the Response
-		/// body stream.
-		between-bytes-timeout: func() -> option<duration>;
-
-		/// The timeout for the initial connect to the HTTP Server.
-		connect-timeout: func() -> option<duration>;
-
-		/// The timeout for receiving the first byte of the Response body.
-		first-byte-timeout: func() -> option<duration>;
-
-		/// Set the timeout for receiving subsequent chunks of bytes in the Response
-		/// body stream. An error return value indicates that this timeout is not
-		/// supported.
-		set-between-bytes-timeout: func(duration: option<duration>) -> result;
-
-		/// Set the timeout for the initial connect to the HTTP Server. An error
-		/// return value indicates that this timeout is not supported.
-		set-connect-timeout: func(duration: option<duration>) -> result;
-
-		/// Set the timeout for receiving the first byte of the Response body. An
-		/// error return value indicates that this timeout is not supported.
-		set-first-byte-timeout: func(duration: option<duration>) -> result;
-	}
-
-	/// Represents the ability to send an HTTP Response.
-	///
-	/// This resource is used by the `wasi:http/incoming-handler` interface to
-	/// allow a Response to be sent corresponding to the Request provided as the
-	/// other argument to `incoming-handler.handle`.
-	resource response-outparam {
-
-		/// Set the value of the `response-outparam` to either send a response,
-		/// or indicate an error.
-		///
-		/// This method consumes the `response-outparam` to ensure that it is
-		/// called at most once. If it is never called, the implementation
-		/// will respond with an error.
-		///
-		/// The user may provide an `error` to `response` to allow the
-		/// implementation determine how to respond with an HTTP error response.
-		set: static func(param: response-outparam, response: result<outgoing-response, error-code>);
-	}
-
-	/// This type corresponds to the HTTP standard Status Code.
-	type status-code = u16;
-
-	/// Represents an incoming HTTP Response.
-	resource incoming-response {
-
-		/// Returns the incoming body. May be called at most once. Returns error
-		/// if called additional times.
-		consume: func() -> result<incoming-body>;
-
-		/// Returns the headers from the incoming response.
-		///
-		/// The returned `headers` resource is immutable: `set`, `append`, and
-		/// `delete` operations will fail with `header-error.immutable`.
-		///
-		/// This headers resource is a child: it must be dropped before the parent
-		/// `incoming-response` is dropped.
-		headers: func() -> headers;
-
-		/// Returns the status code from the incoming response.
-		status: func() -> status-code;
-	}
-
-	/// Represents an incoming HTTP Request or Response's Body.
-	///
-	/// A body has both its contents - a stream of bytes - and a (possibly
-	/// empty) set of trailers, indicating that the full contents of the
-	/// body have been received. This resource represents the contents as
-	/// an `input-stream` and the delivery of trailers as a `future-trailers`,
-	/// and ensures that the user of this interface may only be consuming either
-	/// the body contents or waiting on trailers at any given time.
-	resource incoming-body {
-
-		/// Returns the contents of the body, as a stream of bytes.
-		///
-		/// Returns success on first call: the stream representing the contents
-		/// can be retrieved at most once. Subsequent calls will return error.
-		///
-		/// The returned `input-stream` resource is a child: it must be dropped
-		/// before the parent `incoming-body` is dropped, or consumed by
-		/// `incoming-body.finish`.
-		///
-		/// This invariant ensures that the implementation can determine whether
-		/// the user is consuming the contents of the body, waiting on the
-		/// `future-trailers` to be ready, or neither. This allows for network
-		/// backpressure is to be applied when the user is consuming the body,
-		/// and for that backpressure to not inhibit delivery of the trailers if
-		/// the user does not read the entire body.
-		%stream: func() -> result<input-stream>;
-
-		/// Takes ownership of `incoming-body`, and returns a `future-trailers`.
-		/// This function will trap if the `input-stream` child is still alive.
-		finish: static func(this: incoming-body) -> future-trailers;
-	}
-
-	/// Represents a future which may eventaully return trailers, or an error.
-	///
-	/// In the case that the incoming HTTP Request or Response did not have any
-	/// trailers, this future will resolve to the empty set of trailers once the
-	/// complete Request or Response body has been received.
-	resource future-trailers {
-
-		/// Returns the contents of the trailers, or an error which occured,
-		/// once the future is ready.
-		///
-		/// The outer `option` represents future readiness. Users can wait on this
-		/// `option` to become `some` using the `subscribe` method.
-		///
-		/// The outer `result` is used to retrieve the trailers or error at most
-		/// once. It will be success on the first call in which the outer option
-		/// is `some`, and error on subsequent calls.
-		///
-		/// The inner `result` represents that either the HTTP Request or Response
-		/// body, as well as any trailers, were received successfully, or that an
-		/// error occured receiving them. The optional `trailers` indicates whether
-		/// or not trailers were present in the body.
-		///
-		/// When some `trailers` are returned by this method, the `trailers`
-		/// resource is immutable, and a child. Use of the `set`, `append`, or
-		/// `delete` methods will return an error, and the resource must be
-		/// dropped before the parent `future-trailers` is dropped.
-		get: func() -> option<result<result<option<trailers>, error-code>>>;
-
-		/// Returns a pollable which becomes ready when either the trailers have
-		/// been received, or an error has occured. When this pollable is ready,
-		/// the `get` method will return `some`.
-		subscribe: func() -> pollable;
-	}
-
-	/// Represents an outgoing HTTP Response.
-	resource outgoing-response {
-		/// Construct an `outgoing-response`, with a default `status-code` of `200`.
-		/// If a different `status-code` is needed, it must be set via the
-		/// `set-status-code` method.
-		///
-		/// * `headers` is the HTTP Headers for the Response.
-		constructor(headers: headers);
-
-		/// Returns the resource corresponding to the outgoing Body for this Response.
-		///
-		/// Returns success on the first call: the `outgoing-body` resource for
-		/// this `outgoing-response` can be retrieved at most once. Subsequent
-		/// calls will return error.
-		body: func() -> result<outgoing-body>;
-
-		/// Get the headers associated with the Request.
-		///
-		/// The returned `headers` resource is immutable: `set`, `append`, and
-		/// `delete` operations will fail with `header-error.immutable`.
-		///
-		/// This headers resource is a child: it must be dropped before the parent
-		/// `outgoing-request` is dropped, or its ownership is transfered to
-		/// another component by e.g. `outgoing-handler.handle`.
-		headers: func() -> headers;
-
-		/// Set the HTTP Status Code for the Response. Fails if the status-code
-		/// given is not a valid http status code.
-		set-status-code: func(status-code: status-code) -> result;
-
-		/// Get the HTTP Status Code for the Response.
-		status-code: func() -> status-code;
-	}
-
-	/// Represents an outgoing HTTP Request or Response's Body.
-	///
-	/// A body has both its contents - a stream of bytes - and a (possibly
-	/// empty) set of trailers, inducating the full contents of the body
-	/// have been sent. This resource represents the contents as an
-	/// `output-stream` child resource, and the completion of the body (with
-	/// optional trailers) with a static function that consumes the
-	/// `outgoing-body` resource, and ensures that the user of this interface
-	/// may not write to the body contents after the body has been finished.
-	///
-	/// If the user code drops this resource, as opposed to calling the static
-	/// method `finish`, the implementation should treat the body as incomplete,
-	/// and that an error has occured. The implementation should propogate this
-	/// error to the HTTP protocol by whatever means it has available,
-	/// including: corrupting the body on the wire, aborting the associated
-	/// Request, or sending a late status code for the Response.
-	resource outgoing-body {
-
-		/// Returns a stream for writing the body contents.
-		///
-		/// The returned `output-stream` is a child resource: it must be dropped
-		/// before the parent `outgoing-body` resource is dropped (or finished),
-		/// otherwise the `outgoing-body` drop or `finish` will trap.
-		///
-		/// Returns success on the first call: the `output-stream` resource for
-		/// this `outgoing-body` may be retrieved at most once. Subsequent calls
-		/// will return error.
-		write: func() -> result<output-stream>;
-
-		/// Finalize an outgoing body, optionally providing trailers. This must be
-		/// called to signal that the response is complete. If the `outgoing-body`
-		/// is dropped without calling `outgoing-body.finalize`, the implementation
-		/// should treat the body as corrupted.
-		///
-		/// Fails if the body's `outgoing-request` or `outgoing-response` was
-		/// constructed with a Content-Length header, and the contents written
-		/// to the body (via `write`) does not match the value given in the
-		/// Content-Length.
-		finish: static func(this: outgoing-body, trailers: option<trailers>) -> result<_, error-code>;
-	}
-
-	/// Represents a future which may eventaully return an incoming HTTP
-	/// Response, or an error.
-	///
-	/// This resource is returned by the `wasi:http/outgoing-handler` interface to
-	/// provide the HTTP Response corresponding to the sent Request.
-	resource future-incoming-response {
-
-		/// Returns the incoming HTTP Response, or an error, once one is ready.
-		///
-		/// The outer `option` represents future readiness. Users can wait on this
-		/// `option` to become `some` using the `subscribe` method.
-		///
-		/// The outer `result` is used to retrieve the response or error at most
-		/// once. It will be success on the first call in which the outer option
-		/// is `some`, and error on subsequent calls.
-		///
-		/// The inner `result` represents that either the incoming HTTP Response
-		/// status and headers have recieved successfully, or that an error
-		/// occured. Errors may also occur while consuming the response body,
-		/// but those will be reported by the `incoming-body` and its
-		/// `output-stream` child.
-		get: func() -> option<result<result<incoming-response, error-code>>>;
-
-		/// Returns a pollable which becomes ready when either the Response has
-		/// been received, or an error has occured. When this pollable is ready,
-		/// the `get` method will return `some`.
-		subscribe: func() -> pollable;
-	}
-
-	/// Attempts to extract a http-related `error` from the wasi:io `error`
-	/// provided.
-	///
-	/// Stream operations which return
-	/// `wasi:io/stream/stream-error::last-operation-failed` have a payload of
-	/// type `wasi:io/error/error` with more information about the operation
-	/// that failed. This payload can be passed through to this function to see
-	/// if there's http-related information about the error to return.
-	///
-	/// Note that this function is fallible because not all io-errors are
-	/// http-related errors.
-	http-error-code: func(err: borrow<io-error>) -> option<error-code>;
-}
-
-/// This interface defines a handler of incoming HTTP Requests. It should
-/// be exported by components which can respond to HTTP Requests.
-interface incoming-handler {
-	use types.{incoming-request};
-	use types.{response-outparam};
-
-	/// This function is invoked with an incoming HTTP Request, and a resource
-	/// `response-outparam` which provides the capability to reply with an HTTP
-	/// Response. The response is sent by calling the `response-outparam.set`
-	/// method, which allows execution to continue after the response has been
-	/// sent. This enables both streaming to the response body, and performing other
-	/// work.
-	///
-	/// The implementor of this function must write a response to the
-	/// `response-outparam` before returning, or else the caller will respond
-	/// with an error on its behalf.
-	handle: func(request: incoming-request, response-out: response-outparam);
-}
-
-/// This interface defines a handler of outgoing HTTP Requests. It should be
-/// imported by components which wish to make HTTP Requests.
-interface outgoing-handler {
-	use types.{outgoing-request};
-	use types.{request-options};
-	use types.{future-incoming-response};
-	use types.{error-code};
-
-	/// This function is invoked with an outgoing HTTP Request, and it returns
-	/// a resource `future-incoming-response` which represents an HTTP Response
-	/// which may arrive in the future.
-	///
-	/// The `options` argument accepts optional parameters for the HTTP
-	/// protocol's transport layer.
-	///
-	/// This function may return an error if the `outgoing-request` is invalid
-	/// or not allowed to be made. Otherwise, protocol errors are reported
-	/// through the `future-incoming-response`.
-	handle: func(request: outgoing-request, options: option<request-options>) -> result<future-incoming-response, error-code>;
-}
-
-/// The `wasi:http/imports` world imports all the APIs for HTTP proxies.
-/// It is intended to be `include`d in other worlds.
-world imports {
-	import wasi:random/random@0.2.0;
-	import wasi:io/error@0.2.0;
-	import wasi:io/poll@0.2.0;
-	import wasi:io/streams@0.2.0;
-	import wasi:cli/stdout@0.2.0;
-	import wasi:cli/stderr@0.2.0;
-	import wasi:cli/stdin@0.2.0;
-	import wasi:clocks/monotonic-clock@0.2.0;
-	import types;
-	import outgoing-handler;
-	import wasi:clocks/wall-clock@0.2.0;
-}
-
-/// The `wasi:http/proxy` world captures a widely-implementable intersection of
-/// hosts that includes HTTP forward and reverse proxies. Components targeting
-/// this world may concurrently stream in and out any number of incoming and
-/// outgoing HTTP requests.
-world proxy {
-	import wasi:io/poll@0.2.0;
-	import wasi:clocks/monotonic-clock@0.2.0;
-	import wasi:io/error@0.2.0;
-	import wasi:io/streams@0.2.0;
-	import types;
-	import wasi:random/random@0.2.0;
-	import wasi:cli/stdout@0.2.0;
-	import wasi:cli/stderr@0.2.0;
-	import wasi:cli/stdin@0.2.0;
-	import outgoing-handler;
-	import wasi:clocks/wall-clock@0.2.0;
-	export incoming-handler;
 }

--- a/testdata/wit-parser/complex-include.wit.json
+++ b/testdata/wit-parser/complex-include.wit.json
@@ -4,10 +4,14 @@
       "name": "bar-a",
       "imports": {
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         },
         "interface-1": {
-          "interface": 1
+          "interface": {
+            "id": 1
+          }
         }
       },
       "exports": {},
@@ -17,10 +21,14 @@
       "name": "baz-a",
       "imports": {
         "interface-2": {
-          "interface": 2
+          "interface": {
+            "id": 2
+          }
         },
         "interface-3": {
-          "interface": 3
+          "interface": {
+            "id": 3
+          }
         }
       },
       "exports": {},
@@ -30,10 +38,14 @@
       "name": "a",
       "imports": {
         "interface-4": {
-          "interface": 4
+          "interface": {
+            "id": 4
+          }
         },
         "interface-5": {
-          "interface": 5
+          "interface": {
+            "id": 5
+          }
         }
       },
       "exports": {},
@@ -43,10 +55,14 @@
       "name": "b",
       "imports": {
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         },
         "interface-1": {
-          "interface": 1
+          "interface": {
+            "id": 1
+          }
         }
       },
       "exports": {},
@@ -56,10 +72,14 @@
       "name": "c",
       "imports": {
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         },
         "interface-1": {
-          "interface": 1
+          "interface": {
+            "id": 1
+          }
         }
       },
       "exports": {},
@@ -69,22 +89,34 @@
       "name": "union-world",
       "imports": {
         "interface-4": {
-          "interface": 4
+          "interface": {
+            "id": 4
+          }
         },
         "interface-5": {
-          "interface": 5
+          "interface": {
+            "id": 5
+          }
         },
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         },
         "interface-1": {
-          "interface": 1
+          "interface": {
+            "id": 1
+          }
         },
         "interface-2": {
-          "interface": 2
+          "interface": {
+            "id": 2
+          }
         },
         "interface-3": {
-          "interface": 3
+          "interface": {
+            "id": 3
+          }
         }
       },
       "exports": {},

--- a/testdata/wit-parser/cross-package-resource.wit.json.golden.wit
+++ b/testdata/wit-parser/cross-package-resource.wit.json.golden.wit
@@ -1,13 +1,13 @@
-package some:dep;
-
-interface foo {
-	resource r;
-}
-
-
 package foo:bar;
 
 interface foo {
 	use some:dep/foo.{r};
 	type t = own<r>;
+}
+
+
+package some:dep;
+
+interface foo {
+	resource r;
 }

--- a/testdata/wit-parser/diamond1.wit.json
+++ b/testdata/wit-parser/diamond1.wit.json
@@ -4,10 +4,14 @@
       "name": "foo",
       "imports": {
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         },
         "interface-1": {
-          "interface": 1
+          "interface": {
+            "id": 1
+          }
         }
       },
       "exports": {},

--- a/testdata/wit-parser/feature-gates.wit
+++ b/testdata/wit-parser/feature-gates.wit
@@ -1,0 +1,118 @@
+package a:b;
+
+@unstable(feature = not-active)
+interface gated {
+}
+
+@unstable(feature = active)
+interface ungated {
+  @unstable(feature = not-active)
+  gated: func();
+
+  @unstable(feature = active)
+  ungated: func();
+}
+
+@unstable(feature = active)
+interface ungated2 {
+  @unstable(feature = not-active)
+  type gated = u32;
+  @unstable(feature = not-active)
+  type gated2 = gated;
+
+  @unstable(feature = not-active)
+  type gated-with-anonymous-type = option<option<gated>>;
+
+  @unstable(feature = active)
+  type ungated = u32;
+  @unstable(feature = active)
+  type ungated2 = ungated;
+}
+
+@unstable(feature = inactive)
+interface gated-use-target {
+  @unstable(feature = inactive)
+  type t = u32;
+}
+
+@unstable(feature = inactive)
+interface gated-use {
+  @unstable(feature = inactive)
+  use gated-use-target.{t};
+}
+
+@unstable(feature = active)
+interface ungated-use-target {
+  @unstable(feature = active)
+  type t = u32;
+}
+
+@unstable(feature = active)
+interface ungated-use {
+  @unstable(feature = active)
+  use ungated-use-target.{t};
+}
+
+@unstable(feature = inactive)
+interface gated-for-world {}
+
+@unstable(feature = inactive)
+world gated-world {
+  @unstable(feature = inactive)
+  import gated-for-world;
+  @unstable(feature = inactive)
+  export gated-for-world;
+}
+
+@unstable(feature = active)
+interface ungated-for-world {}
+
+@unstable(feature = active)
+world ungated-world {
+  @unstable(feature = active)
+  import ungated-for-world;
+  @unstable(feature = active)
+  export ungated-for-world;
+}
+
+world mixed-world {
+  @unstable(feature = inactive)
+  import gated-for-world;
+  @unstable(feature = inactive)
+  export gated-for-world;
+  @unstable(feature = inactive)
+  include gated-world;
+
+  @unstable(feature = active)
+  import ungated-for-world;
+  @unstable(feature = active)
+  export ungated-for-world;
+  @unstable(feature = inactive)
+  include ungated-world;
+}
+
+interface with-resources {
+  @unstable(feature = inactive)
+  resource gated {
+    @unstable(feature = inactive)
+    constructor();
+
+    @unstable(feature = inactive)
+    x: static func();
+
+    @unstable(feature = inactive)
+    y: func();
+  }
+
+  @unstable(feature = active)
+  resource ungated {
+    @unstable(feature = active)
+    constructor();
+
+    @unstable(feature = active)
+    x: static func();
+
+    @unstable(feature = active)
+    y: func();
+  }
+}

--- a/testdata/wit-parser/feature-gates.wit.json
+++ b/testdata/wit-parser/feature-gates.wit.json
@@ -1,0 +1,288 @@
+{
+  "worlds": [
+    {
+      "name": "ungated-world",
+      "imports": {
+        "interface-4": {
+          "interface": {
+            "id": 4,
+            "stability": {
+              "type": "unstable",
+              "feature": "active"
+            }
+          }
+        }
+      },
+      "exports": {
+        "interface-4": {
+          "interface": {
+            "id": 4,
+            "stability": {
+              "type": "unstable",
+              "feature": "active"
+            }
+          }
+        }
+      },
+      "package": 0,
+      "stability": {
+        "type": "unstable",
+        "feature": "active"
+      }
+    },
+    {
+      "name": "mixed-world",
+      "imports": {
+        "interface-4": {
+          "interface": {
+            "id": 4,
+            "stability": {
+              "type": "unstable",
+              "feature": "active"
+            }
+          }
+        }
+      },
+      "exports": {
+        "interface-4": {
+          "interface": {
+            "id": 4,
+            "stability": {
+              "type": "unstable",
+              "feature": "active"
+            }
+          }
+        }
+      },
+      "package": 0
+    }
+  ],
+  "interfaces": [
+    {
+      "name": "ungated",
+      "types": {},
+      "functions": {
+        "ungated": {
+          "name": "ungated",
+          "kind": "freestanding",
+          "params": [],
+          "results": [],
+          "stability": {
+            "type": "unstable",
+            "feature": "active"
+          }
+        }
+      },
+      "stability": {
+        "type": "unstable",
+        "feature": "active"
+      },
+      "package": 0
+    },
+    {
+      "name": "ungated2",
+      "types": {
+        "ungated": 0,
+        "ungated2": 1
+      },
+      "functions": {},
+      "stability": {
+        "type": "unstable",
+        "feature": "active"
+      },
+      "package": 0
+    },
+    {
+      "name": "ungated-use-target",
+      "types": {
+        "t": 2
+      },
+      "functions": {},
+      "stability": {
+        "type": "unstable",
+        "feature": "active"
+      },
+      "package": 0
+    },
+    {
+      "name": "ungated-use",
+      "types": {
+        "t": 3
+      },
+      "functions": {},
+      "stability": {
+        "type": "unstable",
+        "feature": "active"
+      },
+      "package": 0
+    },
+    {
+      "name": "ungated-for-world",
+      "types": {},
+      "functions": {},
+      "stability": {
+        "type": "unstable",
+        "feature": "active"
+      },
+      "package": 0
+    },
+    {
+      "name": "with-resources",
+      "types": {
+        "ungated": 4
+      },
+      "functions": {
+        "[constructor]ungated": {
+          "name": "[constructor]ungated",
+          "kind": {
+            "constructor": 4
+          },
+          "params": [],
+          "results": [
+            {
+              "type": 6
+            }
+          ],
+          "stability": {
+            "type": "unstable",
+            "feature": "active"
+          }
+        },
+        "[static]ungated.x": {
+          "name": "[static]ungated.x",
+          "kind": {
+            "static": 4
+          },
+          "params": [],
+          "results": [],
+          "stability": {
+            "type": "unstable",
+            "feature": "active"
+          }
+        },
+        "[method]ungated.y": {
+          "name": "[method]ungated.y",
+          "kind": {
+            "method": 4
+          },
+          "params": [
+            {
+              "name": "self",
+              "type": 5
+            }
+          ],
+          "results": [],
+          "stability": {
+            "type": "unstable",
+            "feature": "active"
+          }
+        }
+      },
+      "package": 0
+    }
+  ],
+  "types": [
+    {
+      "name": "ungated",
+      "kind": {
+        "type": "u32"
+      },
+      "owner": {
+        "interface": 1
+      },
+      "stability": {
+        "type": "unstable",
+        "feature": "active"
+      }
+    },
+    {
+      "name": "ungated2",
+      "kind": {
+        "type": 0
+      },
+      "owner": {
+        "interface": 1
+      },
+      "stability": {
+        "type": "unstable",
+        "feature": "active"
+      }
+    },
+    {
+      "name": "t",
+      "kind": {
+        "type": "u32"
+      },
+      "owner": {
+        "interface": 2
+      },
+      "stability": {
+        "type": "unstable",
+        "feature": "active"
+      }
+    },
+    {
+      "name": "t",
+      "kind": {
+        "type": 2
+      },
+      "owner": {
+        "interface": 3
+      },
+      "stability": {
+        "type": "unstable",
+        "feature": "active"
+      }
+    },
+    {
+      "name": "ungated",
+      "kind": "resource",
+      "owner": {
+        "interface": 5
+      },
+      "stability": {
+        "type": "unstable",
+        "feature": "active"
+      }
+    },
+    {
+      "name": null,
+      "kind": {
+        "handle": {
+          "borrow": 4
+        }
+      },
+      "owner": null,
+      "stability": {
+        "type": "unstable",
+        "feature": "active"
+      }
+    },
+    {
+      "name": null,
+      "kind": {
+        "handle": {
+          "own": 4
+        }
+      },
+      "owner": null
+    }
+  ],
+  "packages": [
+    {
+      "name": "a:b",
+      "interfaces": {
+        "ungated": 0,
+        "ungated2": 1,
+        "ungated-use-target": 2,
+        "ungated-use": 3,
+        "ungated-for-world": 4,
+        "with-resources": 5
+      },
+      "worlds": {
+        "ungated-world": 0,
+        "mixed-world": 1
+      }
+    }
+  ]
+}

--- a/testdata/wit-parser/feature-gates.wit.json
+++ b/testdata/wit-parser/feature-gates.wit.json
@@ -1,55 +1,113 @@
 {
   "worlds": [
     {
-      "name": "ungated-world",
+      "name": "gated-world",
       "imports": {
-        "interface-4": {
+        "interface-7": {
           "interface": {
-            "id": 4,
+            "id": 7,
             "stability": {
-              "type": "unstable",
-              "feature": "active"
+              "unstable": {
+                "feature": "inactive"
+              }
             }
           }
         }
       },
       "exports": {
-        "interface-4": {
+        "interface-7": {
           "interface": {
-            "id": 4,
+            "id": 7,
             "stability": {
-              "type": "unstable",
-              "feature": "active"
+              "unstable": {
+                "feature": "inactive"
+              }
             }
           }
         }
       },
       "package": 0,
       "stability": {
-        "type": "unstable",
-        "feature": "active"
+        "unstable": {
+          "feature": "inactive"
+        }
       }
     },
     {
-      "name": "mixed-world",
+      "name": "ungated-world",
       "imports": {
-        "interface-4": {
+        "interface-8": {
           "interface": {
-            "id": 4,
+            "id": 8,
             "stability": {
-              "type": "unstable",
-              "feature": "active"
+              "unstable": {
+                "feature": "active"
+              }
             }
           }
         }
       },
       "exports": {
-        "interface-4": {
+        "interface-8": {
           "interface": {
-            "id": 4,
+            "id": 8,
             "stability": {
-              "type": "unstable",
-              "feature": "active"
+              "unstable": {
+                "feature": "active"
+              }
+            }
+          }
+        }
+      },
+      "package": 0,
+      "stability": {
+        "unstable": {
+          "feature": "active"
+        }
+      }
+    },
+    {
+      "name": "mixed-world",
+      "imports": {
+        "interface-7": {
+          "interface": {
+            "id": 7,
+            "stability": {
+              "unstable": {
+                "feature": "inactive"
+              }
+            }
+          }
+        },
+        "interface-8": {
+          "interface": {
+            "id": 8,
+            "stability": {
+              "unstable": {
+                "feature": "active"
+              }
+            }
+          }
+        }
+      },
+      "exports": {
+        "interface-7": {
+          "interface": {
+            "id": 7,
+            "stability": {
+              "unstable": {
+                "feature": "inactive"
+              }
+            }
+          }
+        },
+        "interface-8": {
+          "interface": {
+            "id": 8,
+            "stability": {
+              "unstable": {
+                "feature": "active"
+              }
             }
           }
         }
@@ -59,60 +117,127 @@
   ],
   "interfaces": [
     {
+      "name": "gated",
+      "types": {},
+      "functions": {},
+      "stability": {
+        "unstable": {
+          "feature": "not-active"
+        }
+      },
+      "package": 0
+    },
+    {
       "name": "ungated",
       "types": {},
       "functions": {
+        "gated": {
+          "name": "gated",
+          "kind": "freestanding",
+          "params": [],
+          "results": [],
+          "stability": {
+            "unstable": {
+              "feature": "not-active"
+            }
+          }
+        },
         "ungated": {
           "name": "ungated",
           "kind": "freestanding",
           "params": [],
           "results": [],
           "stability": {
-            "type": "unstable",
-            "feature": "active"
+            "unstable": {
+              "feature": "active"
+            }
           }
         }
       },
       "stability": {
-        "type": "unstable",
-        "feature": "active"
+        "unstable": {
+          "feature": "active"
+        }
       },
       "package": 0
     },
     {
       "name": "ungated2",
       "types": {
-        "ungated": 0,
-        "ungated2": 1
+        "gated": 0,
+        "gated2": 1,
+        "gated-with-anonymous-type": 3,
+        "ungated": 4,
+        "ungated2": 5
       },
       "functions": {},
       "stability": {
-        "type": "unstable",
-        "feature": "active"
+        "unstable": {
+          "feature": "active"
+        }
+      },
+      "package": 0
+    },
+    {
+      "name": "gated-use-target",
+      "types": {
+        "t": 6
+      },
+      "functions": {},
+      "stability": {
+        "unstable": {
+          "feature": "inactive"
+        }
+      },
+      "package": 0
+    },
+    {
+      "name": "gated-use",
+      "types": {
+        "t": 7
+      },
+      "functions": {},
+      "stability": {
+        "unstable": {
+          "feature": "inactive"
+        }
       },
       "package": 0
     },
     {
       "name": "ungated-use-target",
       "types": {
-        "t": 2
+        "t": 8
       },
       "functions": {},
       "stability": {
-        "type": "unstable",
-        "feature": "active"
+        "unstable": {
+          "feature": "active"
+        }
       },
       "package": 0
     },
     {
       "name": "ungated-use",
       "types": {
-        "t": 3
+        "t": 9
       },
       "functions": {},
       "stability": {
-        "type": "unstable",
-        "feature": "active"
+        "unstable": {
+          "feature": "active"
+        }
+      },
+      "package": 0
+    },
+    {
+      "name": "gated-for-world",
+      "types": {},
+      "functions": {},
+      "stability": {
+        "unstable": {
+          "feature": "inactive"
+        }
       },
       "package": 0
     },
@@ -121,60 +246,113 @@
       "types": {},
       "functions": {},
       "stability": {
-        "type": "unstable",
-        "feature": "active"
+        "unstable": {
+          "feature": "active"
+        }
       },
       "package": 0
     },
     {
       "name": "with-resources",
       "types": {
-        "ungated": 4
+        "gated": 10,
+        "ungated": 11
       },
       "functions": {
-        "[constructor]ungated": {
-          "name": "[constructor]ungated",
+        "[constructor]gated": {
+          "name": "[constructor]gated",
           "kind": {
-            "constructor": 4
+            "constructor": 10
           },
           "params": [],
           "results": [
             {
-              "type": 6
+              "type": 14
             }
           ],
           "stability": {
-            "type": "unstable",
-            "feature": "active"
+            "unstable": {
+              "feature": "inactive"
+            }
+          }
+        },
+        "[static]gated.x": {
+          "name": "[static]gated.x",
+          "kind": {
+            "static": 10
+          },
+          "params": [],
+          "results": [],
+          "stability": {
+            "unstable": {
+              "feature": "inactive"
+            }
+          }
+        },
+        "[method]gated.y": {
+          "name": "[method]gated.y",
+          "kind": {
+            "method": 10
+          },
+          "params": [
+            {
+              "name": "self",
+              "type": 12
+            }
+          ],
+          "results": [],
+          "stability": {
+            "unstable": {
+              "feature": "inactive"
+            }
+          }
+        },
+        "[constructor]ungated": {
+          "name": "[constructor]ungated",
+          "kind": {
+            "constructor": 11
+          },
+          "params": [],
+          "results": [
+            {
+              "type": 15
+            }
+          ],
+          "stability": {
+            "unstable": {
+              "feature": "active"
+            }
           }
         },
         "[static]ungated.x": {
           "name": "[static]ungated.x",
           "kind": {
-            "static": 4
+            "static": 11
           },
           "params": [],
           "results": [],
           "stability": {
-            "type": "unstable",
-            "feature": "active"
+            "unstable": {
+              "feature": "active"
+            }
           }
         },
         "[method]ungated.y": {
           "name": "[method]ungated.y",
           "kind": {
-            "method": 4
+            "method": 11
           },
           "params": [
             {
               "name": "self",
-              "type": 5
+              "type": 13
             }
           ],
           "results": [],
           "stability": {
-            "type": "unstable",
-            "feature": "active"
+            "unstable": {
+              "feature": "active"
+            }
           }
         }
       },
@@ -183,33 +361,7 @@
   ],
   "types": [
     {
-      "name": "ungated",
-      "kind": {
-        "type": "u32"
-      },
-      "owner": {
-        "interface": 1
-      },
-      "stability": {
-        "type": "unstable",
-        "feature": "active"
-      }
-    },
-    {
-      "name": "ungated2",
-      "kind": {
-        "type": 0
-      },
-      "owner": {
-        "interface": 1
-      },
-      "stability": {
-        "type": "unstable",
-        "feature": "active"
-      }
-    },
-    {
-      "name": "t",
+      "name": "gated",
       "kind": {
         "type": "u32"
       },
@@ -217,52 +369,201 @@
         "interface": 2
       },
       "stability": {
-        "type": "unstable",
-        "feature": "active"
+        "unstable": {
+          "feature": "not-active"
+        }
+      }
+    },
+    {
+      "name": "gated2",
+      "kind": {
+        "type": 0
+      },
+      "owner": {
+        "interface": 2
+      },
+      "stability": {
+        "unstable": {
+          "feature": "not-active"
+        }
+      }
+    },
+    {
+      "name": null,
+      "kind": {
+        "option": 0
+      },
+      "owner": null,
+      "stability": {
+        "unstable": {
+          "feature": "not-active"
+        }
+      }
+    },
+    {
+      "name": "gated-with-anonymous-type",
+      "kind": {
+        "option": 2
+      },
+      "owner": {
+        "interface": 2
+      },
+      "stability": {
+        "unstable": {
+          "feature": "not-active"
+        }
+      }
+    },
+    {
+      "name": "ungated",
+      "kind": {
+        "type": "u32"
+      },
+      "owner": {
+        "interface": 2
+      },
+      "stability": {
+        "unstable": {
+          "feature": "active"
+        }
+      }
+    },
+    {
+      "name": "ungated2",
+      "kind": {
+        "type": 4
+      },
+      "owner": {
+        "interface": 2
+      },
+      "stability": {
+        "unstable": {
+          "feature": "active"
+        }
       }
     },
     {
       "name": "t",
       "kind": {
-        "type": 2
+        "type": "u32"
       },
       "owner": {
         "interface": 3
       },
       "stability": {
-        "type": "unstable",
-        "feature": "active"
+        "unstable": {
+          "feature": "inactive"
+        }
+      }
+    },
+    {
+      "name": "t",
+      "kind": {
+        "type": 6
+      },
+      "owner": {
+        "interface": 4
+      },
+      "stability": {
+        "unstable": {
+          "feature": "inactive"
+        }
+      }
+    },
+    {
+      "name": "t",
+      "kind": {
+        "type": "u32"
+      },
+      "owner": {
+        "interface": 5
+      },
+      "stability": {
+        "unstable": {
+          "feature": "active"
+        }
+      }
+    },
+    {
+      "name": "t",
+      "kind": {
+        "type": 8
+      },
+      "owner": {
+        "interface": 6
+      },
+      "stability": {
+        "unstable": {
+          "feature": "active"
+        }
+      }
+    },
+    {
+      "name": "gated",
+      "kind": "resource",
+      "owner": {
+        "interface": 9
+      },
+      "stability": {
+        "unstable": {
+          "feature": "inactive"
+        }
       }
     },
     {
       "name": "ungated",
       "kind": "resource",
       "owner": {
-        "interface": 5
+        "interface": 9
       },
       "stability": {
-        "type": "unstable",
-        "feature": "active"
+        "unstable": {
+          "feature": "active"
+        }
       }
     },
     {
       "name": null,
       "kind": {
         "handle": {
-          "borrow": 4
+          "borrow": 10
         }
       },
       "owner": null,
       "stability": {
-        "type": "unstable",
-        "feature": "active"
+        "unstable": {
+          "feature": "inactive"
+        }
       }
     },
     {
       "name": null,
       "kind": {
         "handle": {
-          "own": 4
+          "borrow": 11
+        }
+      },
+      "owner": null,
+      "stability": {
+        "unstable": {
+          "feature": "active"
+        }
+      }
+    },
+    {
+      "name": null,
+      "kind": {
+        "handle": {
+          "own": 10
+        }
+      },
+      "owner": null
+    },
+    {
+      "name": null,
+      "kind": {
+        "handle": {
+          "own": 11
         }
       },
       "owner": null
@@ -272,16 +573,21 @@
     {
       "name": "a:b",
       "interfaces": {
-        "ungated": 0,
-        "ungated2": 1,
-        "ungated-use-target": 2,
-        "ungated-use": 3,
-        "ungated-for-world": 4,
-        "with-resources": 5
+        "gated": 0,
+        "ungated": 1,
+        "ungated2": 2,
+        "gated-use-target": 3,
+        "gated-use": 4,
+        "ungated-use-target": 5,
+        "ungated-use": 6,
+        "gated-for-world": 7,
+        "ungated-for-world": 8,
+        "with-resources": 9
       },
       "worlds": {
-        "ungated-world": 0,
-        "mixed-world": 1
+        "gated-world": 0,
+        "ungated-world": 1,
+        "mixed-world": 2
       }
     }
   ]

--- a/testdata/wit-parser/feature-gates.wit.json.golden.wit
+++ b/testdata/wit-parser/feature-gates.wit.json.golden.wit
@@ -1,0 +1,37 @@
+package a:b;
+
+interface ungated {
+	ungated: func();
+}
+
+interface ungated2 {
+	type ungated = u32;
+	type ungated2 = ungated;
+}
+
+interface ungated-use-target {
+	type t = u32;
+}
+
+interface ungated-use {
+	use ungated-use-target.{t};
+}
+
+interface ungated-for-world {}
+
+interface with-resources {
+	resource ungated {
+		constructor();
+		y: func();
+		x: static func();
+	}
+}
+
+world ungated-world {
+	import ungated-for-world;
+	export ungated-for-world;
+}
+world mixed-world {
+	import ungated-for-world;
+	export ungated-for-world;
+}

--- a/testdata/wit-parser/feature-gates.wit.json.golden.wit
+++ b/testdata/wit-parser/feature-gates.wit.json.golden.wit
@@ -1,37 +1,57 @@
 package a:b;
 
+@unstable(feature = active)
 interface ungated {
+	@unstable(feature = active)
 	ungated: func();
 }
 
+@unstable(feature = active)
 interface ungated2 {
+	@unstable(feature = active)
 	type ungated = u32;
+	@unstable(feature = active)
 	type ungated2 = ungated;
 }
 
+@unstable(feature = active)
 interface ungated-use-target {
+	@unstable(feature = active)
 	type t = u32;
 }
 
+@unstable(feature = active)
 interface ungated-use {
+	@unstable(feature = active)
 	use ungated-use-target.{t};
 }
 
+@unstable(feature = active)
 interface ungated-for-world {}
 
 interface with-resources {
+	@unstable(feature = active)
 	resource ungated {
+		@unstable(feature = active)
 		constructor();
+		@unstable(feature = active)
 		y: func();
+		@unstable(feature = active)
 		x: static func();
 	}
 }
 
+@unstable(feature = active)
 world ungated-world {
+	@unstable(feature = active)
 	import ungated-for-world;
+	@unstable(feature = active)
 	export ungated-for-world;
 }
+
 world mixed-world {
+	@unstable(feature = active)
 	import ungated-for-world;
+	@unstable(feature = active)
 	export ungated-for-world;
 }

--- a/testdata/wit-parser/feature-gates.wit.json.golden.wit
+++ b/testdata/wit-parser/feature-gates.wit.json.golden.wit
@@ -1,17 +1,40 @@
 package a:b;
 
+@unstable(feature = not-active)
+interface gated {}
+
 @unstable(feature = active)
 interface ungated {
+	@unstable(feature = not-active)
+	gated: func();
 	@unstable(feature = active)
 	ungated: func();
 }
 
 @unstable(feature = active)
 interface ungated2 {
+	@unstable(feature = not-active)
+	type gated = u32;
+	@unstable(feature = not-active)
+	type gated2 = gated;
+	@unstable(feature = not-active)
+	type gated-with-anonymous-type = option<option<gated>>;
 	@unstable(feature = active)
 	type ungated = u32;
 	@unstable(feature = active)
 	type ungated2 = ungated;
+}
+
+@unstable(feature = inactive)
+interface gated-use-target {
+	@unstable(feature = inactive)
+	type t = u32;
+}
+
+@unstable(feature = inactive)
+interface gated-use {
+	@unstable(feature = inactive)
+	use gated-use-target.{t};
 }
 
 @unstable(feature = active)
@@ -26,10 +49,22 @@ interface ungated-use {
 	use ungated-use-target.{t};
 }
 
+@unstable(feature = inactive)
+interface gated-for-world {}
+
 @unstable(feature = active)
 interface ungated-for-world {}
 
 interface with-resources {
+	@unstable(feature = inactive)
+	resource gated {
+		@unstable(feature = inactive)
+		constructor();
+		@unstable(feature = inactive)
+		y: func();
+		@unstable(feature = inactive)
+		x: static func();
+	}
 	@unstable(feature = active)
 	resource ungated {
 		@unstable(feature = active)
@@ -41,6 +76,14 @@ interface with-resources {
 	}
 }
 
+@unstable(feature = inactive)
+world gated-world {
+	@unstable(feature = inactive)
+	import gated-for-world;
+	@unstable(feature = inactive)
+	export gated-for-world;
+}
+
 @unstable(feature = active)
 world ungated-world {
 	@unstable(feature = active)
@@ -50,8 +93,12 @@ world ungated-world {
 }
 
 world mixed-world {
+	@unstable(feature = inactive)
+	import gated-for-world;
 	@unstable(feature = active)
 	import ungated-for-world;
+	@unstable(feature = inactive)
+	export gated-for-world;
 	@unstable(feature = active)
 	export ungated-for-world;
 }

--- a/testdata/wit-parser/foreign-deps-union.wit.json
+++ b/testdata/wit-parser/foreign-deps-union.wit.json
@@ -4,10 +4,14 @@
       "name": "wasi",
       "imports": {
         "interface-8": {
-          "interface": 8
+          "interface": {
+            "id": 8
+          }
         },
         "interface-7": {
-          "interface": 7
+          "interface": {
+            "id": 7
+          }
         }
       },
       "exports": {},
@@ -17,15 +21,21 @@
       "name": "my-world",
       "imports": {
         "interface-8": {
-          "interface": 8
+          "interface": {
+            "id": 8
+          }
         },
         "interface-7": {
-          "interface": 7
+          "interface": {
+            "id": 7
+          }
         }
       },
       "exports": {
         "interface-1": {
-          "interface": 1
+          "interface": {
+            "id": 1
+          }
         }
       },
       "package": 6
@@ -34,18 +44,26 @@
       "name": "my-world2",
       "imports": {
         "interface-8": {
-          "interface": 8
+          "interface": {
+            "id": 8
+          }
         },
         "interface-7": {
-          "interface": 7
+          "interface": {
+            "id": 7
+          }
         }
       },
       "exports": {
         "interface-9": {
-          "interface": 9
+          "interface": {
+            "id": 9
+          }
         },
         "interface-1": {
-          "interface": 1
+          "interface": {
+            "id": 1
+          }
         }
       },
       "package": 6
@@ -54,10 +72,14 @@
       "name": "bars-world",
       "imports": {
         "interface-4": {
-          "interface": 4
+          "interface": {
+            "id": 4
+          }
         },
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         }
       },
       "exports": {},
@@ -67,18 +89,26 @@
       "name": "unionw-world",
       "imports": {
         "interface-8": {
-          "interface": 8
+          "interface": {
+            "id": 8
+          }
         },
         "interface-7": {
-          "interface": 7
+          "interface": {
+            "id": 7
+          }
         }
       },
       "exports": {
         "interface-1": {
-          "interface": 1
+          "interface": {
+            "id": 1
+          }
         },
         "interface-9": {
-          "interface": 9
+          "interface": {
+            "id": 9
+          }
         }
       },
       "package": 6

--- a/testdata/wit-parser/foreign-deps-union.wit.json.golden.wit
+++ b/testdata/wit-parser/foreign-deps-union.wit.json.golden.wit
@@ -20,37 +20,6 @@ interface the-default {
 }
 
 
-package foo:some-pkg;
-
-interface the-default {
-	type from-default = string;
-}
-
-interface some-interface {
-	type another-type = u32;
-}
-
-interface another-interface {
-	type yet-another-type = u8;
-}
-
-
-package foo:wasi;
-
-interface clocks {
-	type timestamp = u64;
-}
-
-interface filesystem {
-	record stat { ino: u64 }
-}
-
-world wasi {
-	import filesystem;
-	import clocks;
-}
-
-
 package foo:root;
 
 interface foo {
@@ -95,4 +64,35 @@ world unionw-world {
 	import foo:wasi/clocks;
 	export foo:corp/saas;
 	export foo;
+}
+
+
+package foo:some-pkg;
+
+interface the-default {
+	type from-default = string;
+}
+
+interface some-interface {
+	type another-type = u32;
+}
+
+interface another-interface {
+	type yet-another-type = u8;
+}
+
+
+package foo:wasi;
+
+interface clocks {
+	type timestamp = u64;
+}
+
+interface filesystem {
+	record stat { ino: u64 }
+}
+
+world wasi {
+	import filesystem;
+	import clocks;
 }

--- a/testdata/wit-parser/foreign-deps.wit.json
+++ b/testdata/wit-parser/foreign-deps.wit.json
@@ -4,15 +4,21 @@
       "name": "my-world",
       "imports": {
         "interface-8": {
-          "interface": 8
+          "interface": {
+            "id": 8
+          }
         },
         "interface-7": {
-          "interface": 7
+          "interface": {
+            "id": 7
+          }
         }
       },
       "exports": {
         "interface-1": {
-          "interface": 1
+          "interface": {
+            "id": 1
+          }
         }
       },
       "package": 6
@@ -21,18 +27,26 @@
       "name": "my-world2",
       "imports": {
         "interface-8": {
-          "interface": 8
+          "interface": {
+            "id": 8
+          }
         },
         "interface-7": {
-          "interface": 7
+          "interface": {
+            "id": 7
+          }
         }
       },
       "exports": {
         "interface-9": {
-          "interface": 9
+          "interface": {
+            "id": 9
+          }
         },
         "interface-1": {
-          "interface": 1
+          "interface": {
+            "id": 1
+          }
         }
       },
       "package": 6
@@ -41,10 +55,14 @@
       "name": "bars-world",
       "imports": {
         "interface-4": {
-          "interface": 4
+          "interface": {
+            "id": 4
+          }
         },
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         }
       },
       "exports": {},

--- a/testdata/wit-parser/foreign-deps.wit.json.golden.wit
+++ b/testdata/wit-parser/foreign-deps.wit.json.golden.wit
@@ -20,32 +20,6 @@ interface the-default {
 }
 
 
-package foo:some-pkg;
-
-interface the-default {
-	type from-default = string;
-}
-
-interface some-interface {
-	type another-type = u32;
-}
-
-interface another-interface {
-	type yet-another-type = u8;
-}
-
-
-package foo:wasi;
-
-interface clocks {
-	type timestamp = u64;
-}
-
-interface filesystem {
-	record stat { ino: u64 }
-}
-
-
 package foo:root;
 
 interface foo {
@@ -83,4 +57,30 @@ world my-world2 {
 world bars-world {
 	import foo:some-pkg/the-default;
 	import foo:another-pkg/other-interface;
+}
+
+
+package foo:some-pkg;
+
+interface the-default {
+	type from-default = string;
+}
+
+interface some-interface {
+	type another-type = u32;
+}
+
+interface another-interface {
+	type yet-another-type = u8;
+}
+
+
+package foo:wasi;
+
+interface clocks {
+	type timestamp = u64;
+}
+
+interface filesystem {
+	record stat { ino: u64 }
 }

--- a/testdata/wit-parser/ignore-files-deps.wit.json
+++ b/testdata/wit-parser/ignore-files-deps.wit.json
@@ -4,7 +4,9 @@
       "name": "foo",
       "imports": {
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         }
       },
       "exports": {},

--- a/testdata/wit-parser/import-export-overlap2.wit.json
+++ b/testdata/wit-parser/import-export-overlap2.wit.json
@@ -14,7 +14,9 @@
       },
       "exports": {
         "a": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         }
       },
       "package": 0

--- a/testdata/wit-parser/kinds-of-deps.wit.json
+++ b/testdata/wit-parser/kinds-of-deps.wit.json
@@ -4,16 +4,24 @@
       "name": "a",
       "imports": {
         "interface-2": {
-          "interface": 2
+          "interface": {
+            "id": 2
+          }
         },
         "interface-3": {
-          "interface": 3
+          "interface": {
+            "id": 3
+          }
         },
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         },
         "interface-1": {
-          "interface": 1
+          "interface": {
+            "id": 1
+          }
         }
       },
       "exports": {},

--- a/testdata/wit-parser/kinds-of-deps.wit.json.golden.wit
+++ b/testdata/wit-parser/kinds-of-deps.wit.json.golden.wit
@@ -1,11 +1,11 @@
-package d:d;
+package a:a;
 
-interface d {}
-
-
-package e:e;
-
-interface e {}
+world a {
+	import b:b/b;
+	import c:c/c;
+	import d:d/d;
+	import e:e/e;
+}
 
 
 package b:b;
@@ -18,11 +18,11 @@ package c:c;
 interface c {}
 
 
-package a:a;
+package d:d;
 
-world a {
-	import b:b/b;
-	import c:c/c;
-	import d:d/d;
-	import e:e/e;
-}
+interface d {}
+
+
+package e:e;
+
+interface e {}

--- a/testdata/wit-parser/many-names.wit.json
+++ b/testdata/wit-parser/many-names.wit.json
@@ -4,7 +4,9 @@
       "name": "name",
       "imports": {
         "name": {
-          "interface": 1
+          "interface": {
+            "id": 1
+          }
         }
       },
       "exports": {},

--- a/testdata/wit-parser/multi-file-multi-package.wit.json
+++ b/testdata/wit-parser/multi-file-multi-package.wit.json
@@ -1,0 +1,250 @@
+{
+  "worlds": [
+    {
+      "name": "w2",
+      "imports": {
+        "interface-0": {
+          "interface": {
+            "id": 0
+          }
+        },
+        "imp2": {
+          "interface": {
+            "id": 1
+          }
+        }
+      },
+      "exports": {},
+      "package": 0
+    },
+    {
+      "name": "w3",
+      "imports": {
+        "interface-2": {
+          "interface": {
+            "id": 2
+          }
+        },
+        "imp3": {
+          "interface": {
+            "id": 3
+          }
+        }
+      },
+      "exports": {},
+      "package": 1
+    },
+    {
+      "name": "w1",
+      "imports": {
+        "interface-4": {
+          "interface": {
+            "id": 4
+          }
+        },
+        "imp1": {
+          "interface": {
+            "id": 5
+          }
+        }
+      },
+      "exports": {},
+      "package": 2
+    },
+    {
+      "name": "w4",
+      "imports": {
+        "interface-6": {
+          "interface": {
+            "id": 6
+          }
+        },
+        "imp4": {
+          "interface": {
+            "id": 7
+          }
+        }
+      },
+      "exports": {},
+      "package": 3
+    }
+  ],
+  "interfaces": [
+    {
+      "name": "i2",
+      "types": {
+        "b": 0
+      },
+      "functions": {},
+      "package": 0
+    },
+    {
+      "name": null,
+      "types": {
+        "b": 1
+      },
+      "functions": {},
+      "package": 0
+    },
+    {
+      "name": "i3",
+      "types": {
+        "a": 2
+      },
+      "functions": {},
+      "package": 1
+    },
+    {
+      "name": null,
+      "types": {
+        "a": 3
+      },
+      "functions": {},
+      "package": 1
+    },
+    {
+      "name": "i1",
+      "types": {
+        "a": 4
+      },
+      "functions": {},
+      "package": 2
+    },
+    {
+      "name": null,
+      "types": {
+        "a": 5
+      },
+      "functions": {},
+      "package": 2
+    },
+    {
+      "name": "i4",
+      "types": {
+        "b": 6
+      },
+      "functions": {},
+      "package": 3
+    },
+    {
+      "name": null,
+      "types": {
+        "b": 7
+      },
+      "functions": {},
+      "package": 3
+    }
+  ],
+  "types": [
+    {
+      "name": "b",
+      "kind": {
+        "type": "u32"
+      },
+      "owner": {
+        "interface": 0
+      }
+    },
+    {
+      "name": "b",
+      "kind": {
+        "type": 0
+      },
+      "owner": {
+        "interface": 1
+      }
+    },
+    {
+      "name": "a",
+      "kind": {
+        "type": "u32"
+      },
+      "owner": {
+        "interface": 2
+      }
+    },
+    {
+      "name": "a",
+      "kind": {
+        "type": 2
+      },
+      "owner": {
+        "interface": 3
+      }
+    },
+    {
+      "name": "a",
+      "kind": {
+        "type": "u32"
+      },
+      "owner": {
+        "interface": 4
+      }
+    },
+    {
+      "name": "a",
+      "kind": {
+        "type": 4
+      },
+      "owner": {
+        "interface": 5
+      }
+    },
+    {
+      "name": "b",
+      "kind": {
+        "type": "u32"
+      },
+      "owner": {
+        "interface": 6
+      }
+    },
+    {
+      "name": "b",
+      "kind": {
+        "type": 6
+      },
+      "owner": {
+        "interface": 7
+      }
+    }
+  ],
+  "packages": [
+    {
+      "name": "bar:name",
+      "interfaces": {
+        "i2": 0
+      },
+      "worlds": {
+        "w2": 0
+      }
+    },
+    {
+      "name": "baz:name",
+      "interfaces": {
+        "i3": 2
+      },
+      "worlds": {
+        "w3": 1
+      }
+    },
+    {
+      "name": "foo:name",
+      "interfaces": {
+        "i1": 4
+      },
+      "worlds": {
+        "w1": 2
+      }
+    },
+    {
+      "name": "qux:name",
+      "interfaces": {
+        "i4": 6
+      },
+      "worlds": {
+        "w4": 3
+      }
+    }
+  ]
+}

--- a/testdata/wit-parser/multi-file-multi-package.wit.json.golden.wit
+++ b/testdata/wit-parser/multi-file-multi-package.wit.json.golden.wit
@@ -1,0 +1,54 @@
+package bar:name;
+
+interface i2 {
+	type b = u32;
+}
+
+world w2 {
+	import i2;
+	import imp2: interface {
+		use i2.{b};
+	}
+}
+
+
+package baz:name;
+
+interface i3 {
+	type a = u32;
+}
+
+world w3 {
+	import i3;
+	import imp3: interface {
+		use i3.{a};
+	}
+}
+
+
+package foo:name;
+
+interface i1 {
+	type a = u32;
+}
+
+world w1 {
+	import i1;
+	import imp1: interface {
+		use i1.{a};
+	}
+}
+
+
+package qux:name;
+
+interface i4 {
+	type b = u32;
+}
+
+world w4 {
+	import i4;
+	import imp4: interface {
+		use i4.{b};
+	}
+}

--- a/testdata/wit-parser/multi-file.wit.json
+++ b/testdata/wit-parser/multi-file.wit.json
@@ -4,12 +4,16 @@
       "name": "more-depends-on-later-things",
       "imports": {
         "interface-3": {
-          "interface": 3
+          "interface": {
+            "id": 3
+          }
         }
       },
       "exports": {
         "interface-3": {
-          "interface": 3
+          "interface": {
+            "id": 3
+          }
         }
       },
       "package": 0
@@ -18,7 +22,9 @@
       "name": "the-world",
       "imports": {
         "interface-1": {
-          "interface": 1
+          "interface": {
+            "id": 1
+          }
         },
         "x": {
           "type": 15

--- a/testdata/wit-parser/multi-package-shared-deps.wit.json
+++ b/testdata/wit-parser/multi-package-shared-deps.wit.json
@@ -1,67 +1,82 @@
 {
   "worlds": [
     {
-      "name": "bar",
+      "name": "w-bar",
       "imports": {
         "interface-0": {
           "interface": {
             "id": 0
           }
-        }
-      },
-      "exports": {
+        },
         "interface-1": {
           "interface": {
             "id": 1
           }
         }
       },
-      "package": 0
+      "exports": {},
+      "package": 2
     },
     {
-      "name": "foo",
+      "name": "w-qux",
       "imports": {
         "interface-0": {
           "interface": {
             "id": 0
           }
-        }
-      },
-      "exports": {
+        },
         "interface-1": {
           "interface": {
             "id": 1
           }
         }
       },
-      "package": 0
+      "exports": {},
+      "package": 3
     }
   ],
   "interfaces": [
     {
-      "name": "a",
+      "name": "types",
       "types": {},
       "functions": {},
       "package": 0
     },
     {
-      "name": "b",
+      "name": "types",
       "types": {},
       "functions": {},
-      "package": 0
+      "package": 1
     }
   ],
   "types": [],
   "packages": [
     {
-      "name": "foo:foo",
+      "name": "foo:dep1",
       "interfaces": {
-        "a": 0,
-        "b": 1
+        "types": 0
       },
+      "worlds": {}
+    },
+    {
+      "name": "foo:dep2",
+      "interfaces": {
+        "types": 1
+      },
+      "worlds": {}
+    },
+    {
+      "name": "foo:bar",
+      "interfaces": {},
       "worlds": {
-        "bar": 0,
-        "foo": 1
+        "w-bar": 0
+      }
+    },
+    {
+      "name": "foo:qux",
+      "interfaces": {},
+      "worlds": {
+        "w-qux": 1
       }
     }
   ]

--- a/testdata/wit-parser/multi-package-shared-deps.wit.json.golden.wit
+++ b/testdata/wit-parser/multi-package-shared-deps.wit.json.golden.wit
@@ -1,0 +1,24 @@
+package foo:dep1;
+
+interface types {}
+
+
+package foo:dep2;
+
+interface types {}
+
+
+package foo:bar;
+
+world w-bar {
+	import foo:dep1/types;
+	import foo:dep2/types;
+}
+
+
+package foo:qux;
+
+world w-qux {
+	import foo:dep1/types;
+	import foo:dep2/types;
+}

--- a/testdata/wit-parser/multi-package-shared-deps.wit.json.golden.wit
+++ b/testdata/wit-parser/multi-package-shared-deps.wit.json.golden.wit
@@ -1,3 +1,11 @@
+package foo:bar;
+
+world w-bar {
+	import foo:dep1/types;
+	import foo:dep2/types;
+}
+
+
 package foo:dep1;
 
 interface types {}
@@ -6,14 +14,6 @@ interface types {}
 package foo:dep2;
 
 interface types {}
-
-
-package foo:bar;
-
-world w-bar {
-	import foo:dep1/types;
-	import foo:dep2/types;
-}
 
 
 package foo:qux;

--- a/testdata/wit-parser/multi-package-transitive-deps.wit.json
+++ b/testdata/wit-parser/multi-package-transitive-deps.wit.json
@@ -1,0 +1,116 @@
+{
+  "worlds": [
+    {
+      "name": "w-bar",
+      "imports": {
+        "interface-0": {
+          "interface": {
+            "id": 0
+          }
+        },
+        "interface-1": {
+          "interface": {
+            "id": 1
+          }
+        }
+      },
+      "exports": {},
+      "package": 2
+    },
+    {
+      "name": "w-qux",
+      "imports": {
+        "interface-0": {
+          "interface": {
+            "id": 0
+          }
+        }
+      },
+      "exports": {},
+      "package": 3
+    }
+  ],
+  "interfaces": [
+    {
+      "name": "types",
+      "types": {
+        "a": 0
+      },
+      "functions": {},
+      "package": 0
+    },
+    {
+      "name": "types",
+      "types": {
+        "a": 1,
+        "r": 2
+      },
+      "functions": {},
+      "package": 1
+    }
+  ],
+  "types": [
+    {
+      "name": "a",
+      "kind": "resource",
+      "owner": {
+        "interface": 0
+      }
+    },
+    {
+      "name": "a",
+      "kind": {
+        "type": 0
+      },
+      "owner": {
+        "interface": 1
+      }
+    },
+    {
+      "name": "r",
+      "kind": {
+        "record": {
+          "fields": [
+            {
+              "name": "f",
+              "type": "u8"
+            }
+          ]
+        }
+      },
+      "owner": {
+        "interface": 1
+      }
+    }
+  ],
+  "packages": [
+    {
+      "name": "foo:dep2",
+      "interfaces": {
+        "types": 0
+      },
+      "worlds": {}
+    },
+    {
+      "name": "foo:dep1",
+      "interfaces": {
+        "types": 1
+      },
+      "worlds": {}
+    },
+    {
+      "name": "foo:bar",
+      "interfaces": {},
+      "worlds": {
+        "w-bar": 0
+      }
+    },
+    {
+      "name": "foo:qux",
+      "interfaces": {},
+      "worlds": {
+        "w-qux": 1
+      }
+    }
+  ]
+}

--- a/testdata/wit-parser/multi-package-transitive-deps.wit.json.golden.wit
+++ b/testdata/wit-parser/multi-package-transitive-deps.wit.json.golden.wit
@@ -1,7 +1,8 @@
-package foo:dep2;
+package foo:bar;
 
-interface types {
-	resource a;
+world w-bar {
+	import foo:dep2/types;
+	import foo:dep1/types;
 }
 
 
@@ -13,11 +14,10 @@ interface types {
 }
 
 
-package foo:bar;
+package foo:dep2;
 
-world w-bar {
-	import foo:dep2/types;
-	import foo:dep1/types;
+interface types {
+	resource a;
 }
 
 

--- a/testdata/wit-parser/multi-package-transitive-deps.wit.json.golden.wit
+++ b/testdata/wit-parser/multi-package-transitive-deps.wit.json.golden.wit
@@ -1,0 +1,28 @@
+package foo:dep2;
+
+interface types {
+	resource a;
+}
+
+
+package foo:dep1;
+
+interface types {
+	use foo:dep2/types.{a};
+	record r { f: u8 }
+}
+
+
+package foo:bar;
+
+world w-bar {
+	import foo:dep2/types;
+	import foo:dep1/types;
+}
+
+
+package foo:qux;
+
+world w-qux {
+	import foo:dep2/types;
+}

--- a/testdata/wit-parser/name-both-resource-and-type.wit.json.golden.wit
+++ b/testdata/wit-parser/name-both-resource-and-type.wit.json.golden.wit
@@ -1,10 +1,3 @@
-package some:dep;
-
-interface foo {
-	resource a;
-}
-
-
 package foo:bar;
 
 interface foo {
@@ -12,4 +5,11 @@ interface foo {
 	type t1 = a;
 	type t2 = borrow<a>;
 	type t3 = borrow<t1>;
+}
+
+
+package some:dep;
+
+interface foo {
+	resource a;
 }

--- a/testdata/wit-parser/packages-explicit-colliding-decl-names.wit.json
+++ b/testdata/wit-parser/packages-explicit-colliding-decl-names.wit.json
@@ -1,46 +1,45 @@
 {
   "worlds": [
     {
-      "name": "foo",
+      "name": "w",
       "imports": {
         "interface-0": {
           "interface": {
             "id": 0
           }
         },
-        "foo": {
+        "imp": {
+          "interface": {
+            "id": 1
+          }
+        }
+      },
+      "exports": {},
+      "package": 0
+    },
+    {
+      "name": "w",
+      "imports": {
+        "interface-2": {
           "interface": {
             "id": 2
           }
         },
-        "interface-1": {
-          "interface": {
-            "id": 1
-          }
-        },
-        "bar": {
+        "imp": {
           "interface": {
             "id": 3
           }
         }
       },
       "exports": {},
-      "package": 0
+      "package": 1
     }
   ],
   "interfaces": [
     {
-      "name": "shared1",
+      "name": "i",
       "types": {
-        "the-type": 0
-      },
-      "functions": {},
-      "package": 0
-    },
-    {
-      "name": "shared2",
-      "types": {
-        "the-type": 1
+        "a": 0
       },
       "functions": {},
       "package": 0
@@ -48,23 +47,31 @@
     {
       "name": null,
       "types": {
-        "the-type": 2
+        "a": 1
       },
       "functions": {},
       "package": 0
     },
     {
-      "name": null,
+      "name": "i",
       "types": {
-        "the-type": 3
+        "a": 2
       },
       "functions": {},
-      "package": 0
+      "package": 1
+    },
+    {
+      "name": null,
+      "types": {
+        "a": 3
+      },
+      "functions": {},
+      "package": 1
     }
   ],
   "types": [
     {
-      "name": "the-type",
+      "name": "a",
       "kind": {
         "type": "u32"
       },
@@ -73,27 +80,27 @@
       }
     },
     {
-      "name": "the-type",
+      "name": "a",
       "kind": {
-        "type": "u32"
+        "type": 0
       },
       "owner": {
         "interface": 1
       }
     },
     {
-      "name": "the-type",
+      "name": "a",
       "kind": {
-        "type": 0
+        "type": "u32"
       },
       "owner": {
         "interface": 2
       }
     },
     {
-      "name": "the-type",
+      "name": "a",
       "kind": {
-        "type": 1
+        "type": 2
       },
       "owner": {
         "interface": 3
@@ -102,13 +109,21 @@
   ],
   "packages": [
     {
-      "name": "foo:diamond",
+      "name": "bar:name",
       "interfaces": {
-        "shared1": 0,
-        "shared2": 1
+        "i": 0
       },
       "worlds": {
-        "foo": 0
+        "w": 0
+      }
+    },
+    {
+      "name": "foo:name",
+      "interfaces": {
+        "i": 2
+      },
+      "worlds": {
+        "w": 1
       }
     }
   ]

--- a/testdata/wit-parser/packages-explicit-colliding-decl-names.wit.json.golden.wit
+++ b/testdata/wit-parser/packages-explicit-colliding-decl-names.wit.json.golden.wit
@@ -1,0 +1,26 @@
+package bar:name;
+
+interface i {
+	type a = u32;
+}
+
+world w {
+	import i;
+	import imp: interface {
+		use i.{a};
+	}
+}
+
+
+package foo:name;
+
+interface i {
+	type a = u32;
+}
+
+world w {
+	import i;
+	import imp: interface {
+		use i.{a};
+	}
+}

--- a/testdata/wit-parser/packages-explicit-internal-references.wit.json
+++ b/testdata/wit-parser/packages-explicit-internal-references.wit.json
@@ -1,32 +1,26 @@
 {
   "worlds": [
     {
-      "name": "foo",
+      "name": "w1",
       "imports": {
-        "shared-items": {
-          "interface": {
-            "id": 1
-          }
-        },
         "interface-0": {
           "interface": {
             "id": 0
           }
-        }
-      },
-      "exports": {
-        "a-name": {
+        },
+        "imp1": {
           "interface": {
-            "id": 2
+            "id": 1
           }
         }
       },
-      "package": 0
+      "exports": {},
+      "package": 1
     }
   ],
   "interfaces": [
     {
-      "name": "shared-items",
+      "name": "i1",
       "types": {
         "a": 0
       },
@@ -35,17 +29,23 @@
     },
     {
       "name": null,
-      "types": {},
-      "functions": {},
-      "package": 0
-    },
-    {
-      "name": null,
       "types": {
         "a": 1
       },
-      "functions": {},
-      "package": 0
+      "functions": {
+        "fn": {
+          "name": "fn",
+          "kind": "freestanding",
+          "params": [
+            {
+              "name": "a",
+              "type": 1
+            }
+          ],
+          "results": []
+        }
+      },
+      "package": 1
     }
   ],
   "types": [
@@ -64,18 +64,23 @@
         "type": 0
       },
       "owner": {
-        "interface": 2
+        "interface": 1
       }
     }
   ],
   "packages": [
     {
-      "name": "foo:foo",
+      "name": "foo:name",
       "interfaces": {
-        "shared-items": 0
+        "i1": 0
       },
+      "worlds": {}
+    },
+    {
+      "name": "bar:name",
+      "interfaces": {},
       "worlds": {
-        "foo": 0
+        "w1": 0
       }
     }
   ]

--- a/testdata/wit-parser/packages-explicit-internal-references.wit.json.golden.wit
+++ b/testdata/wit-parser/packages-explicit-internal-references.wit.json.golden.wit
@@ -1,10 +1,3 @@
-package foo:name;
-
-interface i1 {
-	type a = u32;
-}
-
-
 package bar:name;
 
 world w1 {
@@ -13,4 +6,11 @@ world w1 {
 		use foo:name/i1.{a};
 		fn: func(a: a);
 	}
+}
+
+
+package foo:name;
+
+interface i1 {
+	type a = u32;
 }

--- a/testdata/wit-parser/packages-explicit-internal-references.wit.json.golden.wit
+++ b/testdata/wit-parser/packages-explicit-internal-references.wit.json.golden.wit
@@ -1,0 +1,16 @@
+package foo:name;
+
+interface i1 {
+	type a = u32;
+}
+
+
+package bar:name;
+
+world w1 {
+	import foo:name/i1;
+	import imp1: interface {
+		use foo:name/i1.{a};
+		fn: func(a: a);
+	}
+}

--- a/testdata/wit-parser/packages-explicit-with-semver.wit.json
+++ b/testdata/wit-parser/packages-explicit-with-semver.wit.json
@@ -1,46 +1,45 @@
 {
   "worlds": [
     {
-      "name": "foo",
+      "name": "w1",
       "imports": {
         "interface-0": {
           "interface": {
             "id": 0
           }
         },
-        "foo": {
+        "imp1": {
+          "interface": {
+            "id": 1
+          }
+        }
+      },
+      "exports": {},
+      "package": 0
+    },
+    {
+      "name": "w1",
+      "imports": {
+        "interface-2": {
           "interface": {
             "id": 2
           }
         },
-        "interface-1": {
-          "interface": {
-            "id": 1
-          }
-        },
-        "bar": {
+        "imp1": {
           "interface": {
             "id": 3
           }
         }
       },
       "exports": {},
-      "package": 0
+      "package": 1
     }
   ],
   "interfaces": [
     {
-      "name": "shared1",
+      "name": "i1",
       "types": {
-        "the-type": 0
-      },
-      "functions": {},
-      "package": 0
-    },
-    {
-      "name": "shared2",
-      "types": {
-        "the-type": 1
+        "a": 0
       },
       "functions": {},
       "package": 0
@@ -48,23 +47,31 @@
     {
       "name": null,
       "types": {
-        "the-type": 2
+        "a": 1
       },
       "functions": {},
       "package": 0
     },
     {
-      "name": null,
+      "name": "i1",
       "types": {
-        "the-type": 3
+        "a": 2
       },
       "functions": {},
-      "package": 0
+      "package": 1
+    },
+    {
+      "name": null,
+      "types": {
+        "a": 3
+      },
+      "functions": {},
+      "package": 1
     }
   ],
   "types": [
     {
-      "name": "the-type",
+      "name": "a",
       "kind": {
         "type": "u32"
       },
@@ -73,27 +80,27 @@
       }
     },
     {
-      "name": "the-type",
+      "name": "a",
       "kind": {
-        "type": "u32"
+        "type": 0
       },
       "owner": {
         "interface": 1
       }
     },
     {
-      "name": "the-type",
+      "name": "a",
       "kind": {
-        "type": 0
+        "type": "u32"
       },
       "owner": {
         "interface": 2
       }
     },
     {
-      "name": "the-type",
+      "name": "a",
       "kind": {
-        "type": 1
+        "type": 2
       },
       "owner": {
         "interface": 3
@@ -102,13 +109,21 @@
   ],
   "packages": [
     {
-      "name": "foo:diamond",
+      "name": "foo:name@1.0.0",
       "interfaces": {
-        "shared1": 0,
-        "shared2": 1
+        "i1": 0
       },
       "worlds": {
-        "foo": 0
+        "w1": 0
+      }
+    },
+    {
+      "name": "foo:name@1.0.1",
+      "interfaces": {
+        "i1": 2
+      },
+      "worlds": {
+        "w1": 1
       }
     }
   ]

--- a/testdata/wit-parser/packages-explicit-with-semver.wit.json.golden.wit
+++ b/testdata/wit-parser/packages-explicit-with-semver.wit.json.golden.wit
@@ -1,0 +1,26 @@
+package foo:name@1.0.0;
+
+interface i1 {
+	type a = u32;
+}
+
+world w1 {
+	import i1;
+	import imp1: interface {
+		use i1.{a};
+	}
+}
+
+
+package foo:name@1.0.1;
+
+interface i1 {
+	type a = u32;
+}
+
+world w1 {
+	import i1;
+	import imp1: interface {
+		use i1.{a};
+	}
+}

--- a/testdata/wit-parser/packages-multiple-explicit.wit.json
+++ b/testdata/wit-parser/packages-multiple-explicit.wit.json
@@ -1,46 +1,45 @@
 {
   "worlds": [
     {
-      "name": "foo",
+      "name": "w2",
       "imports": {
         "interface-0": {
           "interface": {
             "id": 0
           }
         },
-        "foo": {
+        "imp2": {
+          "interface": {
+            "id": 1
+          }
+        }
+      },
+      "exports": {},
+      "package": 0
+    },
+    {
+      "name": "w1",
+      "imports": {
+        "interface-2": {
           "interface": {
             "id": 2
           }
         },
-        "interface-1": {
-          "interface": {
-            "id": 1
-          }
-        },
-        "bar": {
+        "imp1": {
           "interface": {
             "id": 3
           }
         }
       },
       "exports": {},
-      "package": 0
+      "package": 1
     }
   ],
   "interfaces": [
     {
-      "name": "shared1",
+      "name": "i2",
       "types": {
-        "the-type": 0
-      },
-      "functions": {},
-      "package": 0
-    },
-    {
-      "name": "shared2",
-      "types": {
-        "the-type": 1
+        "b": 0
       },
       "functions": {},
       "package": 0
@@ -48,23 +47,31 @@
     {
       "name": null,
       "types": {
-        "the-type": 2
+        "b": 1
       },
       "functions": {},
       "package": 0
     },
     {
-      "name": null,
+      "name": "i1",
       "types": {
-        "the-type": 3
+        "a": 2
       },
       "functions": {},
-      "package": 0
+      "package": 1
+    },
+    {
+      "name": null,
+      "types": {
+        "a": 3
+      },
+      "functions": {},
+      "package": 1
     }
   ],
   "types": [
     {
-      "name": "the-type",
+      "name": "b",
       "kind": {
         "type": "u32"
       },
@@ -73,27 +80,27 @@
       }
     },
     {
-      "name": "the-type",
+      "name": "b",
       "kind": {
-        "type": "u32"
+        "type": 0
       },
       "owner": {
         "interface": 1
       }
     },
     {
-      "name": "the-type",
+      "name": "a",
       "kind": {
-        "type": 0
+        "type": "u32"
       },
       "owner": {
         "interface": 2
       }
     },
     {
-      "name": "the-type",
+      "name": "a",
       "kind": {
-        "type": 1
+        "type": 2
       },
       "owner": {
         "interface": 3
@@ -102,13 +109,21 @@
   ],
   "packages": [
     {
-      "name": "foo:diamond",
+      "name": "bar:name",
       "interfaces": {
-        "shared1": 0,
-        "shared2": 1
+        "i2": 0
       },
       "worlds": {
-        "foo": 0
+        "w2": 0
+      }
+    },
+    {
+      "name": "foo:name",
+      "interfaces": {
+        "i1": 2
+      },
+      "worlds": {
+        "w1": 1
       }
     }
   ]

--- a/testdata/wit-parser/packages-multiple-explicit.wit.json.golden.wit
+++ b/testdata/wit-parser/packages-multiple-explicit.wit.json.golden.wit
@@ -1,0 +1,26 @@
+package bar:name;
+
+interface i2 {
+	type b = u32;
+}
+
+world w2 {
+	import i2;
+	import imp2: interface {
+		use i2.{b};
+	}
+}
+
+
+package foo:name;
+
+interface i1 {
+	type a = u32;
+}
+
+world w1 {
+	import i1;
+	import imp1: interface {
+		use i1.{a};
+	}
+}

--- a/testdata/wit-parser/packages-single-explicit.wit.json
+++ b/testdata/wit-parser/packages-single-explicit.wit.json
@@ -1,39 +1,36 @@
 {
   "worlds": [
     {
-      "name": "w",
+      "name": "w1",
       "imports": {
         "interface-0": {
           "interface": {
             "id": 0
           }
         },
-        "g": {
-          "type": 1
-        }
-      },
-      "exports": {
-        "foo": {
-          "function": {
-            "name": "foo",
-            "kind": "freestanding",
-            "params": [],
-            "results": [
-              {
-                "type": 1
-              }
-            ]
+        "imp1": {
+          "interface": {
+            "id": 1
           }
         }
       },
+      "exports": {},
       "package": 0
     }
   ],
   "interfaces": [
     {
-      "name": "foo",
+      "name": "i1",
       "types": {
-        "g": 0
+        "a": 0
+      },
+      "functions": {},
+      "package": 0
+    },
+    {
+      "name": null,
+      "types": {
+        "a": 1
       },
       "functions": {},
       "package": 0
@@ -41,32 +38,32 @@
   ],
   "types": [
     {
-      "name": "g",
+      "name": "a",
       "kind": {
-        "type": "char"
+        "type": "u32"
       },
       "owner": {
         "interface": 0
       }
     },
     {
-      "name": "g",
+      "name": "a",
       "kind": {
         "type": 0
       },
       "owner": {
-        "world": 0
+        "interface": 1
       }
     }
   ],
   "packages": [
     {
-      "name": "foo:foo",
+      "name": "foo:name",
       "interfaces": {
-        "foo": 0
+        "i1": 0
       },
       "worlds": {
-        "w": 0
+        "w1": 0
       }
     }
   ]

--- a/testdata/wit-parser/packages-single-explicit.wit.json.golden.wit
+++ b/testdata/wit-parser/packages-single-explicit.wit.json.golden.wit
@@ -1,0 +1,12 @@
+package foo:name;
+
+interface i1 {
+	type a = u32;
+}
+
+world w1 {
+	import i1;
+	import imp1: interface {
+		use i1.{a};
+	}
+}

--- a/testdata/wit-parser/shared-types.wit.json
+++ b/testdata/wit-parser/shared-types.wit.json
@@ -4,12 +4,16 @@
       "name": "foo",
       "imports": {
         "foo": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         }
       },
       "exports": {
         "bar": {
-          "interface": 1
+          "interface": {
+            "id": 1
+          }
         }
       },
       "package": 0

--- a/testdata/wit-parser/since-and-unstable.wit
+++ b/testdata/wit-parser/since-and-unstable.wit
@@ -1,0 +1,89 @@
+package a:b@1.0.1;
+
+@since(version = 1.0.0)
+interface foo1 {}
+
+@since(version = 1.0.0, feature = foo)
+interface foo2 {}
+
+@since(version = 1.0.0, feature = foo-bar)
+interface foo3 {}
+
+@unstable(feature = foo2)
+interface foo4 {}
+
+@since(version = 1.0.1)
+world w1 {}
+
+@since(version = 1.0.0)
+world w2 {}
+
+interface in-an-interface {
+  @since(version = 1.0.0)
+  foo: func();
+  @since(version = 1.0.0)
+  resource r1;
+  @since(version = 1.0.0)
+  resource r2 {}
+
+  @since(version = 1.0.0)
+  type t1 = u32;
+  @since(version = 1.0.0)
+  record t2 { a: u32 }
+  @since(version = 1.0.0)
+  enum t3 { a }
+  @since(version = 1.0.0)
+  flags t4 { a }
+  @since(version = 1.0.0)
+  variant t5 { a }
+
+  @since(version = 1.0.0)
+  resource r3 {
+    @since(version = 1.0.0)
+    constructor();
+
+    @since(version = 1.0.0)
+    x1: static func();
+
+    @since(version = 1.0.0)
+    x2: func();
+  }
+}
+
+interface z {}
+
+world in-a-world {
+  @since(version = 1.0.0)
+  import x: func();
+  @since(version = 1.0.0)
+  export x: func();
+
+  @since(version = 1.0.0)
+  import y: interface {}
+  @since(version = 1.0.0)
+  export y: interface {}
+
+  @since(version = 1.0.0)
+  import z;
+  @since(version = 1.0.0)
+  export z;
+
+
+  @since(version = 1.0.0)
+  record t1 { x: u32 }
+  @since(version = 1.0.0)
+  enum t2 { a }
+  @since(version = 1.0.0)
+  variant t3 { a }
+  @since(version = 1.0.0)
+  flags t4 { a }
+  @since(version = 1.0.0)
+  type t5 = u32;
+  @since(version = 1.0.0)
+  resource t6;
+  @since(version = 1.0.0)
+  resource t7 {
+    @since(version = 1.0.0)
+    constructor();
+  }
+}

--- a/testdata/wit-parser/since-and-unstable.wit.json
+++ b/testdata/wit-parser/since-and-unstable.wit.json
@@ -1,0 +1,549 @@
+{
+  "worlds": [
+    {
+      "name": "w1",
+      "imports": {},
+      "exports": {},
+      "package": 0,
+      "stability": {
+        "type": "stable",
+        "since": "1.0.1"
+      }
+    },
+    {
+      "name": "w2",
+      "imports": {},
+      "exports": {},
+      "package": 0,
+      "stability": {
+        "type": "stable",
+        "since": "1.0.0"
+      }
+    },
+    {
+      "name": "in-a-world",
+      "imports": {
+        "y": {
+          "interface": {
+            "id": 5,
+            "stability": {
+              "type": "stable",
+              "since": "1.0.0"
+            }
+          }
+        },
+        "interface-4": {
+          "interface": {
+            "id": 4,
+            "stability": {
+              "type": "stable",
+              "since": "1.0.0"
+            }
+          }
+        },
+        "t1": {
+          "type": 9
+        },
+        "t2": {
+          "type": 10
+        },
+        "t3": {
+          "type": 11
+        },
+        "t4": {
+          "type": 12
+        },
+        "t5": {
+          "type": 13
+        },
+        "t6": {
+          "type": 14
+        },
+        "t7": {
+          "type": 15
+        },
+        "x": {
+          "function": {
+            "name": "x",
+            "kind": "freestanding",
+            "params": [],
+            "results": [],
+            "stability": {
+              "type": "stable",
+              "since": "1.0.0"
+            }
+          }
+        },
+        "[constructor]t7": {
+          "function": {
+            "name": "[constructor]t7",
+            "kind": {
+              "constructor": 15
+            },
+            "params": [],
+            "results": [
+              {
+                "type": 17
+              }
+            ],
+            "stability": {
+              "type": "stable",
+              "since": "1.0.0"
+            }
+          }
+        }
+      },
+      "exports": {
+        "x": {
+          "function": {
+            "name": "x",
+            "kind": "freestanding",
+            "params": [],
+            "results": [],
+            "stability": {
+              "type": "stable",
+              "since": "1.0.0"
+            }
+          }
+        },
+        "y": {
+          "interface": {
+            "id": 6,
+            "stability": {
+              "type": "stable",
+              "since": "1.0.0"
+            }
+          }
+        },
+        "interface-4": {
+          "interface": {
+            "id": 4,
+            "stability": {
+              "type": "stable",
+              "since": "1.0.0"
+            }
+          }
+        }
+      },
+      "package": 0
+    }
+  ],
+  "interfaces": [
+    {
+      "name": "foo1",
+      "types": {},
+      "functions": {},
+      "stability": {
+        "type": "stable",
+        "since": "1.0.0"
+      },
+      "package": 0
+    },
+    {
+      "name": "foo2",
+      "types": {},
+      "functions": {},
+      "stability": {
+        "type": "stable",
+        "since": "1.0.0",
+        "feature": "foo"
+      },
+      "package": 0
+    },
+    {
+      "name": "foo3",
+      "types": {},
+      "functions": {},
+      "stability": {
+        "type": "stable",
+        "since": "1.0.0",
+        "feature": "foo-bar"
+      },
+      "package": 0
+    },
+    {
+      "name": "in-an-interface",
+      "types": {
+        "r1": 0,
+        "r2": 1,
+        "t1": 2,
+        "t2": 3,
+        "t3": 4,
+        "t4": 5,
+        "t5": 6,
+        "r3": 7
+      },
+      "functions": {
+        "foo": {
+          "name": "foo",
+          "kind": "freestanding",
+          "params": [],
+          "results": [],
+          "stability": {
+            "type": "stable",
+            "since": "1.0.0"
+          }
+        },
+        "[constructor]r3": {
+          "name": "[constructor]r3",
+          "kind": {
+            "constructor": 7
+          },
+          "params": [],
+          "results": [
+            {
+              "type": 16
+            }
+          ],
+          "stability": {
+            "type": "stable",
+            "since": "1.0.0"
+          }
+        },
+        "[static]r3.x1": {
+          "name": "[static]r3.x1",
+          "kind": {
+            "static": 7
+          },
+          "params": [],
+          "results": [],
+          "stability": {
+            "type": "stable",
+            "since": "1.0.0"
+          }
+        },
+        "[method]r3.x2": {
+          "name": "[method]r3.x2",
+          "kind": {
+            "method": 7
+          },
+          "params": [
+            {
+              "name": "self",
+              "type": 8
+            }
+          ],
+          "results": [],
+          "stability": {
+            "type": "stable",
+            "since": "1.0.0"
+          }
+        }
+      },
+      "package": 0
+    },
+    {
+      "name": "z",
+      "types": {},
+      "functions": {},
+      "package": 0
+    },
+    {
+      "name": null,
+      "types": {},
+      "functions": {},
+      "stability": {
+        "type": "stable",
+        "since": "1.0.0"
+      },
+      "package": 0
+    },
+    {
+      "name": null,
+      "types": {},
+      "functions": {},
+      "stability": {
+        "type": "stable",
+        "since": "1.0.0"
+      },
+      "package": 0
+    }
+  ],
+  "types": [
+    {
+      "name": "r1",
+      "kind": "resource",
+      "owner": {
+        "interface": 3
+      },
+      "stability": {
+        "type": "stable",
+        "since": "1.0.0"
+      }
+    },
+    {
+      "name": "r2",
+      "kind": "resource",
+      "owner": {
+        "interface": 3
+      },
+      "stability": {
+        "type": "stable",
+        "since": "1.0.0"
+      }
+    },
+    {
+      "name": "t1",
+      "kind": {
+        "type": "u32"
+      },
+      "owner": {
+        "interface": 3
+      },
+      "stability": {
+        "type": "stable",
+        "since": "1.0.0"
+      }
+    },
+    {
+      "name": "t2",
+      "kind": {
+        "record": {
+          "fields": [
+            {
+              "name": "a",
+              "type": "u32"
+            }
+          ]
+        }
+      },
+      "owner": {
+        "interface": 3
+      },
+      "stability": {
+        "type": "stable",
+        "since": "1.0.0"
+      }
+    },
+    {
+      "name": "t3",
+      "kind": {
+        "enum": {
+          "cases": [
+            {
+              "name": "a"
+            }
+          ]
+        }
+      },
+      "owner": {
+        "interface": 3
+      },
+      "stability": {
+        "type": "stable",
+        "since": "1.0.0"
+      }
+    },
+    {
+      "name": "t4",
+      "kind": {
+        "flags": {
+          "flags": [
+            {
+              "name": "a"
+            }
+          ]
+        }
+      },
+      "owner": {
+        "interface": 3
+      },
+      "stability": {
+        "type": "stable",
+        "since": "1.0.0"
+      }
+    },
+    {
+      "name": "t5",
+      "kind": {
+        "variant": {
+          "cases": [
+            {
+              "name": "a",
+              "type": null
+            }
+          ]
+        }
+      },
+      "owner": {
+        "interface": 3
+      },
+      "stability": {
+        "type": "stable",
+        "since": "1.0.0"
+      }
+    },
+    {
+      "name": "r3",
+      "kind": "resource",
+      "owner": {
+        "interface": 3
+      },
+      "stability": {
+        "type": "stable",
+        "since": "1.0.0"
+      }
+    },
+    {
+      "name": null,
+      "kind": {
+        "handle": {
+          "borrow": 7
+        }
+      },
+      "owner": null,
+      "stability": {
+        "type": "stable",
+        "since": "1.0.0"
+      }
+    },
+    {
+      "name": "t1",
+      "kind": {
+        "record": {
+          "fields": [
+            {
+              "name": "x",
+              "type": "u32"
+            }
+          ]
+        }
+      },
+      "owner": {
+        "world": 2
+      },
+      "stability": {
+        "type": "stable",
+        "since": "1.0.0"
+      }
+    },
+    {
+      "name": "t2",
+      "kind": {
+        "enum": {
+          "cases": [
+            {
+              "name": "a"
+            }
+          ]
+        }
+      },
+      "owner": {
+        "world": 2
+      },
+      "stability": {
+        "type": "stable",
+        "since": "1.0.0"
+      }
+    },
+    {
+      "name": "t3",
+      "kind": {
+        "variant": {
+          "cases": [
+            {
+              "name": "a",
+              "type": null
+            }
+          ]
+        }
+      },
+      "owner": {
+        "world": 2
+      },
+      "stability": {
+        "type": "stable",
+        "since": "1.0.0"
+      }
+    },
+    {
+      "name": "t4",
+      "kind": {
+        "flags": {
+          "flags": [
+            {
+              "name": "a"
+            }
+          ]
+        }
+      },
+      "owner": {
+        "world": 2
+      },
+      "stability": {
+        "type": "stable",
+        "since": "1.0.0"
+      }
+    },
+    {
+      "name": "t5",
+      "kind": {
+        "type": "u32"
+      },
+      "owner": {
+        "world": 2
+      },
+      "stability": {
+        "type": "stable",
+        "since": "1.0.0"
+      }
+    },
+    {
+      "name": "t6",
+      "kind": "resource",
+      "owner": {
+        "world": 2
+      },
+      "stability": {
+        "type": "stable",
+        "since": "1.0.0"
+      }
+    },
+    {
+      "name": "t7",
+      "kind": "resource",
+      "owner": {
+        "world": 2
+      },
+      "stability": {
+        "type": "stable",
+        "since": "1.0.0"
+      }
+    },
+    {
+      "name": null,
+      "kind": {
+        "handle": {
+          "own": 7
+        }
+      },
+      "owner": null
+    },
+    {
+      "name": null,
+      "kind": {
+        "handle": {
+          "own": 15
+        }
+      },
+      "owner": null
+    }
+  ],
+  "packages": [
+    {
+      "name": "a:b@1.0.1",
+      "interfaces": {
+        "foo1": 0,
+        "foo2": 1,
+        "foo3": 2,
+        "in-an-interface": 3,
+        "z": 4
+      },
+      "worlds": {
+        "w1": 0,
+        "w2": 1,
+        "in-a-world": 2
+      }
+    }
+  ]
+}

--- a/testdata/wit-parser/since-and-unstable.wit.json
+++ b/testdata/wit-parser/since-and-unstable.wit.json
@@ -6,8 +6,9 @@
       "exports": {},
       "package": 0,
       "stability": {
-        "type": "stable",
-        "since": "1.0.1"
+        "stable": {
+          "since": "1.0.1"
+        }
       }
     },
     {
@@ -16,8 +17,9 @@
       "exports": {},
       "package": 0,
       "stability": {
-        "type": "stable",
-        "since": "1.0.0"
+        "stable": {
+          "since": "1.0.0"
+        }
       }
     },
     {
@@ -25,19 +27,21 @@
       "imports": {
         "y": {
           "interface": {
-            "id": 5,
+            "id": 6,
             "stability": {
-              "type": "stable",
-              "since": "1.0.0"
+              "stable": {
+                "since": "1.0.0"
+              }
             }
           }
         },
-        "interface-4": {
+        "interface-5": {
           "interface": {
-            "id": 4,
+            "id": 5,
             "stability": {
-              "type": "stable",
-              "since": "1.0.0"
+              "stable": {
+                "since": "1.0.0"
+              }
             }
           }
         },
@@ -69,8 +73,9 @@
             "params": [],
             "results": [],
             "stability": {
-              "type": "stable",
-              "since": "1.0.0"
+              "stable": {
+                "since": "1.0.0"
+              }
             }
           }
         },
@@ -87,8 +92,9 @@
               }
             ],
             "stability": {
-              "type": "stable",
-              "since": "1.0.0"
+              "stable": {
+                "since": "1.0.0"
+              }
             }
           }
         }
@@ -101,26 +107,29 @@
             "params": [],
             "results": [],
             "stability": {
-              "type": "stable",
-              "since": "1.0.0"
+              "stable": {
+                "since": "1.0.0"
+              }
             }
           }
         },
         "y": {
           "interface": {
-            "id": 6,
+            "id": 7,
             "stability": {
-              "type": "stable",
-              "since": "1.0.0"
+              "stable": {
+                "since": "1.0.0"
+              }
             }
           }
         },
-        "interface-4": {
+        "interface-5": {
           "interface": {
-            "id": 4,
+            "id": 5,
             "stability": {
-              "type": "stable",
-              "since": "1.0.0"
+              "stable": {
+                "since": "1.0.0"
+              }
             }
           }
         }
@@ -134,8 +143,9 @@
       "types": {},
       "functions": {},
       "stability": {
-        "type": "stable",
-        "since": "1.0.0"
+        "stable": {
+          "since": "1.0.0"
+        }
       },
       "package": 0
     },
@@ -144,9 +154,10 @@
       "types": {},
       "functions": {},
       "stability": {
-        "type": "stable",
-        "since": "1.0.0",
-        "feature": "foo"
+        "stable": {
+          "since": "1.0.0",
+          "feature": "foo"
+        }
       },
       "package": 0
     },
@@ -155,9 +166,21 @@
       "types": {},
       "functions": {},
       "stability": {
-        "type": "stable",
-        "since": "1.0.0",
-        "feature": "foo-bar"
+        "stable": {
+          "since": "1.0.0",
+          "feature": "foo-bar"
+        }
+      },
+      "package": 0
+    },
+    {
+      "name": "foo4",
+      "types": {},
+      "functions": {},
+      "stability": {
+        "unstable": {
+          "feature": "foo2"
+        }
       },
       "package": 0
     },
@@ -180,8 +203,9 @@
           "params": [],
           "results": [],
           "stability": {
-            "type": "stable",
-            "since": "1.0.0"
+            "stable": {
+              "since": "1.0.0"
+            }
           }
         },
         "[constructor]r3": {
@@ -196,8 +220,9 @@
             }
           ],
           "stability": {
-            "type": "stable",
-            "since": "1.0.0"
+            "stable": {
+              "since": "1.0.0"
+            }
           }
         },
         "[static]r3.x1": {
@@ -208,8 +233,9 @@
           "params": [],
           "results": [],
           "stability": {
-            "type": "stable",
-            "since": "1.0.0"
+            "stable": {
+              "since": "1.0.0"
+            }
           }
         },
         "[method]r3.x2": {
@@ -225,8 +251,9 @@
           ],
           "results": [],
           "stability": {
-            "type": "stable",
-            "since": "1.0.0"
+            "stable": {
+              "since": "1.0.0"
+            }
           }
         }
       },
@@ -243,8 +270,9 @@
       "types": {},
       "functions": {},
       "stability": {
-        "type": "stable",
-        "since": "1.0.0"
+        "stable": {
+          "since": "1.0.0"
+        }
       },
       "package": 0
     },
@@ -253,8 +281,9 @@
       "types": {},
       "functions": {},
       "stability": {
-        "type": "stable",
-        "since": "1.0.0"
+        "stable": {
+          "since": "1.0.0"
+        }
       },
       "package": 0
     }
@@ -264,22 +293,24 @@
       "name": "r1",
       "kind": "resource",
       "owner": {
-        "interface": 3
+        "interface": 4
       },
       "stability": {
-        "type": "stable",
-        "since": "1.0.0"
+        "stable": {
+          "since": "1.0.0"
+        }
       }
     },
     {
       "name": "r2",
       "kind": "resource",
       "owner": {
-        "interface": 3
+        "interface": 4
       },
       "stability": {
-        "type": "stable",
-        "since": "1.0.0"
+        "stable": {
+          "since": "1.0.0"
+        }
       }
     },
     {
@@ -288,11 +319,12 @@
         "type": "u32"
       },
       "owner": {
-        "interface": 3
+        "interface": 4
       },
       "stability": {
-        "type": "stable",
-        "since": "1.0.0"
+        "stable": {
+          "since": "1.0.0"
+        }
       }
     },
     {
@@ -308,11 +340,12 @@
         }
       },
       "owner": {
-        "interface": 3
+        "interface": 4
       },
       "stability": {
-        "type": "stable",
-        "since": "1.0.0"
+        "stable": {
+          "since": "1.0.0"
+        }
       }
     },
     {
@@ -327,11 +360,12 @@
         }
       },
       "owner": {
-        "interface": 3
+        "interface": 4
       },
       "stability": {
-        "type": "stable",
-        "since": "1.0.0"
+        "stable": {
+          "since": "1.0.0"
+        }
       }
     },
     {
@@ -346,11 +380,12 @@
         }
       },
       "owner": {
-        "interface": 3
+        "interface": 4
       },
       "stability": {
-        "type": "stable",
-        "since": "1.0.0"
+        "stable": {
+          "since": "1.0.0"
+        }
       }
     },
     {
@@ -366,22 +401,24 @@
         }
       },
       "owner": {
-        "interface": 3
+        "interface": 4
       },
       "stability": {
-        "type": "stable",
-        "since": "1.0.0"
+        "stable": {
+          "since": "1.0.0"
+        }
       }
     },
     {
       "name": "r3",
       "kind": "resource",
       "owner": {
-        "interface": 3
+        "interface": 4
       },
       "stability": {
-        "type": "stable",
-        "since": "1.0.0"
+        "stable": {
+          "since": "1.0.0"
+        }
       }
     },
     {
@@ -393,8 +430,9 @@
       },
       "owner": null,
       "stability": {
-        "type": "stable",
-        "since": "1.0.0"
+        "stable": {
+          "since": "1.0.0"
+        }
       }
     },
     {
@@ -413,8 +451,9 @@
         "world": 2
       },
       "stability": {
-        "type": "stable",
-        "since": "1.0.0"
+        "stable": {
+          "since": "1.0.0"
+        }
       }
     },
     {
@@ -432,8 +471,9 @@
         "world": 2
       },
       "stability": {
-        "type": "stable",
-        "since": "1.0.0"
+        "stable": {
+          "since": "1.0.0"
+        }
       }
     },
     {
@@ -452,8 +492,9 @@
         "world": 2
       },
       "stability": {
-        "type": "stable",
-        "since": "1.0.0"
+        "stable": {
+          "since": "1.0.0"
+        }
       }
     },
     {
@@ -471,8 +512,9 @@
         "world": 2
       },
       "stability": {
-        "type": "stable",
-        "since": "1.0.0"
+        "stable": {
+          "since": "1.0.0"
+        }
       }
     },
     {
@@ -484,8 +526,9 @@
         "world": 2
       },
       "stability": {
-        "type": "stable",
-        "since": "1.0.0"
+        "stable": {
+          "since": "1.0.0"
+        }
       }
     },
     {
@@ -495,8 +538,9 @@
         "world": 2
       },
       "stability": {
-        "type": "stable",
-        "since": "1.0.0"
+        "stable": {
+          "since": "1.0.0"
+        }
       }
     },
     {
@@ -506,8 +550,9 @@
         "world": 2
       },
       "stability": {
-        "type": "stable",
-        "since": "1.0.0"
+        "stable": {
+          "since": "1.0.0"
+        }
       }
     },
     {
@@ -536,8 +581,9 @@
         "foo1": 0,
         "foo2": 1,
         "foo3": 2,
-        "in-an-interface": 3,
-        "z": 4
+        "foo4": 3,
+        "in-an-interface": 4,
+        "z": 5
       },
       "worlds": {
         "w1": 0,

--- a/testdata/wit-parser/since-and-unstable.wit.json.golden.wit
+++ b/testdata/wit-parser/since-and-unstable.wit.json.golden.wit
@@ -1,45 +1,78 @@
 package a:b@1.0.1;
 
+@since(version = 1.0.0)
 interface foo1 {}
 
+@since(version = 1.0.0, feature = foo)
 interface foo2 {}
 
+@since(version = 1.0.0, feature = foo-bar)
 interface foo3 {}
 
 interface in-an-interface {
+	@since(version = 1.0.0)
 	resource r1;
+	@since(version = 1.0.0)
 	resource r2;
+	@since(version = 1.0.0)
 	type t1 = u32;
+	@since(version = 1.0.0)
 	record t2 { a: u32 }
+	@since(version = 1.0.0)
 	enum t3 { a }
+	@since(version = 1.0.0)
 	flags t4 { a }
+	@since(version = 1.0.0)
 	variant t5 { a }
+	@since(version = 1.0.0)
 	resource r3 {
+		@since(version = 1.0.0)
 		constructor();
+		@since(version = 1.0.0)
 		x2: func();
+		@since(version = 1.0.0)
 		x1: static func();
 	}
+	@since(version = 1.0.0)
 	foo: func();
 }
 
 interface z {}
 
+@since(version = 1.0.1)
 world w1 {}
+
+@since(version = 1.0.0)
 world w2 {}
+
 world in-a-world {
+	@since(version = 1.0.0)
 	import y: interface {}
+	@since(version = 1.0.0)
 	import z;
+	@since(version = 1.0.0)
 	record t1 { x: u32 }
+	@since(version = 1.0.0)
 	enum t2 { a }
+	@since(version = 1.0.0)
 	variant t3 { a }
+	@since(version = 1.0.0)
 	flags t4 { a }
+	@since(version = 1.0.0)
 	type t5 = u32;
+	@since(version = 1.0.0)
 	resource t6;
+	@since(version = 1.0.0)
 	resource t7 {
+		@since(version = 1.0.0)
 		constructor();
 	}
+	@since(version = 1.0.0)
 	import x: func();
+	@since(version = 1.0.0)
 	export x: func();
+	@since(version = 1.0.0)
 	export y: interface {}
+	@since(version = 1.0.0)
 	export z;
 }

--- a/testdata/wit-parser/since-and-unstable.wit.json.golden.wit
+++ b/testdata/wit-parser/since-and-unstable.wit.json.golden.wit
@@ -9,6 +9,9 @@ interface foo2 {}
 @since(version = 1.0.0, feature = foo-bar)
 interface foo3 {}
 
+@unstable(feature = foo2)
+interface foo4 {}
+
 interface in-an-interface {
 	@since(version = 1.0.0)
 	resource r1;

--- a/testdata/wit-parser/since-and-unstable.wit.json.golden.wit
+++ b/testdata/wit-parser/since-and-unstable.wit.json.golden.wit
@@ -1,0 +1,45 @@
+package a:b@1.0.1;
+
+interface foo1 {}
+
+interface foo2 {}
+
+interface foo3 {}
+
+interface in-an-interface {
+	resource r1;
+	resource r2;
+	type t1 = u32;
+	record t2 { a: u32 }
+	enum t3 { a }
+	flags t4 { a }
+	variant t5 { a }
+	resource r3 {
+		constructor();
+		x2: func();
+		x1: static func();
+	}
+	foo: func();
+}
+
+interface z {}
+
+world w1 {}
+world w2 {}
+world in-a-world {
+	import y: interface {}
+	import z;
+	record t1 { x: u32 }
+	enum t2 { a }
+	variant t3 { a }
+	flags t4 { a }
+	type t5 = u32;
+	resource t6;
+	resource t7 {
+		constructor();
+	}
+	import x: func();
+	export x: func();
+	export y: interface {}
+	export z;
+}

--- a/testdata/wit-parser/stress-export-elaborate.wit.json
+++ b/testdata/wit-parser/stress-export-elaborate.wit.json
@@ -4,36 +4,56 @@
       "name": "foo",
       "imports": {
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         },
         "interface-1": {
-          "interface": 1
+          "interface": {
+            "id": 1
+          }
         },
         "interface-2": {
-          "interface": 2
+          "interface": {
+            "id": 2
+          }
         },
         "interface-3": {
-          "interface": 3
+          "interface": {
+            "id": 3
+          }
         },
         "interface-4": {
-          "interface": 4
+          "interface": {
+            "id": 4
+          }
         },
         "interface-5": {
-          "interface": 5
+          "interface": {
+            "id": 5
+          }
         },
         "interface-6": {
-          "interface": 6
+          "interface": {
+            "id": 6
+          }
         },
         "interface-7": {
-          "interface": 7
+          "interface": {
+            "id": 7
+          }
         },
         "interface-8": {
-          "interface": 8
+          "interface": {
+            "id": 8
+          }
         }
       },
       "exports": {
         "interface-9": {
-          "interface": 9
+          "interface": {
+            "id": 9
+          }
         }
       },
       "package": 0

--- a/testdata/wit-parser/world-diamond.wit.json
+++ b/testdata/wit-parser/world-diamond.wit.json
@@ -4,13 +4,19 @@
       "name": "the-world",
       "imports": {
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         },
         "interface-1": {
-          "interface": 1
+          "interface": {
+            "id": 1
+          }
         },
         "interface-2": {
-          "interface": 2
+          "interface": {
+            "id": 2
+          }
         },
         "a": {
           "function": {

--- a/testdata/wit-parser/world-iface-no-collide.wit.json
+++ b/testdata/wit-parser/world-iface-no-collide.wit.json
@@ -4,7 +4,9 @@
       "name": "bar",
       "imports": {
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         },
         "t": {
           "type": 1

--- a/testdata/wit-parser/world-implicit-import1.wit.json
+++ b/testdata/wit-parser/world-implicit-import1.wit.json
@@ -4,13 +4,19 @@
       "name": "the-world",
       "imports": {
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         },
         "bar": {
-          "interface": 1
+          "interface": {
+            "id": 1
+          }
         },
         "foo": {
-          "interface": 2
+          "interface": {
+            "id": 2
+          }
         }
       },
       "exports": {},

--- a/testdata/wit-parser/world-implicit-import2.wit.json
+++ b/testdata/wit-parser/world-implicit-import2.wit.json
@@ -4,7 +4,9 @@
       "name": "w",
       "imports": {
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         },
         "g": {
           "type": 1

--- a/testdata/wit-parser/world-top-level-resources.wit.json
+++ b/testdata/wit-parser/world-top-level-resources.wit.json
@@ -4,15 +4,21 @@
       "name": "proxy",
       "imports": {
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         },
         "interface-1": {
-          "interface": 1
+          "interface": {
+            "id": 1
+          }
         }
       },
       "exports": {
         "interface-1": {
-          "interface": 1
+          "interface": {
+            "id": 1
+          }
         }
       },
       "package": 0

--- a/testdata/wit-parser/worlds-union-dedup.wit.json
+++ b/testdata/wit-parser/worlds-union-dedup.wit.json
@@ -4,10 +4,14 @@
       "name": "my-world-a",
       "imports": {
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         },
         "interface-2": {
-          "interface": 2
+          "interface": {
+            "id": 2
+          }
         }
       },
       "exports": {},
@@ -17,10 +21,14 @@
       "name": "my-world-b",
       "imports": {
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         },
         "interface-2": {
-          "interface": 2
+          "interface": {
+            "id": 2
+          }
         }
       },
       "exports": {},
@@ -30,10 +38,14 @@
       "name": "union-my-world",
       "imports": {
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         },
         "interface-2": {
-          "interface": 2
+          "interface": {
+            "id": 2
+          }
         }
       },
       "exports": {},

--- a/testdata/wit-parser/worlds-with-types.wit.json
+++ b/testdata/wit-parser/worlds-with-types.wit.json
@@ -35,7 +35,9 @@
       "name": "bar",
       "imports": {
         "interface-0": {
-          "interface": 0
+          "interface": {
+            "id": 0
+          }
         },
         "t": {
           "type": 3

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -251,7 +251,7 @@ func (g *generator) defineWorld(w *wit.World) error {
 	var err error
 	w.Imports.All()(func(name string, v wit.WorldItem) bool {
 		switch v := v.(type) {
-		case *wit.InterfaceStability:
+		case *wit.InterfaceRef:
 			// TODO: handle Stability
 			err = g.defineInterface(wit.Imported, v.Interface, name)
 		case *wit.TypeDef:
@@ -269,7 +269,7 @@ func (g *generator) defineWorld(w *wit.World) error {
 
 	w.Exports.All()(func(name string, v wit.WorldItem) bool {
 		switch v := v.(type) {
-		case *wit.InterfaceStability:
+		case *wit.InterfaceRef:
 			// TODO: handle Stability
 			err = g.defineInterface(wit.Exported, v.Interface, name)
 		case *wit.TypeDef:

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -251,8 +251,9 @@ func (g *generator) defineWorld(w *wit.World) error {
 	var err error
 	w.Imports.All()(func(name string, v wit.WorldItem) bool {
 		switch v := v.(type) {
-		case *wit.Interface:
-			err = g.defineInterface(wit.Imported, v, name)
+		case *wit.InterfaceStability:
+			// TODO: handle Stability
+			err = g.defineInterface(wit.Imported, v.Interface, name)
 		case *wit.TypeDef:
 			err = g.defineTypeDef(wit.Imported, v, name)
 		case *wit.Function:
@@ -268,8 +269,9 @@ func (g *generator) defineWorld(w *wit.World) error {
 
 	w.Exports.All()(func(name string, v wit.WorldItem) bool {
 		switch v := v.(type) {
-		case *wit.Interface:
-			err = g.defineInterface(wit.Exported, v, name)
+		case *wit.InterfaceStability:
+			// TODO: handle Stability
+			err = g.defineInterface(wit.Exported, v.Interface, name)
 		case *wit.TypeDef:
 			// WIT does not currently allow worlds to export types.
 			err = errors.New("exported type in world " + w.Name)

--- a/wit/codec.go
+++ b/wit/codec.go
@@ -39,6 +39,8 @@ func (res *Resolve) ResolveCodec(v any) codec.Codec {
 		return &functionKindCodec{v}
 	case *Handle:
 		return &handleCodec{v}
+	case *Stability:
+		return &stabilityCodec{v}
 	case *Type:
 		return &typeCodec{v, res}
 	case *TypeDefKind:
@@ -202,6 +204,18 @@ func (pn *Ident) DecodeString(s string) error {
 
 // DecodeField implements the [codec.FieldDecoder] interface
 // to decode a struct or JSON object.
+func (i *InterfaceStability) DecodeField(dec codec.Decoder, name string) error {
+	switch name {
+	case "id":
+		return dec.Decode(&i.Interface)
+	case "stability":
+		return dec.Decode(&i.Stability)
+	}
+	return nil
+}
+
+// DecodeField implements the [codec.FieldDecoder] interface
+// to decode a struct or JSON object.
 func (d *Docs) DecodeField(dec codec.Decoder, name string) error {
 	switch name {
 	case "contents":
@@ -220,8 +234,8 @@ func (c *worldItemCodec) DecodeField(dec codec.Decoder, name string) error {
 	var err error
 	switch name {
 	case "interface":
-		var v *Interface
-		err = dec.Decode(&v)
+		v := &InterfaceStability{}
+		err = dec.Decode(v)
 		*c.v = v
 	case "function":
 		var v *Function
@@ -439,6 +453,25 @@ func (c *handleCodec) DecodeField(dec codec.Decoder, name string) error {
 	case "borrow":
 		v := &Borrow{}
 		err = dec.Decode(&v.Type)
+		*c.v = v
+	}
+	return err
+}
+
+type stabilityCodec struct {
+	v *Stability
+}
+
+func (c *stabilityCodec) DecodeField(dec codec.Decoder, name string) error {
+	var err error
+	switch name {
+	case "stable":
+		v := &Stable{}
+		err = dec.Decode(v)
+		*c.v = v
+	case "unstable":
+		v := &Unstable{}
+		err = dec.Decode(v)
 		*c.v = v
 	}
 	return err

--- a/wit/codec.go
+++ b/wit/codec.go
@@ -204,7 +204,7 @@ func (pn *Ident) DecodeString(s string) error {
 
 // DecodeField implements the [codec.FieldDecoder] interface
 // to decode a struct or JSON object.
-func (i *InterfaceStability) DecodeField(dec codec.Decoder, name string) error {
+func (i *InterfaceRef) DecodeField(dec codec.Decoder, name string) error {
 	switch name {
 	case "id":
 		return dec.Decode(&i.Interface)
@@ -234,7 +234,7 @@ func (c *worldItemCodec) DecodeField(dec codec.Decoder, name string) error {
 	var err error
 	switch name {
 	case "interface":
-		v := &InterfaceStability{}
+		v := &InterfaceRef{}
 		err = dec.Decode(v)
 		*c.v = v
 	case "function":

--- a/wit/docs.go
+++ b/wit/docs.go
@@ -10,7 +10,7 @@
 //
 // Types that are represented as Rust enums are implemented via sealed Go interfaces, implemented by other types
 // in this package. An example is [WorldItem], which is the set of types that a [World] may
-// import or export, currently [Interface], [TypeDef], and [Function].
+// import or export, currently [InterfaceStability], [TypeDef], and [Function].
 //
 // # JSON
 //

--- a/wit/docs.go
+++ b/wit/docs.go
@@ -10,7 +10,7 @@
 //
 // Types that are represented as Rust enums are implemented via sealed Go interfaces, implemented by other types
 // in this package. An example is [WorldItem], which is the set of types that a [World] may
-// import or export, currently [InterfaceStability], [TypeDef], and [Function].
+// import or export, currently [InterfaceRef], [TypeDef], and [Function].
 //
 // # JSON
 //

--- a/wit/load.go
+++ b/wit/load.go
@@ -39,7 +39,7 @@ func LoadWIT(path string) (*Resolve, error) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 
-	cmd := exec.Command(wasmTools, "component", "wit", "-j")
+	cmd := exec.Command(wasmTools, "component", "wit", "-j", "--features", "active")
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if path == "" || path == "-" {

--- a/wit/load.go
+++ b/wit/load.go
@@ -39,7 +39,7 @@ func LoadWIT(path string) (*Resolve, error) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 
-	cmd := exec.Command(wasmTools, "component", "wit", "-j", "--features", "active")
+	cmd := exec.Command(wasmTools, "component", "wit", "-j", "--all-features")
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if path == "" || path == "-" {

--- a/wit/resolve.go
+++ b/wit/resolve.go
@@ -123,10 +123,9 @@ type Interface struct {
 	Name      *string
 	TypeDefs  ordered.Map[string, *TypeDef]
 	Functions ordered.Map[string, *Function]
-
-	// The [Package] that this Interface belongs to. It must be non-nil when fully resolved.
-	Package *Package
-	Docs    Docs
+	Package   *Package  // the Package this Interface belongs to
+	Stability Stability // WIT @since or @unstable (nil if unknown)
+	Docs      Docs
 }
 
 // AllFunctions returns a [sequence] that yields each [Function] in an [Interface].
@@ -147,10 +146,11 @@ func (i *Interface) AllFunctions() iterate.Seq[*Function] {
 type TypeDef struct {
 	_type
 	_worldItem
-	Name  *string
-	Kind  TypeDefKind
-	Owner TypeOwner
-	Docs  Docs
+	Name      *string
+	Kind      TypeDefKind
+	Owner     TypeOwner
+	Stability Stability // WIT @since or @unstable (nil if unknown)
+	Docs      Docs
 }
 
 // TypeName returns the [WIT] type name for t.
@@ -1289,11 +1289,12 @@ type String struct{ _primitive[string] }
 // [function]: https://component-model.bytecodealliance.org/design/wit.html#functions
 type Function struct {
 	_worldItem
-	Name    string
-	Kind    FunctionKind
-	Params  []Param // arguments to the function
-	Results []Param // a function can have a single anonymous result, or > 1 named results
-	Docs    Docs
+	Name      string
+	Kind      FunctionKind
+	Params    []Param   // arguments to the function
+	Results   []Param   // a function can have a single anonymous result, or > 1 named results
+	Stability Stability // WIT @since or @unstable (nil if unknown)
+	Docs      Docs
 }
 
 // BaseName returns the base name of [Function] f.

--- a/wit/resolve.go
+++ b/wit/resolve.go
@@ -90,7 +90,7 @@ func (w *World) AllFunctions() iterate.Seq[*Function] {
 }
 
 // A WorldItem is any item that can be exported from or imported into a [World],
-// currently either an [InterfaceStability], [TypeDef], or [Function].
+// currently either an [InterfaceRef], [TypeDef], or [Function].
 // Any WorldItem is also a [Node].
 type WorldItem interface {
 	Node
@@ -102,9 +102,9 @@ type _worldItem struct{}
 
 func (_worldItem) isWorldItem() {}
 
-// An InterfaceStability represents a reference to an [Interface] with a [Stability] attribute.
+// An InterfaceRef represents a reference to an [Interface] with a [Stability] attribute.
 // It implements the [Node] and [WorldItem] interfaces.
-type InterfaceStability struct {
+type InterfaceRef struct {
 	_worldItem
 
 	Interface *Interface

--- a/wit/resolve.go
+++ b/wit/resolve.go
@@ -54,13 +54,12 @@ func (r *Resolve) AllFunctions() iterate.Seq[*Function] {
 type World struct {
 	_typeOwner
 
-	Name    string
-	Imports ordered.Map[string, WorldItem]
-	Exports ordered.Map[string, WorldItem]
-
-	// The [Package] that this World belongs to. It must be non-nil when fully resolved.
-	Package *Package
-	Docs    Docs
+	Name      string
+	Imports   ordered.Map[string, WorldItem]
+	Exports   ordered.Map[string, WorldItem]
+	Package   *Package  // the Package this World belongs to (must be non-nil)
+	Stability Stability // WIT @since or @unstable (nil if unknown)
+	Docs      Docs
 }
 
 // AllFunctions returns a [sequence] that yields each [Function] in a [World].

--- a/wit/resolve.go
+++ b/wit/resolve.go
@@ -736,7 +736,7 @@ func (v *Variant) hasResource() bool {
 // It implements the [Node] interface.
 type Case struct {
 	Name string
-	Type Type // optional associated Type (can be nil)
+	Type Type // optional associated [Type] (can be nil)
 	Docs Docs
 }
 
@@ -855,8 +855,8 @@ func (o *Option) Flat() []Type {
 // [result type]: https://component-model.bytecodealliance.org/design/wit.html#results
 type Result struct {
 	_typeDefKind
-	OK  Type // optional associated Type (can be nil)
-	Err Type // optional associated Type (can be nil)
+	OK  Type // optional associated [Type] (can be nil)
+	Err Type // optional associated [Type] (can be nil)
 }
 
 // Despecialize despecializes [Result] o into a [Variant] with two cases, "ok" and "error".

--- a/wit/testdata_test.go
+++ b/wit/testdata_test.go
@@ -63,7 +63,9 @@ func TestGoldenWITFiles(t *testing.T) {
 }
 
 var canWasmTools = sync.OnceValue[bool](func() bool {
-	_, err := exec.LookPath("wasm-tools")
+	// This is explicitly NOT using exec.LookPath so itfails to run on WebAssembly.
+	// This disables tests that require wasm-tools.
+	err := exec.Command("wasm-tools", "--version").Run()
 	return err == nil
 })
 

--- a/wit/testdata_test.go
+++ b/wit/testdata_test.go
@@ -85,7 +85,7 @@ func TestGoldenWITRoundTrip(t *testing.T) {
 		}
 		t.Run(path, func(t *testing.T) {
 			// Run the generated WIT through wasm-tools to generate JSON.
-			cmd := exec.Command("wasm-tools", "component", "wit", "-j", "--features", "active")
+			cmd := exec.Command("wasm-tools", "component", "wit", "-j", "--all-features")
 			cmd.Stdin = strings.NewReader(data)
 			stdout := &bytes.Buffer{}
 			stderr := &bytes.Buffer{}

--- a/wit/testdata_test.go
+++ b/wit/testdata_test.go
@@ -63,7 +63,7 @@ func TestGoldenWITFiles(t *testing.T) {
 }
 
 var canWasmTools = sync.OnceValue[bool](func() bool {
-	err := exec.Command("wasm-tools", "--version").Run()
+	_, err := exec.LookPath("wasm-tools")
 	return err == nil
 })
 
@@ -83,7 +83,7 @@ func TestGoldenWITRoundTrip(t *testing.T) {
 		}
 		t.Run(path, func(t *testing.T) {
 			// Run the generated WIT through wasm-tools to generate JSON.
-			cmd := exec.Command("wasm-tools", "component", "wit", "-j")
+			cmd := exec.Command("wasm-tools", "component", "wit", "-j", "--features", "active")
 			cmd.Stdin = strings.NewReader(data)
 			stdout := &bytes.Buffer{}
 			stderr := &bytes.Buffer{}

--- a/wit/wit.go
+++ b/wit/wit.go
@@ -195,7 +195,7 @@ func (w *World) WIT(ctx Node, name string) string {
 
 func (w *World) itemWIT(motion, name string, v WorldItem) string {
 	switch v := v.(type) {
-	case *InterfaceStability, *Function:
+	case *InterfaceRef, *Function:
 		return motion + " " + v.WIT(w, name) // TODO: handle resource methods?
 	case *TypeDef:
 		return v.WIT(w, name) // no motion, in Imports only
@@ -204,16 +204,16 @@ func (w *World) itemWIT(motion, name string, v WorldItem) string {
 }
 
 // WITKind returns the WIT kind.
-func (*InterfaceStability) WITKind() string { return "interface stability" }
+func (*InterfaceRef) WITKind() string { return "interface ref" }
 
-// WIT returns the [WIT] text format for [InterfaceStability] i.
+// WIT returns the [WIT] text format for [InterfaceRef] i.
 //
 // [WIT]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md
-func (i *InterfaceStability) WIT(ctx Node, name string) string {
-	if i.Stability == nil {
-		return i.Interface.WIT(ctx, name)
+func (ref *InterfaceRef) WIT(ctx Node, name string) string {
+	if ref.Stability == nil {
+		return ref.Interface.WIT(ctx, name)
 	}
-	return i.Stability.WIT(ctx, "") + "\n" + i.Interface.WIT(ctx, name)
+	return ref.Stability.WIT(ctx, "") + "\n" + ref.Interface.WIT(ctx, name)
 }
 
 // WITKind returns the WIT kind.

--- a/wit/wit.go
+++ b/wit/wit.go
@@ -67,6 +67,38 @@ func (r *Resolve) WIT(_ Node, _ string) string {
 }
 
 // WITKind returns the WIT kind.
+func (*Stable) WITKind() string { return "@since" }
+
+// WIT returns the [WIT] text format for [Stable] s.
+//
+// [WIT]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md
+func (s *Stable) WIT(_ Node, _ string) string {
+	var b strings.Builder
+	b.WriteString("@since(version = ")
+	b.WriteString(s.Since.String())
+	if s.Feature != "" {
+		b.WriteString(", feature = ")
+		b.WriteString(s.Feature)
+	}
+	b.WriteRune(')')
+	return b.String()
+}
+
+// WITKind returns the WIT kind.
+func (*Unstable) WITKind() string { return "@unstable" }
+
+// WIT returns the [WIT] text format for [Unstable] u.
+//
+// [WIT]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md
+func (u *Unstable) WIT(_ Node, _ string) string {
+	var b strings.Builder
+	b.WriteString("@unstable(feature = ")
+	b.WriteString(u.Feature)
+	b.WriteRune(')')
+	return b.String()
+}
+
+// WITKind returns the WIT kind.
 func (*Docs) WITKind() string { return "docs" }
 
 // WIT returns the [WIT] text format for [Docs] d.
@@ -163,12 +195,25 @@ func (w *World) WIT(ctx Node, name string) string {
 
 func (w *World) itemWIT(motion, name string, v WorldItem) string {
 	switch v := v.(type) {
-	case *Interface, *Function:
+	case *InterfaceStability, *Function:
 		return motion + " " + v.WIT(w, name) // TODO: handle resource methods?
 	case *TypeDef:
 		return v.WIT(w, name) // no motion, in Imports only
 	}
 	panic("BUG: unknown WorldItem")
+}
+
+// WITKind returns the WIT kind.
+func (*InterfaceStability) WITKind() string { return "interface stability" }
+
+// WIT returns the [WIT] text format for [InterfaceStability] i.
+//
+// [WIT]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md
+func (i *InterfaceStability) WIT(ctx Node, name string) string {
+	if i.Stability == nil {
+		return i.Interface.WIT(ctx, name)
+	}
+	return i.Stability.WIT(ctx, "") + "\n" + i.Interface.WIT(ctx, name)
 }
 
 // WITKind returns the WIT kind.

--- a/wit/wit.go
+++ b/wit/wit.go
@@ -55,8 +55,12 @@ func (*Resolve) WITKind() string { return "resolve" }
 //
 // [WIT]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md
 func (r *Resolve) WIT(_ Node, _ string) string {
+	packages := slices.Clone(r.Packages)
+	slices.SortFunc(packages, func(a, b *Package) int {
+		return strings.Compare(a.Name.String(), b.Name.String())
+	})
 	var b strings.Builder
-	for i, p := range r.Packages {
+	for i, p := range packages {
 		if i > 0 {
 			b.WriteRune('\n')
 			b.WriteRune('\n')


### PR DESCRIPTION
This adds support for `@since` and `@unstable` directives in WIT files added to `wasm-tools` in https://github.com/bytecodealliance/wasm-tools/pull/1508.

TODO from [Zulip](https://bytecodealliance.zulipchat.com/#narrow/stream/327223-wit-bindgen/topic/wit-parser.20crate.3A.20JSON.20format.20changes/near/443516048):

- [x] Determine if `wasm-tools component wit -j` should require the `--features` argument, or if `-j` (JSON) implies all features. (bytecodealliance/wasm-tools#1599)
- [x] Determine if the JSON schema for `Stability` should change. (bytecodealliance/wasm-tools#1598)

Do not merge until bytecodealliance/wasm-tools#1598 and bytecodealliance/wasm-tools#1599 are merged.