### PR TITLE
chore: bump dependencies

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,12 +14,12 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Set up Go
-        uses: actions/setup-go@v5.0.1
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
@@ -36,17 +36,17 @@ jobs:
         go-version: ["1.22"]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Set up wasm-tools
-        uses: bytecodealliance/actions/wasm-tools/setup@v1.1.0
+        uses: bytecodealliance/actions/wasm-tools/setup@v1
         with:
           version: v1.212.0
 
       - name: Set up Go
-        uses: actions/setup-go@v5.0.1
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
 
@@ -75,22 +75,22 @@ jobs:
         go-version: ["1.22"]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Set up wasm-tools
-        uses: bytecodealliance/actions/wasm-tools/setup@v1.1.0
+        uses: bytecodealliance/actions/wasm-tools/setup@v1
         with:
           version: v1.212.0
 
       - name: Set up Go
-        uses: actions/setup-go@v5.0.1
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Set up TinyGo
-        uses: acifani/setup-tinygo@v2.0.0
+        uses: acifani/setup-tinygo@v2
         with:
           tinygo-version: ${{ matrix.tinygo-version }}
 
@@ -112,27 +112,27 @@ jobs:
         go-version: ["1.22"] # WASI Preview 1 only available in Go 1.21 or later
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Set up wasm-tools
-        uses: bytecodealliance/actions/wasm-tools/setup@v1.1.0
+        uses: bytecodealliance/actions/wasm-tools/setup@v1
         with:
           version: v1.212.0
 
       - name: Set up Wasmtime
-        uses: bytecodealliance/actions/wasmtime/setup@v1.1.0
+        uses: bytecodealliance/actions/wasmtime/setup@v1
         with:
           version: ${{ matrix.wasmtime-version }}
 
       - name: Set up Go
-        uses: actions/setup-go@v5.0.1
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Set up TinyGo
-        uses: acifani/setup-tinygo@v2.0.0
+        uses: acifani/setup-tinygo@v2
         with:
           tinygo-version: ${{ matrix.tinygo-version }}
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up wasm-tools
         uses: bytecodealliance/actions/wasm-tools/setup@v1.1.0
         with:
-          version: v1.210.0
+          version: v1.212.0
 
       - name: Set up Go
         uses: actions/setup-go@v5.0.1
@@ -82,7 +82,7 @@ jobs:
       - name: Set up wasm-tools
         uses: bytecodealliance/actions/wasm-tools/setup@v1.1.0
         with:
-          version: v1.210.0
+          version: v1.212.0
 
       - name: Set up Go
         uses: actions/setup-go@v5.0.1
@@ -119,7 +119,7 @@ jobs:
       - name: Set up wasm-tools
         uses: bytecodealliance/actions/wasm-tools/setup@v1.1.0
         with:
-          version: v1.210.0
+          version: v1.212.0
 
       - name: Set up Wasmtime
         uses: bytecodealliance/actions/wasmtime/setup@v1.1.0


### PR DESCRIPTION
- **.github/workflows: bump wasm-tools crate to v1.212.0**
- **.github/workflows: use v(N) versions for GitHub Actions dependencies**
