### PR TITLE
wit/bindgen: skip writing empty Go files

### DIFF
--- a/cmd/wit-bindgen-go/cmd/generate/generate.go
+++ b/cmd/wit-bindgen-go/cmd/generate/generate.go
@@ -108,12 +108,17 @@ func action(ctx context.Context, cmd *cli.Command) error {
 			file := pkg.Files[filename]
 
 			dir := filepath.Join(out, strings.TrimPrefix(file.Package.Path, pkgRoot))
+			path := filepath.Join(dir, file.Name)
+
+			if !file.HasContent() {
+				fmt.Fprintf(os.Stderr, "Skipping empty file: %s\n", path)
+				continue
+			}
+
 			err := os.MkdirAll(dir, outPerm)
 			if err != nil {
 				return err
 			}
-
-			path := filepath.Join(dir, file.Name)
 
 			b, err := file.Bytes()
 			if err != nil {

--- a/internal/go/gen/file.go
+++ b/internal/go/gen/file.go
@@ -62,6 +62,23 @@ func (f *File) IsGo() bool {
 	return strings.HasSuffix(f.Name, ".go")
 }
 
+// HasContent returns true if f contains any content.
+func (f *File) HasContent() bool {
+	if !f.IsGo() {
+		return len(f.Content) > 0
+	}
+	if len(f.PackageDocs) > 0 || len(f.Header) > 0 || len(f.Content) > 0 || len(f.Trailer) > 0 {
+		return true
+	}
+	for _, name := range f.Imports {
+		if name == "_" {
+			// This file has content because it imports a Go package for its side effects.
+			return true
+		}
+	}
+	return false
+}
+
 // Write implements [io.Writer].
 func (f *File) Write(content []byte) (int, error) {
 	f.Content = append(f.Content, content...)

--- a/internal/go/gen/file_test.go
+++ b/internal/go/gen/file_test.go
@@ -4,6 +4,40 @@ import (
 	"testing"
 )
 
+func TestFileHasContent(t *testing.T) {
+	positives := []File{
+		{Name: "comment.go", Content: []byte("// Comment\n")},
+		{Name: "package_docs.go", PackageDocs: "package documentation"},
+		{Name: "header.go", Header: "// Header\n"},
+		{Name: "trailer.go", Trailer: "// Trailer\n"},
+		{Name: "blank_imports.go", Imports: map[string]string{"unsafe": "_"}},
+		{Name: "assembly.s", Content: []byte("// Comment\n")},
+	}
+	for _, f := range positives {
+		t.Run(f.Name, func(t *testing.T) {
+			got, want := f.HasContent(), true
+			if got != want {
+				t.Errorf("f.HasContent(): %t, expected %t", got, want)
+			}
+		})
+	}
+
+	negatives := []File{
+		{Name: "empty.go", GeneratedBy: "package testing"},
+		{Name: "build_tag_only.go", Build: "!wasip1"},
+		{Name: "named_imports.go", Imports: map[string]string{"unsafe": "unsafe"}},
+		{Name: "assembly.s", Content: nil},
+	}
+	for _, f := range negatives {
+		t.Run(f.Name, func(t *testing.T) {
+			got, want := f.HasContent(), false
+			if got != want {
+				t.Errorf("f.HasContent(): %t, expected %t", got, want)
+			}
+		})
+	}
+}
+
 func TestFileBytes(t *testing.T) {
 	pkg := NewPackage("wasm/wasi/clocks/wallclock")
 	f := pkg.File("wallclock.wit.go")

--- a/internal/go/gen/package.go
+++ b/internal/go/gen/package.go
@@ -54,7 +54,7 @@ func (pkg *Package) HasPackageDocs() bool {
 // with non-empty content.
 func (pkg *Package) HasContent() bool {
 	for _, file := range pkg.Files {
-		if len(file.Content) > 0 {
+		if file.HasContent() {
 			return true
 		}
 	}

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -997,7 +997,7 @@ func (g *generator) lowerRecord(file *gen.File, dir wit.Direction, t *wit.TypeDe
 		stringio.Write(&b, " = ", g.lowerType(afile, dir, f.Type, "v."+fieldName(f.Name, true)), "\n")
 	}
 	b.WriteString("return\n")
-	return g.typeDefLowerFunction(afile, dir, t, input, b.String())
+	return g.typeDefLowerFunction(file, dir, t, input, b.String())
 }
 
 func (g *generator) lowerTuple(file *gen.File, dir wit.Direction, t *wit.TypeDef, input string) string {
@@ -1019,7 +1019,7 @@ func (g *generator) lowerTuple(file *gen.File, dir wit.Direction, t *wit.TypeDef
 		stringio.Write(&b, " = ", g.lowerType(afile, dir, tt, field), "\n")
 	}
 	b.WriteString("return\n")
-	return g.typeDefLowerFunction(afile, dir, t, input, b.String())
+	return g.typeDefLowerFunction(file, dir, t, input, b.String())
 }
 
 func (g *generator) lowerFlags(file *gen.File, dir wit.Direction, t *wit.TypeDef, input string) string {

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -1001,9 +1001,9 @@ func (g *generator) lowerRecord(file *gen.File, dir wit.Direction, t *wit.TypeDe
 }
 
 func (g *generator) lowerTuple(file *gen.File, dir wit.Direction, t *wit.TypeDef, input string) string {
-	afile := g.abiFile(file.Package)
 	tup := t.Kind.(*wit.Tuple)
 	mono := tup.Type()
+	afile := g.abiFile(file.Package)
 	var b strings.Builder
 	for i, tt := range tup.Types {
 		for j := range tt.Flat() {
@@ -1038,12 +1038,12 @@ func (g *generator) lowerFlags(file *gen.File, dir wit.Direction, t *wit.TypeDef
 }
 
 func (g *generator) lowerVariant(file *gen.File, dir wit.Direction, t *wit.TypeDef, input string) string {
-	afile := g.abiFile(file.Package)
 	v := t.Kind.(*wit.Variant)
 	if v.Enum() != nil {
 		return g.cmCall(file, "LowerEnum", input)
 	}
 	flat := t.Flat()
+	afile := g.abiFile(file.Package)
 	var b strings.Builder
 	stringio.Write(&b, "f0 = ", g.cast(afile, dir, wit.Discriminant(len(v.Cases)), flat[0], g.cmCall(afile, "Tag", "&v")), "\n")
 	stringio.Write(&b, "switch f0 {\n")
@@ -1062,12 +1062,12 @@ func (g *generator) lowerVariant(file *gen.File, dir wit.Direction, t *wit.TypeD
 }
 
 func (g *generator) lowerResult(file *gen.File, dir wit.Direction, t *wit.TypeDef, input string) string {
-	afile := g.abiFile(file.Package)
 	r := t.Kind.(*wit.Result)
 	if r.OK == nil && r.Err == nil {
 		return g.cmCall(file, "LowerResult", input)
 	}
 	flat := t.Flat()
+	afile := g.abiFile(file.Package)
 	var b strings.Builder
 	stringio.Write(&b, "switch ", g.cmCall(afile, "IsErr", "&v"), " {\n")
 	b.WriteString("case false:\n")
@@ -1081,9 +1081,9 @@ func (g *generator) lowerResult(file *gen.File, dir wit.Direction, t *wit.TypeDe
 }
 
 func (g *generator) lowerOption(file *gen.File, dir wit.Direction, t *wit.TypeDef, input string) string {
-	afile := g.abiFile(file.Package)
 	o := t.Kind.(*wit.Option)
 	flat := t.Flat()
+	afile := g.abiFile(file.Package)
 	var b strings.Builder
 	stringio.Write(&b, "some := v.Some()\n")
 	b.WriteString("if some != nil {\n")
@@ -1202,8 +1202,8 @@ func (g *generator) typeDefLiftFunction(file *gen.File, dir wit.Direction, t *wi
 }
 
 func (g *generator) liftRecord(file *gen.File, dir wit.Direction, t *wit.TypeDef, input string) string {
-	afile := g.abiFile(file.Package)
 	r := t.Kind.(*wit.Record)
+	afile := g.abiFile(file.Package)
 	var b strings.Builder
 	i := 0
 	for _, f := range r.Fields {
@@ -1222,9 +1222,9 @@ func (g *generator) liftRecord(file *gen.File, dir wit.Direction, t *wit.TypeDef
 }
 
 func (g *generator) liftTuple(file *gen.File, dir wit.Direction, t *wit.TypeDef, input string) string {
-	afile := g.abiFile(file.Package)
 	tup := t.Kind.(*wit.Tuple)
 	mono := tup.Type()
+	afile := g.abiFile(file.Package)
 	var b strings.Builder
 	k := 0
 	for i, tt := range tup.Types {
@@ -1247,12 +1247,12 @@ func (g *generator) liftTuple(file *gen.File, dir wit.Direction, t *wit.TypeDef,
 }
 
 func (g *generator) liftResult(file *gen.File, dir wit.Direction, t *wit.TypeDef, input string) string {
-	afile := g.abiFile(file.Package)
 	r := t.Kind.(*wit.Result)
 	if r.OK == nil && r.Err == nil {
 		return g.cmCall(file, "Reinterpret["+g.typeRep(file, dir, t)+"]", input)
 	}
 	flat := t.Flat()
+	afile := g.abiFile(file.Package)
 	var b strings.Builder
 	stringio.Write(&b, "switch f0 {\n")
 	if r.OK != nil {
@@ -1269,9 +1269,9 @@ func (g *generator) liftResult(file *gen.File, dir wit.Direction, t *wit.TypeDef
 }
 
 func (g *generator) liftOption(file *gen.File, dir wit.Direction, t *wit.TypeDef, input string) string {
-	afile := g.abiFile(file.Package)
 	o := t.Kind.(*wit.Option)
 	flat := t.Flat()
+	afile := g.abiFile(file.Package)
 	var b strings.Builder
 	b.WriteString("if f0 == 0 {\n")
 	b.WriteString("return")


### PR DESCRIPTION
- **internal/go: add File.HasContent**
- **cmd/wit-bindgen-go: skip writing Go files without content**
- **wit/bindgen: defer creating abi.go file until needed**
- **wit/bindgen: pass file, not ABI file to typeDefLowerFunction**
