### PR TITLE
cm, wit/bindgen: fix LiftString with named string types

### DIFF
--- a/cm/abi.go
+++ b/cm/abi.go
@@ -39,9 +39,9 @@ func LiftString[Data unsafe.Pointer | uintptr | *uint8, Len uint | uintptr | uin
 }
 
 // LowerList lowers a [List] into a pair of Core WebAssembly types.
-func LowerList[L ~struct{ list[T] }, T any](list L) (*T, uint) {
+func LowerList[L ~struct{ list[T] }, T any](list L) (*T, uint32) {
 	l := (*List[T])(unsafe.Pointer(&list))
-	return l.data, l.len
+	return l.data, uint32(l.len)
 }
 
 // LiftList lifts Core WebAssembly types into a [List].

--- a/cm/abi.go
+++ b/cm/abi.go
@@ -34,8 +34,8 @@ func LowerString[S ~string](s S) (*byte, uint32) {
 }
 
 // LiftString lifts Core WebAssembly types into a [string].
-func LiftString[Data unsafe.Pointer | uintptr | *uint8, Len uint | uintptr | uint32 | uint64](data Data, len Len) string {
-	return unsafe.String((*uint8)(unsafe.Pointer(data)), int(len))
+func LiftString[T ~string, Data unsafe.Pointer | uintptr | *uint8, Len uint | uintptr | uint32 | uint64](data Data, len Len) T {
+	return T(unsafe.String((*uint8)(unsafe.Pointer(data)), int(len)))
 }
 
 // LowerList lowers a [List] into a pair of Core WebAssembly types.

--- a/testdata/example/records.wit
+++ b/testdata/example/records.wit
@@ -1,14 +1,16 @@
 package example:records;
 
 interface a {
+	type value = string;
+
 	record request {
-		name: string,
+		name: value,
 		value: u32,
 		attributes: list<u32>,
 	}
 
 	record response {
-		value: string,
+		value: value,
 		rating: u32,
 		attributes: list<u32>,
 	}
@@ -18,4 +20,5 @@ interface a {
 
 world imports {
 	import a;
+	export a;
 }

--- a/testdata/example/records.wit
+++ b/testdata/example/records.wit
@@ -4,11 +4,13 @@ interface a {
 	record request {
 		name: string,
 		value: u32,
+		attributes: list<u32>,
 	}
 
 	record response {
 		value: string,
 		rating: u32,
+		attributes: list<u32>,
 	}
 
 	handle: func(r: request) -> response;

--- a/testdata/example/records.wit.json
+++ b/testdata/example/records.wit.json
@@ -9,7 +9,13 @@
           }
         }
       },
-      "exports": {},
+      "exports": {
+        "interface-0": {
+          "interface": {
+            "id": 0
+          }
+        }
+      },
       "package": 0
     }
   ],
@@ -17,8 +23,9 @@
     {
       "name": "a",
       "types": {
-        "request": 1,
-        "response": 2
+        "value": 0,
+        "request": 2,
+        "response": 3
       },
       "functions": {
         "handle": {
@@ -27,12 +34,12 @@
           "params": [
             {
               "name": "r",
-              "type": 1
+              "type": 2
             }
           ],
           "results": [
             {
-              "type": 2
+              "type": 3
             }
           ]
         }
@@ -41,6 +48,15 @@
     }
   ],
   "types": [
+    {
+      "name": "value",
+      "kind": {
+        "type": "string"
+      },
+      "owner": {
+        "interface": 0
+      }
+    },
     {
       "name": null,
       "kind": {
@@ -55,7 +71,7 @@
           "fields": [
             {
               "name": "name",
-              "type": "string"
+              "type": 0
             },
             {
               "name": "value",
@@ -63,7 +79,7 @@
             },
             {
               "name": "attributes",
-              "type": 0
+              "type": 1
             }
           ]
         }
@@ -79,7 +95,7 @@
           "fields": [
             {
               "name": "value",
-              "type": "string"
+              "type": 0
             },
             {
               "name": "rating",
@@ -87,7 +103,7 @@
             },
             {
               "name": "attributes",
-              "type": 0
+              "type": 1
             }
           ]
         }

--- a/testdata/example/records.wit.json
+++ b/testdata/example/records.wit.json
@@ -17,8 +17,8 @@
     {
       "name": "a",
       "types": {
-        "request": 0,
-        "response": 1
+        "request": 1,
+        "response": 2
       },
       "functions": {
         "handle": {
@@ -27,12 +27,12 @@
           "params": [
             {
               "name": "r",
-              "type": 0
+              "type": 1
             }
           ],
           "results": [
             {
-              "type": 1
+              "type": 2
             }
           ]
         }
@@ -41,6 +41,13 @@
     }
   ],
   "types": [
+    {
+      "name": null,
+      "kind": {
+        "list": "u32"
+      },
+      "owner": null
+    },
     {
       "name": "request",
       "kind": {
@@ -53,6 +60,10 @@
             {
               "name": "value",
               "type": "u32"
+            },
+            {
+              "name": "attributes",
+              "type": 0
             }
           ]
         }
@@ -73,6 +84,10 @@
             {
               "name": "rating",
               "type": "u32"
+            },
+            {
+              "name": "attributes",
+              "type": 0
             }
           ]
         }

--- a/testdata/example/records.wit.json.golden.wit
+++ b/testdata/example/records.wit.json.golden.wit
@@ -1,13 +1,14 @@
 package example:records;
 
 interface a {
+	type value = string;
 	record request {
-		name: string,
+		name: value,
 		value: u32,
 		attributes: list<u32>,
 	}
 	record response {
-		value: string,
+		value: value,
 		rating: u32,
 		attributes: list<u32>,
 	}

--- a/testdata/example/records.wit.json.golden.wit
+++ b/testdata/example/records.wit.json.golden.wit
@@ -1,8 +1,16 @@
 package example:records;
 
 interface a {
-	record request { name: string, value: u32 }
-	record response { value: string, rating: u32 }
+	record request {
+		name: string,
+		value: u32,
+		attributes: list<u32>,
+	}
+	record response {
+		value: string,
+		rating: u32,
+		attributes: list<u32>,
+	}
 	handle: func(r: request) -> response;
 }
 

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -1308,7 +1308,7 @@ func (g *generator) liftPrimitive(file *gen.File, dir wit.Direction, t wit.Type,
 	flat := p.Flat()
 	switch p.(type) {
 	case wit.String:
-		return g.cmCall(file, "LiftString", input)
+		return g.cmCall(file, "LiftString["+g.typeRep(file, dir, t)+"]", input)
 	default:
 		return g.cast(file, dir, flat[0], t, input)
 	}


### PR DESCRIPTION
- **cm: LowerList returns uint32 length instead of uint**
- **testdata/example: add example of typed string**
- **cm, wit/bindgen: parameterize LiftString**
