### PR TITLE
wit/bindgen: preserve all-uppercase segments in WIT identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- WIT labels with uppercase acronyms or [initialisms](https://go.dev/wiki/CodeReviewComments#initialisms) are now preserved in Go form. For example, the WIT name `time-EOD` will result in the Go name `TimeEOD`.
+- `OK` is now a predefined initialism.
+
 ## [v0.1.0] — 2024-07-04
 
 Initial version, supporting [TinyGo](https://tinygo.org/) + [WASI](https://wasi.dev) 0.2 (WASI Preview 2).

--- a/internal/go/gen/names.go
+++ b/internal/go/gen/names.go
@@ -188,6 +188,7 @@ var Initialisms = mapWords(
 	"json",
 	"lhs",
 	"mime",
+	"ok",
 	"posix",
 	"qps",
 	"ram",

--- a/wit/bindgen/names.go
+++ b/wit/bindgen/names.go
@@ -20,19 +20,28 @@ func GoPackageName(name string) string {
 // GoName returns an idiomatic (exported CamelCase) Go name for a WIT name.
 func GoName(name string, export bool) string {
 	var b strings.Builder
-	for i, segment := range segments(strings.ToLower(name)) {
+	for i, segment := range segments(name) {
 		if i == 0 && !export {
+			segment = strings.ToLower(segment)
 			if s, ok := Segments[segment]; ok {
+				// Use opinionated segment
 				b.WriteString(s)
 			} else {
+				// Default to lowercase segment
 				b.WriteString(segment)
 			}
 		} else {
-			if s, ok := ExportedSegments[segment]; ok {
+			if segment == strings.ToUpper(segment) {
+				// Preserve all UPPERCASE
+				b.WriteString(segment)
+			} else if s, ok := ExportedSegments[segment]; ok {
+				// Use opinionated segment
 				b.WriteString(s)
 			} else if gen.Initialisms[segment] {
+				// Use opinionated segment from initialisms
 				b.WriteString(strings.ToUpper(segment))
 			} else {
+				// Title-case the segment
 				runes := []rune(segment)
 				runes[0] = unicode.ToUpper(runes[0])
 				b.WriteString(string(runes))

--- a/wit/bindgen/names_test.go
+++ b/wit/bindgen/names_test.go
@@ -19,6 +19,8 @@ func TestGoName(t *testing.T) {
 		{"fifo-queue", "fifoQueue", "FIFOQueue"},
 		{"FIFO-queue", "fifoQueue", "FIFOQueue"},
 		{"metadata-hash-value", "metadataHashValue", "MetadataHashValue"},
+		{"time-EOD", "timeEOD", "TimeEOD"},
+		{"EOD-time", "eodTime", "EODTime"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/wit/bindgen/names_test.go
+++ b/wit/bindgen/names_test.go
@@ -8,13 +8,16 @@ func TestGoName(t *testing.T) {
 		want     string
 		exported string
 	}{
+		{"canonical-ABI", "canonicalABI", "CanonicalABI"},
 		{"cabi", "cabi", "CABI"},
 		{"datetime", "dateTime", "DateTime"},
 		{"fast-api", "fastAPI", "FastAPI"},
+		{"fast-API", "fastAPI", "FastAPI"},
 		{"blocking-read", "blockingRead", "BlockingRead"},
 		{"ipv4-socket", "ipv4Socket", "IPv4Socket"},
 		{"via-ipv6", "viaIPv6", "ViaIPv6"},
 		{"fifo-queue", "fifoQueue", "FIFOQueue"},
+		{"FIFO-queue", "fifoQueue", "FIFOQueue"},
 		{"metadata-hash-value", "metadataHashValue", "MetadataHashValue"},
 	}
 	for _, tt := range tests {
@@ -27,7 +30,6 @@ func TestGoName(t *testing.T) {
 			if exported != tt.exported {
 				t.Errorf("GoName(%q, true): %q, expected %q", tt.name, exported, tt.exported)
 			}
-
 		})
 	}
 }


### PR DESCRIPTION
- **internal/go/gen: add OK as a known initialism**
- **wit/bindgen: preserve acronym/initialism UPPERCASE segments in WIT names**
