### PR TITLE
wit/bindgen: disable generation of post-return functions

### DIFF
--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -1494,7 +1494,7 @@ func (g *generator) defineFunction(owner wit.Ident, dir wit.Direction, f *wit.Fu
 		if err != nil {
 			return err
 		}
-		if pf := f.PostReturn(); pf != nil {
+		if pf := f.PostReturn(dir); pf != nil {
 			return g.defineFunction(owner, dir, pf)
 		}
 	default:

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -1494,9 +1494,13 @@ func (g *generator) defineFunction(owner wit.Ident, dir wit.Direction, f *wit.Fu
 		if err != nil {
 			return err
 		}
-		if pf := f.PostReturn(dir); pf != nil {
-			return g.defineFunction(owner, dir, pf)
-		}
+		// A post-return function is mechanically different than
+		// other functions, in that it might not have a user-defined
+		// implementation. Since Go has a GC, this work can be deferred.
+		// Additional design work is needed here.
+		// if pf := f.PostReturn(dir); pf != nil {
+		// 	return g.defineFunction(owner, dir, pf)
+		// }
 	default:
 		return errors.New("BUG: unknown direction " + dir.String())
 	}

--- a/wit/resolve.go
+++ b/wit/resolve.go
@@ -308,7 +308,7 @@ func (*Pointer) Align() uintptr { return 4 }
 // Flat returns the [flattened] ABI representation of [Pointer].
 //
 // [flattened]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#flattening
-func (*Pointer) Flat() []Type { return []Type{U32{}} }
+func (p *Pointer) Flat() []Type { return []Type{PointerTo(p.Type)} }
 
 // hasPointer always returns true.
 func (*Pointer) hasPointer() bool    { return true }


### PR DESCRIPTION
The implementation of post-return functions (`cabi_post_*`) was wrong. This PR does two things:

1. Correct the function signature of post-return functions, deriving from the flattened (Core WebAssembly) version of exported functions, rather than the original function signature.
2. Disable generation of Go `*PostReturn` functions, including user-defined side, until a point at which we can generate a correct implementation.

The implementation of post-return functions for Go needs more design work. Given that Go has a GC, the returned pointers should eventually be garbage collected. Areas of exploration:

- Create a bookkeeping mechanism to keep track of pointers passed to `wasmexport` functions and free/release them when passed back via a post-return function.
- Determine whether this should also apply to any allocations created with `cabi_realloc`.
- For Go (as opposed to TinyGo), figure out a way to handle pointers in `variant` types, which need to represent both non-pointer and pointer values in the same memory location. This might involve sidecar returns from variant-returning or accepting functions.