### PR TITLE
all: use byte array shape for result and variant data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+This release changes the memory layout of `variant` and `result` types to permit passing these types on the stack safely. This required breaking changes to package `cm`, detailed below, as well as slightly more verbose type signatures for WIT functions that return a typed `result`.
+
+### Breaking Changes
+- Type `cm.Result` is now `cm.BoolResult`.
+- Types `cm.OKResult` and `cm.ErrResult` have been removed, replaced with a more generalized `cm.Result[Shape, OK, Err]` type.
+
+### Added
+- WIT labels with uppercase acronyms or [initialisms](https://go.dev/wiki/CodeReviewComments#initialisms) are now preserved in Go form. For example, the WIT name `time-EOD` will result in the Go name `TimeEOD`.
+- `OK` is now a predefined initialism. For example, the WIT name `state-ok` would previously translate into the Go name `StateOk` instead of the idiomatic `StateOK`.
+
 ### Fixed
 - [#95](https://github.com/ydnar/wasm-tools-go/issues/95): `wit-bindgen-go` now correctly generates packed `data` shape types for `variant` and `result` types.
-- WIT labels with uppercase acronyms or [initialisms](https://go.dev/wiki/CodeReviewComments#initialisms) are now preserved in Go form. For example, the WIT name `time-EOD` will result in the Go name `TimeEOD`.
-- `OK` is now a predefined initialism.
+- Fixed swapped `Shape` and `Align` type parameters in the functions `cm.New` and `cm.Case` for manipulating `variant` types.
+- Variant validation now correctly reports `variant` instead of `result` in panic messages.
 
 ## [v0.1.0] — 2024-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Unreleased]
 
 ### Fixed
+- [#95](https://github.com/ydnar/wasm-tools-go/issues/95): `wit-bindgen-go` now correctly generates packed `data` shape types for `variant` and `result` types.
 - WIT labels with uppercase acronyms or [initialisms](https://go.dev/wiki/CodeReviewComments#initialisms) are now preserved in Go form. For example, the WIT name `time-EOD` will result in the Go name `TimeEOD`.
 - `OK` is now a predefined initialism.
 

--- a/cm/abi.go
+++ b/cm/abi.go
@@ -4,6 +4,9 @@ import (
 	"unsafe"
 )
 
+// StringShape is a GC shape for storing strings in [Variant] or [Result] types.
+type StringShape [unsafe.Sizeof("")]byte
+
 // Reinterpret reinterprets the bits of type From into type T.
 // Will panic if the size of From is smaller than the size of To.
 func Reinterpret[T, From any](from From) (to T) {

--- a/cm/abi.go
+++ b/cm/abi.go
@@ -4,9 +4,6 @@ import (
 	"unsafe"
 )
 
-// StringShape is a GC shape for storing strings in [Variant] or [Result] types.
-type StringShape [unsafe.Sizeof("")]byte
-
 // Reinterpret reinterprets the bits of type From into type T.
 // Will panic if the size of From is smaller than the size of To.
 func Reinterpret[T, From any](from From) (to T) {

--- a/cm/debug_test.go
+++ b/cm/debug_test.go
@@ -49,9 +49,9 @@ type ResultDebug interface {
 	VariantDebug
 }
 
-func (r Result) Size() uintptr       { return unsafe.Sizeof(r) }
-func (r Result) DataAlign() uintptr  { return 0 }
-func (r Result) DataOffset() uintptr { return 0 }
+func (r BoolResult) Size() uintptr       { return unsafe.Sizeof(r) }
+func (r BoolResult) DataAlign() uintptr  { return 0 }
+func (r BoolResult) DataOffset() uintptr { return 0 }
 
 func (r result[Shape, OK, Err]) Size() uintptr       { return unsafe.Sizeof(r) }
 func (r result[Shape, OK, Err]) DataAlign() uintptr  { return unsafe.Alignof(r.data) }

--- a/cm/result.go
+++ b/cm/result.go
@@ -36,8 +36,8 @@ type ErrResult[OK, Err any] struct{ result[Err, OK, Err] }
 // result represents the internal representation of a Component Model result type.
 type result[Shape, OK, Err any] struct {
 	isErr bool
-	_     [0][2]OK
-	_     [0][2]Err
+	_     [0]OK
+	_     [0]Err
 	data  Shape // [unsafe.Sizeof(*(*Shape)(unsafe.Pointer(nil)))]byte
 }
 

--- a/cm/result.go
+++ b/cm/result.go
@@ -33,7 +33,7 @@ type result[Shape, OK, Err any] struct {
 	isErr bool
 	_     [0]OK
 	_     [0]Err
-	data  Shape
+	data  Shape // [unsafe.Sizeof(*(*Shape)(unsafe.Pointer(nil)))]byte
 }
 
 // IsOK returns true if r represents the OK case.

--- a/cm/result.go
+++ b/cm/result.go
@@ -36,8 +36,8 @@ type ErrResult[OK, Err any] struct{ result[Err, OK, Err] }
 // result represents the internal representation of a Component Model result type.
 type result[Shape, OK, Err any] struct {
 	isErr bool
-	_     [0]OK
-	_     [0]Err
+	_     [0][2]OK
+	_     [0][2]Err
 	data  Shape // [unsafe.Sizeof(*(*Shape)(unsafe.Pointer(nil)))]byte
 }
 

--- a/cm/result.go
+++ b/cm/result.go
@@ -14,6 +14,11 @@ const (
 // False represents the OK case and true represents the error case.
 type Result bool
 
+// SomeResult represents a result sized to hold the Shape type.
+// The size of the Shape type must be greater than or equal to the size of OK and Err types.
+// For results with two zero-length types, use [Result].
+type SomeResult[Shape, OK, Err any] struct{ result[Shape, OK, Err] }
+
 // OKResult represents a result sized to hold the OK type.
 // The size of the OK type must be greater than or equal to the size of the Err type.
 // For results with two zero-length types, use [Result].

--- a/cm/result.go
+++ b/cm/result.go
@@ -19,20 +19,6 @@ type BoolResult bool
 // For results with two zero-length types, use [BoolResult].
 type Result[Shape, OK, Err any] struct{ result[Shape, OK, Err] }
 
-// OKResult represents a result sized to hold the OK type.
-// The size of the OK type must be greater than or equal to the size of the Err type.
-// For results with two zero-length types, use [BoolResult].
-//
-// TODO: change this to an alias when https://github.com/golang/go/issues/46477 is implemented.
-type OKResult[OK, Err any] struct{ result[OK, OK, Err] }
-
-// ErrResult represents a result sized to hold the Err type.
-// The size of the Err type must be greater than or equal to the size of the OK type.
-// For results with two zero-length types, use [BoolResult].
-//
-// TODO: change this to an alias when https://github.com/golang/go/issues/46477 is implemented.
-type ErrResult[OK, Err any] struct{ result[Err, OK, Err] }
-
 // result represents the internal representation of a Component Model result type.
 type result[Shape, OK, Err any] struct {
 	isErr bool
@@ -101,7 +87,7 @@ func (r *result[Shape, OK, Err]) validate() {
 }
 
 // OK returns an OK result with shape Shape and type OK and Err.
-// Pass OKResult[OK, Err] or ErrResult[OK, Err] as the first type argument.
+// Pass Result[OK, OK, Err] or Result[Err, OK, Err] as the first type argument.
 func OK[R ~struct{ result[Shape, OK, Err] }, Shape, OK, Err any](ok OK) R {
 	var r struct{ result[Shape, OK, Err] }
 	r.validate()
@@ -111,7 +97,7 @@ func OK[R ~struct{ result[Shape, OK, Err] }, Shape, OK, Err any](ok OK) R {
 }
 
 // Err returns an error result with shape Shape and type OK and Err.
-// Pass OKResult[OK, Err] or ErrResult[OK, Err] as the first type argument.
+// Pass Result[OK, OK, Err] or Result[Err, OK, Err] as the first type argument.
 func Err[R ~struct{ result[Shape, OK, Err] }, Shape, OK, Err any](err Err) R {
 	var r struct{ result[Shape, OK, Err] }
 	r.validate()

--- a/cm/result.go
+++ b/cm/result.go
@@ -10,25 +10,25 @@ const (
 	ResultErr = true
 )
 
-// Result represents a result with no OK or error type.
+// BoolResult represents a result with no OK or error type.
 // False represents the OK case and true represents the error case.
-type Result bool
+type BoolResult bool
 
-// SomeResult represents a result sized to hold the Shape type.
+// Result represents a result sized to hold the Shape type.
 // The size of the Shape type must be greater than or equal to the size of OK and Err types.
-// For results with two zero-length types, use [Result].
-type SomeResult[Shape, OK, Err any] struct{ result[Shape, OK, Err] }
+// For results with two zero-length types, use [BoolResult].
+type Result[Shape, OK, Err any] struct{ result[Shape, OK, Err] }
 
 // OKResult represents a result sized to hold the OK type.
 // The size of the OK type must be greater than or equal to the size of the Err type.
-// For results with two zero-length types, use [Result].
+// For results with two zero-length types, use [BoolResult].
 //
 // TODO: change this to an alias when https://github.com/golang/go/issues/46477 is implemented.
 type OKResult[OK, Err any] struct{ result[OK, OK, Err] }
 
 // ErrResult represents a result sized to hold the Err type.
 // The size of the Err type must be greater than or equal to the size of the OK type.
-// For results with two zero-length types, use [Result].
+// For results with two zero-length types, use [BoolResult].
 //
 // TODO: change this to an alias when https://github.com/golang/go/issues/46477 is implemented.
 type ErrResult[OK, Err any] struct{ result[Err, OK, Err] }

--- a/cm/result_test.go
+++ b/cm/result_test.go
@@ -163,9 +163,10 @@ func TestIssue95String(t *testing.T) {
 
 func TestIssue95Uint64(t *testing.T) {
 	type (
-		// uint64Variant Variant[uint8, uint64, uint64]
-		uint64Variant Variant[uint8, [unsafe.Sizeof(uint64(0))]byte, uint64]
-		uint64Result  ErrResult[uint64, uint64Variant]
+		uint64Variant Variant[uint8, uint64, uint64]
+		// uint64Variant Variant[uint8, [unsafe.Sizeof(uint64(0))]byte, uint64]
+		// uint64Result ErrResult[uint64, uint64Variant]
+		uint64Result Result[[unsafe.Sizeof(uint64Variant{})]byte, uint64, uint64Variant]
 	)
 
 	want := uint64(123)

--- a/cm/result_test.go
+++ b/cm/result_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 var (
-	_ resulter[string, bool] = &OKResult[string, bool]{}
-	_ resulter[bool, string] = &ErrResult[bool, string]{}
+	_ resulter[string, bool] = &Result[string, string, bool]{}
+	_ resulter[bool, string] = &Result[string, bool, string]{}
 )
 
 type resulter[OK, Err any] interface {
@@ -33,28 +33,28 @@ func TestResultLayout(t *testing.T) {
 		{"ok", BoolResult(ResultOK), 1, 0},
 		{"err", BoolResult(ResultErr), 1, 0},
 
-		{"result<string, string>", OKResult[string, string]{}, sizePlusAlignOf[string](), ptrSize},
-		{"result<bool, string>", ErrResult[bool, string]{}, sizePlusAlignOf[string](), ptrSize},
-		{"result<string, _>", OKResult[string, struct{}]{}, sizePlusAlignOf[string](), ptrSize},
-		{"result<_, string>", ErrResult[struct{}, string]{}, sizePlusAlignOf[string](), ptrSize},
-		{"result<u64, u64>", OKResult[uint64, uint64]{}, 16, alignOf[uint64]()},
-		{"result<u32, u64>", ErrResult[uint32, uint64]{}, 16, alignOf[uint64]()},
-		{"result<u64, u32>", OKResult[uint64, uint32]{}, 16, alignOf[uint64]()},
-		{"result<u8, u64>", ErrResult[uint8, uint64]{}, 16, alignOf[uint64]()},
-		{"result<u64, u8>", OKResult[uint64, uint8]{}, 16, alignOf[uint64]()},
-		{"result<u8, u32>", ErrResult[uint8, uint32]{}, 8, alignOf[uint32]()},
-		{"result<u32, u8>", OKResult[uint32, uint8]{}, 8, alignOf[uint32]()},
-		{"result<[9]u8, u64>", OKResult[[9]byte, uint64]{}, 24, alignOf[uint64]()},
+		{"result<string, string>", Result[string, string, string]{}, sizePlusAlignOf[string](), ptrSize},
+		{"result<bool, string>", Result[string, bool, string]{}, sizePlusAlignOf[string](), ptrSize},
+		{"result<string, _>", Result[string, string, struct{}]{}, sizePlusAlignOf[string](), ptrSize},
+		{"result<_, string>", Result[string, struct{}, string]{}, sizePlusAlignOf[string](), ptrSize},
+		{"result<u64, u64>", Result[uint64, uint64, uint64]{}, 16, alignOf[uint64]()},
+		{"result<u32, u64>", Result[uint64, uint32, uint64]{}, 16, alignOf[uint64]()},
+		{"result<u64, u32>", Result[uint64, uint64, uint32]{}, 16, alignOf[uint64]()},
+		{"result<u8, u64>", Result[uint64, uint8, uint64]{}, 16, alignOf[uint64]()},
+		{"result<u64, u8>", Result[uint64, uint64, uint8]{}, 16, alignOf[uint64]()},
+		{"result<u8, u32>", Result[uint32, uint8, uint32]{}, 8, alignOf[uint32]()},
+		{"result<u32, u8>", Result[uint32, uint32, uint8]{}, 8, alignOf[uint32]()},
+		{"result<[9]u8, u64>", Result[[9]byte, [9]byte, uint64]{}, 24, alignOf[uint64]()},
 
-		{"result<string, _>", OKResult[string, struct{}]{}, sizePlusAlignOf[string](), ptrSize},
-		{"result<string, _>", OKResult[string, struct{}]{}, sizePlusAlignOf[string](), ptrSize},
-		{"result<string, bool>", OKResult[string, bool]{}, sizePlusAlignOf[string](), ptrSize},
-		{"result<[9]u8, u64>", OKResult[[9]byte, uint64]{}, 24, alignOf[uint64]()},
+		{"result<string, _>", Result[string, string, struct{}]{}, sizePlusAlignOf[string](), ptrSize},
+		{"result<string, _>", Result[string, string, struct{}]{}, sizePlusAlignOf[string](), ptrSize},
+		{"result<string, bool>", Result[string, string, bool]{}, sizePlusAlignOf[string](), ptrSize},
+		{"result<[9]u8, u64>", Result[[9]byte, [9]byte, uint64]{}, 24, alignOf[uint64]()},
 
-		{"result<_, string>", ErrResult[struct{}, string]{}, sizePlusAlignOf[string](), ptrSize},
-		{"result<_, string>", ErrResult[struct{}, string]{}, sizePlusAlignOf[string](), ptrSize},
-		{"result<bool, string>", ErrResult[bool, string]{}, sizePlusAlignOf[string](), ptrSize},
-		{"result<u64, [9]u8>", ErrResult[uint64, [9]byte]{}, 24, alignOf[uint64]()},
+		{"result<_, string>", Result[string, struct{}, string]{}, sizePlusAlignOf[string](), ptrSize},
+		{"result<_, string>", Result[string, struct{}, string]{}, sizePlusAlignOf[string](), ptrSize},
+		{"result<bool, string>", Result[string, bool, string]{}, sizePlusAlignOf[string](), ptrSize},
+		{"result<u64, [9]u8>", Result[[9]byte, uint64, [9]byte]{}, 24, alignOf[uint64]()},
 	}
 
 	for _, tt := range tests {
@@ -71,7 +71,7 @@ func TestResultLayout(t *testing.T) {
 }
 
 func TestResultOKOrErr(t *testing.T) {
-	r1 := OK[OKResult[string, struct{}]]("hello")
+	r1 := OK[Result[string, string, struct{}]]("hello")
 	if ok := r1.OK(); ok == nil {
 		t.Errorf("OK(): %v, expected non-nil OK", ok)
 	}
@@ -79,7 +79,7 @@ func TestResultOKOrErr(t *testing.T) {
 		t.Errorf("Err(): %v, expected nil Err", err)
 	}
 
-	r2 := Err[ErrResult[struct{}, bool]](true)
+	r2 := Err[Result[bool, struct{}, bool]](true)
 	if ok := r2.OK(); ok != nil {
 		t.Errorf("OK(): %v, expected nil OK", ok)
 	}
@@ -129,7 +129,7 @@ func unequalSize[A, B any](t *testing.T, a A, b B) {
 func BenchmarkResultInlines(b *testing.B) {
 	var ok *struct{}
 	var err *string
-	r1 := Err[ErrResult[struct{}, string]]("hello")
+	r1 := Err[Result[string, struct{}, string]]("hello")
 	for i := 0; i < b.N; i++ {
 		ok = r1.OK()
 	}
@@ -146,7 +146,7 @@ func TestIssue95String(t *testing.T) {
 		stringVariant Variant[uint8, string, string]
 		// stringVariant Variant[uint8, [unsafe.Sizeof("")]byte, string]
 		// stringVariant Variant[uint8, magic, string]
-		// stringResult ErrResult[string, stringVariant]
+		// stringResult Result[stringVariant, string, stringVariant]
 		stringResult Result[[unsafe.Sizeof(*(*stringVariant)(nil))]byte, string, stringVariant]
 	)
 
@@ -165,7 +165,7 @@ func TestIssue95Uint64(t *testing.T) {
 	type (
 		uint64Variant Variant[uint8, uint64, uint64]
 		// uint64Variant Variant[uint8, [unsafe.Sizeof(uint64(0))]byte, uint64]
-		// uint64Result ErrResult[uint64, uint64Variant]
+		// uint64Result Result[uint64Variant, uint64, uint64Variant]
 		uint64Result Result[[unsafe.Sizeof(uint64Variant{})]byte, uint64, uint64Variant]
 	)
 
@@ -181,14 +181,14 @@ func TestIssue95Uint64(t *testing.T) {
 
 func TestIssue95Struct(t *testing.T) {
 	type (
-		// structResult  ErrResult[stringStruct, structVariant]
+		// structResult  Result[structVariant, stringStruct, structVariant]
 		stringStruct struct {
 			// i int
 			s string
 		}
 		structVariant Variant[uint8, stringStruct, stringStruct]
 		// structVariant Variant[uint8, [1]stringStruct, [2]stringStruct]
-		// structResult ErrResult[stringStruct, structVariant]
+		// structResult Result[structVariant, stringStruct, structVariant]
 		structResult Result[[unsafe.Sizeof(*(*structVariant)(nil))]byte, stringStruct, structVariant]
 		// structResult Result[[2]uintptr, stringStruct, structVariant]
 	)
@@ -204,7 +204,7 @@ func TestIssue95Struct(t *testing.T) {
 }
 
 func TestIssue95BoolInt64(t *testing.T) {
-	type boolInt64Result ErrResult[bool, int64]
+	type boolInt64Result Result[int64, bool, int64]
 	want := int64(1234567890)
 	res := Err[boolInt64Result](1234567890)
 	got := *res.Err()

--- a/cm/result_test.go
+++ b/cm/result_test.go
@@ -29,9 +29,9 @@ func TestResultLayout(t *testing.T) {
 		size   uintptr
 		offset uintptr
 	}{
-		{"result", Result(false), 1, 0},
-		{"ok", Result(ResultOK), 1, 0},
-		{"err", Result(ResultErr), 1, 0},
+		{"result", BoolResult(false), 1, 0},
+		{"ok", BoolResult(ResultOK), 1, 0},
+		{"err", BoolResult(ResultErr), 1, 0},
 
 		{"result<string, string>", OKResult[string, string]{}, sizePlusAlignOf[string](), ptrSize},
 		{"result<bool, string>", ErrResult[bool, string]{}, sizePlusAlignOf[string](), ptrSize},
@@ -147,7 +147,7 @@ func TestIssue95String(t *testing.T) {
 		// stringVariant Variant[uint8, [unsafe.Sizeof("")]byte, string]
 		// stringVariant Variant[uint8, magic, string]
 		// stringResult ErrResult[string, stringVariant]
-		stringResult SomeResult[[unsafe.Sizeof(*(*stringVariant)(nil))]byte, string, stringVariant]
+		stringResult Result[[unsafe.Sizeof(*(*stringVariant)(nil))]byte, string, stringVariant]
 	)
 
 	want := "hello"
@@ -183,7 +183,7 @@ func TestIssue95Struct(t *testing.T) {
 		// structResult  ErrResult[stringStruct, structVariant]
 		stringStruct  struct{ string }
 		structVariant Variant[uint8, stringStruct, stringStruct]
-		structResult  SomeResult[[unsafe.Sizeof(*(*structVariant)(nil))]byte, stringStruct, structVariant]
+		structResult  Result[[unsafe.Sizeof(*(*structVariant)(nil))]byte, stringStruct, structVariant]
 	)
 
 	want := stringStruct{"hello"}

--- a/cm/result_test.go
+++ b/cm/result_test.go
@@ -135,3 +135,24 @@ func BenchmarkResultInlines(b *testing.B) {
 	_ = ok
 	_ = err
 }
+
+func TestIssue95(t *testing.T) {
+	want := "hello"
+	res := issue95(false, want)
+	got := *res.OK()
+	if got != want {
+		t.Errorf("*res.OK(): %s, expected %s", got, want)
+	}
+}
+
+func issue95(isErr bool, v string) stringResult {
+	if isErr {
+		err := New[stringVariant](0, v)
+		return Err[stringResult](err)
+	}
+	return OK[stringResult](v)
+}
+
+type stringResult ErrResult[string, stringVariant]
+
+type stringVariant Variant[uint8, string, string]

--- a/cm/result_test.go
+++ b/cm/result_test.go
@@ -181,12 +181,18 @@ func TestIssue95Uint64(t *testing.T) {
 func TestIssue95Struct(t *testing.T) {
 	type (
 		// structResult  ErrResult[stringStruct, structVariant]
-		stringStruct  struct{ string }
+		stringStruct struct {
+			// i int
+			s string
+		}
 		structVariant Variant[uint8, stringStruct, stringStruct]
-		structResult  Result[[unsafe.Sizeof(*(*structVariant)(nil))]byte, stringStruct, structVariant]
+		// structVariant Variant[uint8, [1]stringStruct, [2]stringStruct]
+		// structResult ErrResult[stringStruct, structVariant]
+		structResult Result[[unsafe.Sizeof(*(*structVariant)(nil))]byte, stringStruct, structVariant]
+		// structResult Result[[2]uintptr, stringStruct, structVariant]
 	)
 
-	want := stringStruct{"hello"}
+	want := stringStruct{s: "hello"}
 	res := OK[structResult](want)
 	got := *res.OK()
 	fmt.Printf("unsafe.Sizeof(res): %d\n", unsafe.Sizeof(res))

--- a/cm/result_test.go
+++ b/cm/result_test.go
@@ -146,8 +146,8 @@ func TestIssue95String(t *testing.T) {
 		stringVariant Variant[uint8, string, string]
 		// stringVariant Variant[uint8, [unsafe.Sizeof("")]byte, string]
 		// stringVariant Variant[uint8, magic, string]
-		// stringResult ErrResult[string, stringVariant]
-		stringResult Result[[unsafe.Sizeof(*(*stringVariant)(nil))]byte, string, stringVariant]
+		stringResult ErrResult[string, stringVariant]
+		// stringResult Result[[unsafe.Sizeof(*(*stringVariant)(nil))]byte, string, stringVariant]
 	)
 
 	want := "hello"
@@ -163,9 +163,9 @@ func TestIssue95String(t *testing.T) {
 
 func TestIssue95Uint64(t *testing.T) {
 	type (
-		// uint64Variant Variant[uint8, uint64, uint64]
-		uint64Variant Variant[uint8, [unsafe.Sizeof(uint64(0))]byte, uint64]
-		uint64Result  ErrResult[uint64, uint64Variant]
+		uint64Variant Variant[uint8, uint64, uint64]
+		// uint64Variant Variant[uint8, [unsafe.Sizeof(uint64(0))]byte, uint64]
+		uint64Result ErrResult[uint64, uint64Variant]
 	)
 
 	want := uint64(123)
@@ -187,8 +187,8 @@ func TestIssue95Struct(t *testing.T) {
 		}
 		structVariant Variant[uint8, stringStruct, stringStruct]
 		// structVariant Variant[uint8, [1]stringStruct, [2]stringStruct]
-		// structResult ErrResult[stringStruct, structVariant]
-		structResult Result[[unsafe.Sizeof(*(*structVariant)(nil))]byte, stringStruct, structVariant]
+		structResult ErrResult[stringStruct, structVariant]
+		// structResult Result[[unsafe.Sizeof(*(*structVariant)(nil))]byte, stringStruct, structVariant]
 		// structResult Result[[2]uintptr, stringStruct, structVariant]
 	)
 

--- a/cm/result_test.go
+++ b/cm/result_test.go
@@ -146,8 +146,8 @@ func TestIssue95String(t *testing.T) {
 		stringVariant Variant[uint8, string, string]
 		// stringVariant Variant[uint8, [unsafe.Sizeof("")]byte, string]
 		// stringVariant Variant[uint8, magic, string]
-		stringResult ErrResult[string, stringVariant]
-		// stringResult Result[[unsafe.Sizeof(*(*stringVariant)(nil))]byte, string, stringVariant]
+		// stringResult ErrResult[string, stringVariant]
+		stringResult Result[[unsafe.Sizeof(*(*stringVariant)(nil))]byte, string, stringVariant]
 	)
 
 	want := "hello"
@@ -163,9 +163,9 @@ func TestIssue95String(t *testing.T) {
 
 func TestIssue95Uint64(t *testing.T) {
 	type (
-		uint64Variant Variant[uint8, uint64, uint64]
-		// uint64Variant Variant[uint8, [unsafe.Sizeof(uint64(0))]byte, uint64]
-		uint64Result ErrResult[uint64, uint64Variant]
+		// uint64Variant Variant[uint8, uint64, uint64]
+		uint64Variant Variant[uint8, [unsafe.Sizeof(uint64(0))]byte, uint64]
+		uint64Result  ErrResult[uint64, uint64Variant]
 	)
 
 	want := uint64(123)
@@ -187,8 +187,8 @@ func TestIssue95Struct(t *testing.T) {
 		}
 		structVariant Variant[uint8, stringStruct, stringStruct]
 		// structVariant Variant[uint8, [1]stringStruct, [2]stringStruct]
-		structResult ErrResult[stringStruct, structVariant]
-		// structResult Result[[unsafe.Sizeof(*(*structVariant)(nil))]byte, stringStruct, structVariant]
+		// structResult ErrResult[stringStruct, structVariant]
+		structResult Result[[unsafe.Sizeof(*(*structVariant)(nil))]byte, stringStruct, structVariant]
 		// structResult Result[[2]uintptr, stringStruct, structVariant]
 	)
 

--- a/cm/variant.go
+++ b/cm/variant.go
@@ -64,11 +64,11 @@ func validateVariant[Disc Discriminant, Shape, Align any, T any]() {
 
 	// Check if size of T is greater than Shape
 	if unsafe.Sizeof(t) > unsafe.Sizeof(v.data) {
-		panic("result: size of requested type > data type")
+		panic("variant: size of requested type > data type")
 	}
 
 	// Check if Shape is zero-sized, but size of result != 1
 	if unsafe.Sizeof(v.data) == 0 && unsafe.Sizeof(v) != 1 {
-		panic("result: size of data type == 0, but result size != 1")
+		panic("variant: size of data type == 0, but result size != 1")
 	}
 }

--- a/cm/variant.go
+++ b/cm/variant.go
@@ -48,7 +48,7 @@ func Case[T any, V ~struct{ variant[Tag, Shape, Align] }, Tag Discriminant, Shap
 // Shape and Align must be non-zero sized types.
 type variant[Tag Discriminant, Shape, Align any] struct {
 	tag  Tag
-	_    [0]Align
+	_    [0][2]Align
 	data Shape // [unsafe.Sizeof(*(*Shape)(unsafe.Pointer(nil)))]byte
 }
 

--- a/cm/variant.go
+++ b/cm/variant.go
@@ -26,7 +26,7 @@ func NewVariant[Tag Discriminant, Shape, Align any, T any](tag Tag, data T) Vari
 
 // New returns a [Variant] with tag of type Disc, storage and GC shape of type Shape,
 // aligned to type Align, with a value of type T.
-func New[V ~struct{ variant[Tag, Align, Shape] }, Tag Discriminant, Shape, Align any, T any](tag Tag, data T) V {
+func New[V ~struct{ variant[Tag, Shape, Align] }, Tag Discriminant, Shape, Align any, T any](tag Tag, data T) V {
 	validateVariant[Tag, Shape, Align, T]()
 	var v variant[Tag, Shape, Align]
 	v.tag = tag
@@ -35,7 +35,7 @@ func New[V ~struct{ variant[Tag, Align, Shape] }, Tag Discriminant, Shape, Align
 }
 
 // Case returns a non-nil *T if the [Variant] case is equal to tag, otherwise it returns nil.
-func Case[T any, V ~struct{ variant[Tag, Align, Shape] }, Tag Discriminant, Shape, Align any](v *V, tag Tag) *T {
+func Case[T any, V ~struct{ variant[Tag, Shape, Align] }, Tag Discriminant, Shape, Align any](v *V, tag Tag) *T {
 	validateVariant[Tag, Shape, Align, T]()
 	v2 := (*variant[Tag, Shape, Align])(unsafe.Pointer(v))
 	if v2.tag == tag {

--- a/cm/variant.go
+++ b/cm/variant.go
@@ -20,7 +20,7 @@ func NewVariant[Tag Discriminant, Shape, Align any, T any](tag Tag, data T) Vari
 	validateVariant[Tag, Shape, Align, T]()
 	var v Variant[Tag, Shape, Align]
 	v.tag = tag
-	v.data = *(*Shape)(unsafe.Pointer(&data))
+	*(*T)(unsafe.Pointer(&v.data)) = data
 	return v
 }
 
@@ -30,7 +30,7 @@ func New[V ~struct{ variant[Tag, Shape, Align] }, Tag Discriminant, Shape, Align
 	validateVariant[Tag, Shape, Align, T]()
 	var v variant[Tag, Shape, Align]
 	v.tag = tag
-	v.data = *(*Shape)(unsafe.Pointer(&data))
+	*(*T)(unsafe.Pointer(&v.data)) = data
 	return *(*V)(unsafe.Pointer(&v))
 }
 
@@ -49,7 +49,7 @@ func Case[T any, V ~struct{ variant[Tag, Shape, Align] }, Tag Discriminant, Shap
 type variant[Tag Discriminant, Shape, Align any] struct {
 	tag  Tag
 	_    [0]Align
-	data Shape
+	data Shape // [unsafe.Sizeof(*(*Shape)(unsafe.Pointer(nil)))]byte
 }
 
 // Tag returns the tag (discriminant) of variant v.

--- a/cm/variant.go
+++ b/cm/variant.go
@@ -48,7 +48,7 @@ func Case[T any, V ~struct{ variant[Tag, Shape, Align] }, Tag Discriminant, Shap
 // Shape and Align must be non-zero sized types.
 type variant[Tag Discriminant, Shape, Align any] struct {
 	tag  Tag
-	_    [0][2]Align
+	_    [0]Align
 	data Shape // [unsafe.Sizeof(*(*Shape)(unsafe.Pointer(nil)))]byte
 }
 

--- a/cm/variant.go
+++ b/cm/variant.go
@@ -69,6 +69,6 @@ func validateVariant[Disc Discriminant, Shape, Align any, T any]() {
 
 	// Check if Shape is zero-sized, but size of result != 1
 	if unsafe.Sizeof(v.data) == 0 && unsafe.Sizeof(v) != 1 {
-		panic("variant: size of data type == 0, but result size != 1")
+		panic("variant: size of data type == 0, but variant size != 1")
 	}
 }

--- a/testdata/example/only-result.wit
+++ b/testdata/example/only-result.wit
@@ -1,0 +1,14 @@
+package example:only;
+
+interface a {
+	f: func() -> result<u32, u8>;
+}
+
+interface b {
+	f: func() -> result<u32, u8>;
+}
+
+world w {
+	import a;
+	import b;
+}

--- a/testdata/example/only-result.wit.json
+++ b/testdata/example/only-result.wit.json
@@ -1,0 +1,81 @@
+{
+  "worlds": [
+    {
+      "name": "w",
+      "imports": {
+        "interface-0": {
+          "interface": {
+            "id": 0
+          }
+        },
+        "interface-1": {
+          "interface": {
+            "id": 1
+          }
+        }
+      },
+      "exports": {},
+      "package": 0
+    }
+  ],
+  "interfaces": [
+    {
+      "name": "a",
+      "types": {},
+      "functions": {
+        "f": {
+          "name": "f",
+          "kind": "freestanding",
+          "params": [],
+          "results": [
+            {
+              "type": 0
+            }
+          ]
+        }
+      },
+      "package": 0
+    },
+    {
+      "name": "b",
+      "types": {},
+      "functions": {
+        "f": {
+          "name": "f",
+          "kind": "freestanding",
+          "params": [],
+          "results": [
+            {
+              "type": 0
+            }
+          ]
+        }
+      },
+      "package": 0
+    }
+  ],
+  "types": [
+    {
+      "name": null,
+      "kind": {
+        "result": {
+          "ok": "u32",
+          "err": "u8"
+        }
+      },
+      "owner": null
+    }
+  ],
+  "packages": [
+    {
+      "name": "example:only",
+      "interfaces": {
+        "a": 0,
+        "b": 1
+      },
+      "worlds": {
+        "w": 0
+      }
+    }
+  ]
+}

--- a/testdata/example/only-result.wit.json.golden.wit
+++ b/testdata/example/only-result.wit.json.golden.wit
@@ -1,0 +1,14 @@
+package example:only;
+
+interface a {
+	f: func() -> result<u32, u8>;
+}
+
+interface b {
+	f: func() -> result<u32, u8>;
+}
+
+world w {
+	import a;
+	import b;
+}

--- a/testdata/issues/issue95.wit
+++ b/testdata/issues/issue95.wit
@@ -1,0 +1,15 @@
+package issues:issue95;
+
+interface i {
+	type r = result<string, error>;
+
+	variant error {
+		too-short(string),
+		too-tall(string),
+		unknown(string),
+	}
+}
+
+world w {
+	import i;
+}

--- a/testdata/issues/issue95.wit.json
+++ b/testdata/issues/issue95.wit.json
@@ -1,0 +1,76 @@
+{
+  "worlds": [
+    {
+      "name": "w",
+      "imports": {
+        "interface-0": {
+          "interface": {
+            "id": 0
+          }
+        }
+      },
+      "exports": {},
+      "package": 0
+    }
+  ],
+  "interfaces": [
+    {
+      "name": "i",
+      "types": {
+        "error": 0,
+        "r": 1
+      },
+      "functions": {},
+      "package": 0
+    }
+  ],
+  "types": [
+    {
+      "name": "error",
+      "kind": {
+        "variant": {
+          "cases": [
+            {
+              "name": "too-short",
+              "type": "string"
+            },
+            {
+              "name": "too-tall",
+              "type": "string"
+            },
+            {
+              "name": "unknown",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "owner": {
+        "interface": 0
+      }
+    },
+    {
+      "name": "r",
+      "kind": {
+        "result": {
+          "ok": "string",
+          "err": 0
+        }
+      },
+      "owner": {
+        "interface": 0
+      }
+    }
+  ],
+  "packages": [
+    {
+      "name": "issues:issue95",
+      "interfaces": {
+        "i": 0
+      },
+      "worlds": {
+        "w": 0
+      }
+    }
+  ]
+}

--- a/testdata/issues/issue95.wit.json.golden.wit
+++ b/testdata/issues/issue95.wit.json.golden.wit
@@ -1,0 +1,14 @@
+package issues:issue95;
+
+interface i {
+	variant error {
+		too-short(string),
+		too-tall(string),
+		unknown(string),
+	}
+	type r = result<string, error>;
+}
+
+world w {
+	import i;
+}

--- a/wit/bindgen/abi.go
+++ b/wit/bindgen/abi.go
@@ -6,15 +6,14 @@ import (
 	"github.com/ydnar/wasm-tools-go/wit"
 )
 
-// variantShape returns the largest associated type in v.
-// If v has multiple types with the same size, it returns the
-// type that contains a pointer.
-func variantShape(v *wit.Variant) wit.Type {
-	types := v.Types()
+// variantShape returns the type with the greatest size.
+// If there are multiple types with the same size, it returns
+// the first type that contains a pointer.
+func variantShape(types []wit.Type) wit.Type {
 	if len(types) == 0 {
 		return nil
 	}
-	slices.SortFunc(types, func(a, b wit.Type) int {
+	slices.SortStableFunc(types, func(a, b wit.Type) int {
 		switch {
 		case a.Size() > b.Size():
 			return -1
@@ -31,13 +30,12 @@ func variantShape(v *wit.Variant) wit.Type {
 	return types[0]
 }
 
-// variantAlign returns the type with the highest align value in v.
-func variantAlign(v *wit.Variant) wit.Type {
-	types := v.Types()
+// variantAlign returns the type with the largest alignment.
+func variantAlign(types []wit.Type) wit.Type {
 	if len(types) == 0 {
 		return nil
 	}
-	slices.SortFunc(types, func(a, b wit.Type) int {
+	slices.SortStableFunc(types, func(a, b wit.Type) int {
 		switch {
 		case a.Align() > b.Align():
 			return -1

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -940,8 +940,8 @@ func (g *generator) typeShape(file *gen.File, dir wit.Direction, t wit.Type) str
 	case *wit.TypeDef:
 		t = t.Root()
 		return g.typeDefShape(file, dir, t)
-	case wit.String:
-		return file.Import(g.opts.cmPackage) + ".StringShape"
+	// case wit.String:
+	// 	return file.Import(g.opts.cmPackage) + ".StringShape"
 	default:
 		return g.typeRep(file, dir, t)
 	}
@@ -955,7 +955,7 @@ func (g *generator) typeDefShape(file *gen.File, dir wit.Direction, t *wit.TypeD
 		if kind.Enum() != nil {
 			return g.typeRep(file, dir, t)
 		}
-	case *wit.Resource, *wit.Own, *wit.Borrow, *wit.Enum, *wit.Flags:
+	case *wit.Resource, *wit.Own, *wit.Borrow, *wit.Enum, *wit.Flags, *wit.List:
 		return g.typeRep(file, dir, t)
 	}
 

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -104,7 +104,7 @@ func goParams(scope gen.Scope, dir wit.Direction, params []wit.Param) []param {
 type typeUse struct {
 	pkg *gen.Package
 	dir wit.Direction
-	typ wit.Type
+	typ *wit.TypeDef
 }
 
 type generator struct {

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -951,9 +951,16 @@ func (g *generator) typeDefShape(file *gen.File, dir wit.Direction, t *wit.TypeD
 		return g.typeShape(file, dir, kind)
 	case *wit.Variant:
 		if kind.Enum() != nil {
+			// Variants that can be represented as an enum do not need a custom shape.
+			return g.typeRep(file, dir, t)
+		}
+	case *wit.Tuple:
+		if kind.Type() != nil {
+			// Monotypic tuples have a packed memory layout.
 			return g.typeRep(file, dir, t)
 		}
 	case *wit.Resource, *wit.Own, *wit.Borrow, *wit.Enum, *wit.Flags, *wit.List:
+		// Resource handles, enum, flags, and list types do not need a custom shape.
 		return g.typeRep(file, dir, t)
 	}
 

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -38,7 +38,7 @@ const (
 	experimentPredeclareHandles = false
 
 	// Define Go GC shape types for variant and result storage.
-	experimentCreateShapeTypes = true
+	experimentCreateShapeTypes = false
 )
 
 type typeDecl struct {

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -839,10 +839,15 @@ func (g *generator) variantRep(file *gen.File, dir wit.Direction, v *wit.Variant
 	shape := variantShape(v.Types())
 	align := variantAlign(v.Types())
 
+	typeShape := g.typeShape(file, dir, shape)
+	if len(v.Types()) == 1 {
+		typeShape = g.typeRep(file, dir, shape)
+	}
+
 	// Emit type
 	var b strings.Builder
 	cm := file.Import(g.opts.cmPackage)
-	stringio.Write(&b, cm, ".Variant[", g.typeRep(file, dir, disc), ", ", g.typeShape(file, dir, shape), ", ", g.typeRep(file, dir, align), "]\n\n")
+	stringio.Write(&b, cm, ".Variant[", g.typeRep(file, dir, disc), ", ", typeShape, ", ", g.typeRep(file, dir, align), "]\n\n")
 
 	// Emit cases
 	for i, c := range v.Cases {
@@ -887,6 +892,10 @@ func (g *generator) variantRep(file *gen.File, dir wit.Direction, v *wit.Variant
 
 func (g *generator) resultRep(file *gen.File, dir wit.Direction, r *wit.Result) string {
 	shape := variantShape(r.Types())
+	typeShape := g.typeShape(file, dir, shape)
+	if len(r.Types()) == 1 {
+		typeShape = g.typeRep(file, dir, shape)
+	}
 
 	// Emit type
 	var b strings.Builder
@@ -894,7 +903,7 @@ func (g *generator) resultRep(file *gen.File, dir wit.Direction, r *wit.Result) 
 	if r.OK == nil && r.Err == nil {
 		b.WriteString(".BoolResult")
 	} else {
-		stringio.Write(&b, ".Result[", g.typeShape(file, dir, shape), ", ", g.typeRep(file, dir, r.OK), ", ", g.typeRep(file, dir, r.Err), "]")
+		stringio.Write(&b, ".Result[", typeShape, ", ", g.typeRep(file, dir, r.OK), ", ", g.typeRep(file, dir, r.Err), "]")
 	}
 	return b.String()
 }

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -38,7 +38,7 @@ const (
 	experimentPredeclareHandles = false
 
 	// Define Go GC shape types for variant and result storage.
-	experimentCreateShapeTypes = false
+	experimentCreateShapeTypes = true
 )
 
 type typeDecl struct {

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -607,7 +607,7 @@ func typeDefOwner(t *wit.TypeDef) wit.Ident {
 
 // typeDefGoName returns a mangled Go name for t.
 func (g *generator) typeDefGoName(dir wit.Direction, t *wit.TypeDef) string {
-	if decl, ok := g.types[dir][t]; ok {
+	if decl, ok := g.types[dir][t]; ok && decl.name != "" {
 		return decl.name
 	}
 	return GoName(t.WIT(nil, t.TypeName()), true)

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -36,6 +36,9 @@ const (
 	// Predeclare Go types for own<T> and borrow<T>.
 	// Currently broken.
 	experimentPredeclareHandles = false
+
+	// Define Go GC shape types for variant and result storage.
+	experimentCreateShapeTypes = true
 )
 
 type typeDecl struct {
@@ -929,6 +932,10 @@ func (g *generator) borrowRep(file *gen.File, dir wit.Direction, b *wit.Borrow) 
 }
 
 func (g *generator) typeShape(file *gen.File, dir wit.Direction, t wit.Type) string {
+	if !experimentCreateShapeTypes {
+		return g.typeRep(file, dir, t)
+	}
+
 	switch t := t.(type) {
 	case *wit.TypeDef:
 		t = t.Root()

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -140,7 +140,8 @@ type generator struct {
 	defined [2]map[any]bool
 
 	// ABI shapes for any type, use for variant and result Shape type parameters.
-	shapes map[typeUse]string
+	shapes   map[typeUse]string
+	shapeNum int
 
 	// lowering and lifting functions for defined types.
 	lowerFunctions map[typeUse]function
@@ -961,7 +962,8 @@ func (g *generator) typeDefShape(file *gen.File, dir wit.Direction, t *wit.TypeD
 	name, ok := g.shapes[use]
 	if !ok {
 		afile := g.abiFile(file.Package)
-		name = afile.DeclareName(g.typeDefGoName(dir, t) + "Shape")
+		g.shapeNum++
+		name = afile.DeclareName("Shape" + strconv.Itoa(g.shapeNum))
 		g.shapes[use] = name
 		var b bytes.Buffer
 		stringio.Write(&b, "// ", name, " is used for storage in variant or result types.\n")

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -879,14 +879,15 @@ func (g *generator) variantRep(file *gen.File, dir wit.Direction, v *wit.Variant
 }
 
 func (g *generator) resultRep(file *gen.File, dir wit.Direction, r *wit.Result) string {
+	shape := variantShape(r.Types())
+
+	// Emit type
 	var b strings.Builder
 	b.WriteString(file.Import(g.opts.cmPackage))
 	if r.OK == nil && r.Err == nil {
-		b.WriteString(".Result")
-	} else if r.OK == nil || (r.Err != nil && r.Err.Size() > r.OK.Size()) {
-		stringio.Write(&b, ".ErrResult[", g.typeRep(file, dir, r.OK), ", ", g.typeRep(file, dir, r.Err), "]")
+		b.WriteString(".BoolResult")
 	} else {
-		stringio.Write(&b, ".OKResult[", g.typeRep(file, dir, r.OK), ", ", g.typeRep(file, dir, r.Err), "]")
+		stringio.Write(&b, ".Result[", g.typeRep(file, dir, shape), ", ", g.typeRep(file, dir, r.OK), ", ", g.typeRep(file, dir, r.Err), "]")
 	}
 	return b.String()
 }

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -829,8 +829,8 @@ func (g *generator) variantRep(file *gen.File, dir wit.Direction, v *wit.Variant
 	}
 
 	disc := wit.Discriminant(len(v.Cases))
-	shape := variantShape(v)
-	align := variantAlign(v)
+	shape := variantShape(v.Types())
+	align := variantAlign(v.Types())
 
 	// Emit type
 	var b strings.Builder

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -940,8 +940,6 @@ func (g *generator) typeShape(file *gen.File, dir wit.Direction, t wit.Type) str
 	case *wit.TypeDef:
 		t = t.Root()
 		return g.typeDefShape(file, dir, t)
-	// case wit.String:
-	// 	return file.Import(g.opts.cmPackage) + ".StringShape"
 	default:
 		return g.typeRep(file, dir, t)
 	}

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -602,12 +602,10 @@ func typeDefOwner(t *wit.TypeDef) wit.Ident {
 	return id
 }
 
-// typeGoName returns a mangled Go name for t.
-func (g *generator) typeGoName(dir wit.Direction, t wit.Type) string {
-	if td, ok := t.(*wit.TypeDef); ok {
-		if decl, ok := g.types[dir][td]; ok {
-			return decl.name
-		}
+// typeDefGoName returns a mangled Go name for t.
+func (g *generator) typeDefGoName(dir wit.Direction, t *wit.TypeDef) string {
+	if decl, ok := g.types[dir][t]; ok {
+		return decl.name
 	}
 	return GoName(t.WIT(nil, t.TypeName()), true)
 }
@@ -954,7 +952,7 @@ func (g *generator) typeDefShape(file *gen.File, dir wit.Direction, t *wit.TypeD
 	name, ok := g.shapes[use]
 	if !ok {
 		afile := g.abiFile(file.Package)
-		name = afile.DeclareName(g.typeGoName(dir, t) + "Shape")
+		name = afile.DeclareName(g.typeDefGoName(dir, t) + "Shape")
 		g.shapes[use] = name
 		stringio.Write(afile, "type ", name, " ", g.typeRep(afile, dir, t), "\n\n")
 	}
@@ -1018,7 +1016,7 @@ func (g *generator) typeDefLowerFunction(file *gen.File, dir wit.Direction, t *w
 	f, ok := g.lowerFunctions[use]
 	if !ok {
 		afile := g.abiFile(file.Package)
-		name := afile.DeclareName("lower_" + g.typeGoName(dir, t))
+		name := afile.DeclareName("lower_" + g.typeDefGoName(dir, t))
 		f = goFunction(afile, dir, wit.Imported, wit.LowerFunction(t), name)
 		g.lowerFunctions[use] = f
 		stringio.Write(afile, "func ", name, g.functionSignature(afile, f), " {\n", body, "}\n\n")
@@ -1237,7 +1235,7 @@ func (g *generator) typeDefLiftFunction(file *gen.File, dir wit.Direction, t *wi
 	f, ok := g.liftFunctions[use]
 	if !ok {
 		afile := g.abiFile(file.Package)
-		name := afile.DeclareName("lift_" + g.typeGoName(dir, t))
+		name := afile.DeclareName("lift_" + g.typeDefGoName(dir, t))
 		f = goFunction(afile, dir, wit.Imported, wit.LiftFunction(t), name)
 		g.liftFunctions[use] = f
 		stringio.Write(afile, "func ", name, g.functionSignature(afile, f), " {\n", body, "}\n\n")

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -104,7 +104,7 @@ func goParams(scope gen.Scope, dir wit.Direction, params []wit.Param) []param {
 type typeUse struct {
 	pkg *gen.Package
 	dir wit.Direction
-	td  *wit.TypeDef
+	typ wit.Type
 }
 
 type generator struct {

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -140,8 +140,7 @@ type generator struct {
 	defined [2]map[any]bool
 
 	// ABI shapes for any type, use for variant and result Shape type parameters.
-	shapes   map[typeUse]string
-	shapeNum int
+	shapes map[typeUse]string
 
 	// lowering and lifting functions for defined types.
 	lowerFunctions map[typeUse]function
@@ -962,8 +961,7 @@ func (g *generator) typeDefShape(file *gen.File, dir wit.Direction, t *wit.TypeD
 	name, ok := g.shapes[use]
 	if !ok {
 		afile := g.abiFile(file.Package)
-		g.shapeNum++
-		name = afile.DeclareName("Shape" + strconv.Itoa(g.shapeNum))
+		name = afile.DeclareName(g.typeDefGoName(dir, t) + "Shape")
 		g.shapes[use] = name
 		var b bytes.Buffer
 		stringio.Write(&b, "// ", name, " is used for storage in variant or result types.\n")

--- a/wit/resolve.go
+++ b/wit/resolve.go
@@ -869,6 +869,18 @@ func (r *Result) Despecialize() TypeDefKind {
 	}
 }
 
+// Types returns the unique associated types in [Result] r.
+func (r *Result) Types() []Type {
+	var types []Type
+	if r.OK != nil {
+		types = append(types, r.OK)
+	}
+	if r.Err != nil && r.Err != r.OK {
+		types = append(types, r.Err)
+	}
+	return types
+}
+
 // Size returns the [ABI byte size] for [Result] r.
 // It is first [despecialized] into a [Variant] with two cases "ok" and "error", then sized.
 //


### PR DESCRIPTION
This PR implements a change to how `result` and `variant` types are represented in Go, namely generating a storage shape sized to match the largest associated type.

1. It implements an experiment, enabled by default, to generate `byte` array backing for `result` and `variant` data fields. This makes the ergonomics of using generated code slightly worse, by introducing single-use types, e.g. `MyRecordShape` into caller-visible code.
2. It implemented, then reverted, a fix for the data shape of `result` and `variant` types using arrays. This fix, does not work with TinyGo (LLVM), so it was abandoned (see e9d6c260fc6167ba32ee546295f14b91d0fe2982).

This corrects an issue with the original implementation, which used a Go type parameter `Shape` in `Variant` and `*Result` types. If a variant shape was a struct with "holes," e.g. a `uint8` followed by a wider type, say `uint32`, then the 3 bytes between the fields may not be passed to the caller if the `variant` or `result` type is passed on the stack.

Fixes #95.