### PR TITLE
all: cleanup

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up wasm-tools
         uses: bytecodealliance/actions/wasm-tools/setup@v1
         with:
-          version: v1.212.0
+          version: v1.213.0
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -82,7 +82,7 @@ jobs:
       - name: Set up wasm-tools
         uses: bytecodealliance/actions/wasm-tools/setup@v1
         with:
-          version: v1.212.0
+          version: v1.213.0
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -119,7 +119,7 @@ jobs:
       - name: Set up wasm-tools
         uses: bytecodealliance/actions/wasm-tools/setup@v1
         with:
-          version: v1.212.0
+          version: v1.213.0
 
       - name: Set up Wasmtime
         uses: bytecodealliance/actions/wasmtime/setup@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -71,7 +71,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        tinygo-version: ["0.31.2"]
+        tinygo-version: ["0.31.2", "0.32.0"]
         go-version: ["1.22"]
     steps:
       - name: Checkout repo
@@ -108,7 +108,7 @@ jobs:
     strategy:
       matrix:
         wasmtime-version: ["21.0.1"]
-        tinygo-version: ["0.31.2"]
+        tinygo-version: ["0.31.2", "0.32.0"]
         go-version: ["1.22"] # WASI Preview 1 only available in Go 1.21 or later
     steps:
       - name: Checkout repo

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .DS_Store
-generated
+./generated

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .DS_Store
-./generated
+generated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `Tuple9`...`Tuple16` types in package `cm` to align with [component-model#373](https://github.com/WebAssembly/component-model/issues/373). Tuples with 9 to 16 types will no longer generate inline `struct` types.
+- Documentation for Canonical ABI lift and lower helper functions in package `cm`.
+
+### Changed
+- Removed outdated documentation in [design](./design/README.md).
+
 ## [v0.1.3] — 2024-07-08
 
 ### Added

--- a/cm/abi.go
+++ b/cm/abi.go
@@ -14,6 +14,8 @@ func Reinterpret[T, From any](from From) (to T) {
 }
 
 // LowerString lowers a [string] into a pair of Core WebAssembly types.
+//
+// [string]: https://pkg.go.dev/builtin#string
 func LowerString[S ~string](s S) (*byte, uint32) {
 	return unsafe.StringData(string(s)), uint32(len(s))
 }
@@ -37,12 +39,16 @@ func LiftList[L List[T], T any, Data unsafe.Pointer | uintptr | *T, Len uint | u
 // BoolToU32 converts a value whose underlying type is [bool] into a [uint32].
 // Used to lower a [bool] into a Core WebAssembly i32 as specified in the [Canonical ABI].
 //
+// [bool]: https://pkg.go.dev/builtin#bool
+// [uint32]: https://pkg.go.dev/builtin#uint32
 // [Canonical ABI]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md
 func BoolToU32[B ~bool](v B) uint32 { return uint32(*(*uint8)(unsafe.Pointer(&v))) }
 
 // U32ToBool converts a [uint32] into a [bool].
 // Used to lift a Core WebAssembly i32 into a [bool] as specified in the [Canonical ABI].
 //
+// [uint32]: https://pkg.go.dev/builtin#uint32
+// [bool]: https://pkg.go.dev/builtin#bool
 // [Canonical ABI]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md
 func U32ToBool(v uint32) bool { tmp := uint8(v); return *(*bool)(unsafe.Pointer(&tmp)) }
 
@@ -50,47 +56,61 @@ func U32ToBool(v uint32) bool { tmp := uint8(v); return *(*bool)(unsafe.Pointer(
 // Used to lower a [float32] into a Core WebAssembly i32 as specified in the [Canonical ABI].
 //
 // [Canonical ABI]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md
+// [float32]: https://pkg.go.dev/builtin#float32
+// [uint32]: https://pkg.go.dev/builtin#uint32
 func F32ToU32(v float32) uint32 { return *(*uint32)(unsafe.Pointer(&v)) }
 
 // U32ToF32 maps the bits of a [uint32] into a [float32].
 // Used to lift a Core WebAssembly i32 into a [float32] as specified in the [Canonical ABI].
 //
+// [uint32]: https://pkg.go.dev/builtin#uint32
+// [float32]: https://pkg.go.dev/builtin#float32
 // [Canonical ABI]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md
 func U32ToF32(v uint32) float32 { return *(*float32)(unsafe.Pointer(&v)) }
 
 // F64ToU64 maps the bits of a [float64] into a [uint64].
 // Used to lower a [float64] into a Core WebAssembly i64 as specified in the [Canonical ABI].
 //
+// [float64]: https://pkg.go.dev/builtin#float64
+// [uint64]: https://pkg.go.dev/builtin#uint64
 // [Canonical ABI]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md
+//
+// [uint32]: https://pkg.go.dev/builtin#uint32
 func F64ToU64(v float64) uint64 { return *(*uint64)(unsafe.Pointer(&v)) }
 
 // U64ToF64 maps the bits of a [uint64] into a [float64].
 // Used to lift a Core WebAssembly i64 into a [float64] as specified in the [Canonical ABI].
 //
+// [uint64]: https://pkg.go.dev/builtin#uint64
+// [float64]: https://pkg.go.dev/builtin#float64
 // [Canonical ABI]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md
 func U64ToF64(v uint64) float64 { return *(*float64)(unsafe.Pointer(&v)) }
 
 // PointerToU32 converts a pointer of type *T into a [uint32].
 // Used to lower a pointer into a Core WebAssembly i32 as specified in the [Canonical ABI].
 //
+// [uint32]: https://pkg.go.dev/builtin#uint32
 // [Canonical ABI]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md
 func PointerToU32[T any](v *T) uint32 { return uint32(uintptr(unsafe.Pointer(v))) }
 
 // U32ToPointer converts a [uint32] into a pointer of type *T.
 // Used to lift a Core WebAssembly i32 into a pointer as specified in the [Canonical ABI].
 //
+// [uint32]: https://pkg.go.dev/builtin#uint32
 // [Canonical ABI]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md
 func U32ToPointer[T any](v uint32) *T { return (*T)(unsafePointer(uintptr(v))) }
 
 // PointerToU64 converts a pointer of type *T into a [uint64].
 // Used to lower a pointer into a Core WebAssembly i64 as specified in the [Canonical ABI].
 //
+// [uint64]: https://pkg.go.dev/builtin#uint64
 // [Canonical ABI]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md
 func PointerToU64[T any](v *T) uint64 { return uint64(uintptr(unsafe.Pointer(v))) }
 
 // U64ToPointer converts a [uint64] into a pointer of type *T.
 // Used to lift a Core WebAssembly i64 into a pointer as specified in the [Canonical ABI].
 //
+// [uint64]: https://pkg.go.dev/builtin#uint64
 // [Canonical ABI]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md
 func U64ToPointer[T any](v uint64) *T { return (*T)(unsafePointer(uintptr(v))) }
 

--- a/cm/abi.go
+++ b/cm/abi.go
@@ -34,16 +34,64 @@ func LiftList[L List[T], T any, Data unsafe.Pointer | uintptr | *T, Len uint | u
 	return L(NewList((*T)(unsafe.Pointer(data)), uint(len)))
 }
 
-func BoolToU32[B ~bool](v B) uint32   { return uint32(*(*uint8)(unsafe.Pointer(&v))) }
-func U32ToBool(v uint32) bool         { tmp := uint8(v); return *(*bool)(unsafe.Pointer(&tmp)) }
-func U32ToF32(v uint32) float32       { return *(*float32)(unsafe.Pointer(&v)) }
-func U64ToF64(v uint64) float64       { return *(*float64)(unsafe.Pointer(&v)) }
-func F32ToF64(v float32) float64      { return float64(v) }
-func F32ToU32(v float32) uint32       { return *(*uint32)(unsafe.Pointer(&v)) }
-func F64ToU64(v float64) uint64       { return *(*uint64)(unsafe.Pointer(&v)) }
+// BoolToU32 converts a value whose underlying type is [bool] into a [uint32].
+// Used to lower a [bool] into a Core WebAssembly i32 as specified in the [Canonical ABI].
+//
+// [Canonical ABI]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md
+func BoolToU32[B ~bool](v B) uint32 { return uint32(*(*uint8)(unsafe.Pointer(&v))) }
+
+// U32ToBool converts a [uint32] into a [bool].
+// Used to lift a Core WebAssembly i32 into a [bool] as specified in the [Canonical ABI].
+//
+// [Canonical ABI]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md
+func U32ToBool(v uint32) bool { tmp := uint8(v); return *(*bool)(unsafe.Pointer(&tmp)) }
+
+// F32ToU32 maps the bits of a [float32] into a [uint32].
+// Used to lower a [float32] into a Core WebAssembly i32 as specified in the [Canonical ABI].
+//
+// [Canonical ABI]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md
+func F32ToU32(v float32) uint32 { return *(*uint32)(unsafe.Pointer(&v)) }
+
+// U32ToF32 maps the bits of a [uint32] into a [float32].
+// Used to lift a Core WebAssembly i32 into a [float32] as specified in the [Canonical ABI].
+//
+// [Canonical ABI]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md
+func U32ToF32(v uint32) float32 { return *(*float32)(unsafe.Pointer(&v)) }
+
+// F64ToU64 maps the bits of a [float64] into a [uint64].
+// Used to lower a [float64] into a Core WebAssembly i64 as specified in the [Canonical ABI].
+//
+// [Canonical ABI]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md
+func F64ToU64(v float64) uint64 { return *(*uint64)(unsafe.Pointer(&v)) }
+
+// U64ToF64 maps the bits of a [uint64] into a [float64].
+// Used to lift a Core WebAssembly i64 into a [float64] as specified in the [Canonical ABI].
+//
+// [Canonical ABI]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md
+func U64ToF64(v uint64) float64 { return *(*float64)(unsafe.Pointer(&v)) }
+
+// PointerToU32 converts a pointer of type *T into a [uint32].
+// Used to lower a pointer into a Core WebAssembly i32 as specified in the [Canonical ABI].
+//
+// [Canonical ABI]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md
 func PointerToU32[T any](v *T) uint32 { return uint32(uintptr(unsafe.Pointer(v))) }
-func PointerToU64[T any](v *T) uint64 { return uint64(uintptr(unsafe.Pointer(v))) }
+
+// U32ToPointer converts a [uint32] into a pointer of type *T.
+// Used to lift a Core WebAssembly i32 into a pointer as specified in the [Canonical ABI].
+//
+// [Canonical ABI]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md
 func U32ToPointer[T any](v uint32) *T { return (*T)(unsafePointer(uintptr(v))) }
+
+// PointerToU64 converts a pointer of type *T into a [uint64].
+// Used to lower a pointer into a Core WebAssembly i64 as specified in the [Canonical ABI].
+//
+// [Canonical ABI]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md
+func PointerToU64[T any](v *T) uint64 { return uint64(uintptr(unsafe.Pointer(v))) }
+
+// U64ToPointer converts a [uint64] into a pointer of type *T.
+// Used to lift a Core WebAssembly i64 into a pointer as specified in the [Canonical ABI].
+//
+// [Canonical ABI]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md
 func U64ToPointer[T any](v uint64) *T { return (*T)(unsafePointer(uintptr(v))) }
 
 // Appease vet, see https://github.com/golang/go/issues/58625

--- a/cm/docs.go
+++ b/cm/docs.go
@@ -1,7 +1,7 @@
-// Package cm (Component Model) contains types and functions for interfacing with the WebAssembly [Component Model].
+// Package cm contains types and functions for interfacing with the WebAssembly Component Model.
 //
 // The types in this package (such as [List], [Option], [Result], and [Variant]) are designed to match the memory layout
-// as specified in the [Canonical ABI].
+// of [Component Model] types as specified in the [Canonical ABI].
 //
 // [Component Model]: https://component-model.bytecodealliance.org/introduction.html
 // [Canonical ABI]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#alignment

--- a/cm/tuple.go
+++ b/cm/tuple.go
@@ -77,6 +77,154 @@ type Tuple8[T0, T1, T2, T3, T4, T5, T6, T7 any] struct {
 	F7 T7
 }
 
-// MaxTuple specifies the maximum number of fields in a Tuple(n) type.
-// currently [Tuple8].
-const MaxTuple = 8
+// Tuple9 represents a [Component Model tuple] with 9 fields.
+//
+// [Component Model tuple]: https://component-model.bytecodealliance.org/design/wit.html#tuples
+type Tuple9[T0, T1, T2, T3, T4, T5, T6, T7, T8 any] struct {
+	F0 T0
+	F1 T1
+	F2 T2
+	F3 T3
+	F4 T4
+	F5 T5
+	F6 T6
+	F7 T7
+	F8 T8
+}
+
+// Tuple10 represents a [Component Model tuple] with 10 fields.
+//
+// [Component Model tuple]: https://component-model.bytecodealliance.org/design/wit.html#tuples
+type Tuple10[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9 any] struct {
+	F0 T0
+	F1 T1
+	F2 T2
+	F3 T3
+	F4 T4
+	F5 T5
+	F6 T6
+	F7 T7
+	F8 T8
+	F9 T9
+}
+
+// Tuple11 represents a [Component Model tuple] with 11 fields.
+//
+// [Component Model tuple]: https://component-model.bytecodealliance.org/design/wit.html#tuples
+type Tuple11[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10 any] struct {
+	F0  T0
+	F1  T1
+	F2  T2
+	F3  T3
+	F4  T4
+	F5  T5
+	F6  T6
+	F7  T7
+	F8  T8
+	F9  T9
+	F10 T10
+}
+
+// Tuple12 represents a [Component Model tuple] with 12 fields.
+//
+// [Component Model tuple]: https://component-model.bytecodealliance.org/design/wit.html#tuples
+type Tuple12[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11 any] struct {
+	F0  T0
+	F1  T1
+	F2  T2
+	F3  T3
+	F4  T4
+	F5  T5
+	F6  T6
+	F7  T7
+	F8  T8
+	F9  T9
+	F10 T10
+	F11 T11
+}
+
+// Tuple13 represents a [Component Model tuple] with 13 fields.
+//
+// [Component Model tuple]: https://component-model.bytecodealliance.org/design/wit.html#tuples
+type Tuple13[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12 any] struct {
+	F0  T0
+	F1  T1
+	F2  T2
+	F3  T3
+	F4  T4
+	F5  T5
+	F6  T6
+	F7  T7
+	F8  T8
+	F9  T9
+	F10 T10
+	F11 T11
+	F12 T12
+}
+
+// Tuple14 represents a [Component Model tuple] with 14 fields.
+//
+// [Component Model tuple]: https://component-model.bytecodealliance.org/design/wit.html#tuples
+type Tuple14[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13 any] struct {
+	F0  T0
+	F1  T1
+	F2  T2
+	F3  T3
+	F4  T4
+	F5  T5
+	F6  T6
+	F7  T7
+	F8  T8
+	F9  T9
+	F10 T10
+	F11 T11
+	F12 T12
+	F13 T13
+}
+
+// Tuple15 represents a [Component Model tuple] with 15 fields.
+//
+// [Component Model tuple]: https://component-model.bytecodealliance.org/design/wit.html#tuples
+type Tuple15[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14 any] struct {
+	F0  T0
+	F1  T1
+	F2  T2
+	F3  T3
+	F4  T4
+	F5  T5
+	F6  T6
+	F7  T7
+	F8  T8
+	F9  T9
+	F10 T10
+	F11 T11
+	F12 T12
+	F13 T13
+	F14 T14
+}
+
+// Tuple16 represents a [Component Model tuple] with 16 fields.
+//
+// [Component Model tuple]: https://component-model.bytecodealliance.org/design/wit.html#tuples
+type Tuple16[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15 any] struct {
+	F0  T0
+	F1  T1
+	F2  T2
+	F3  T3
+	F4  T4
+	F5  T5
+	F6  T6
+	F7  T7
+	F8  T8
+	F9  T9
+	F10 T10
+	F11 T11
+	F12 T12
+	F13 T13
+	F14 T14
+	F15 T15
+}
+
+// MaxTuple specifies the maximum number of fields in a Tuple* type, currently [Tuple16].
+// See https://github.com/WebAssembly/component-model/issues/373 for more information.
+const MaxTuple = 16

--- a/design/README.md
+++ b/design/README.md
@@ -47,22 +47,3 @@ For each exported function that returns allocated memory, there is a [post-retur
 The post-return function name is `cabi_post_` followed by the fully-qualified function name. For example, the WIT function `example:foo/bar#echo` returning a `string` would have a post-return function named `cabi_post_example:foo/bar#echo`.
 
 The post-return function has the form of `(func (param flatten_functype($ft).results))`, where the arguments is a flattened representation of the function results.
-
-### Example in Go
-
-#### Generated Bindings
-
-```go
-package bar
-
-// imports omitted
-
-type Water cm.Resource
-
-//go:wasmimport [export]example:foo/bar [resource-new]water
-func wasmimport_WaterResourceNew(rep uintptr) Water
-
-func WaterResourceNew[Rep WaterInterface](rep Rep) Water {
-	return wasmimport_WaterResourceNew(*(*uintptr)(unsafe.Pointer(&rep)))
-}
-```


### PR DESCRIPTION
This PR adds TinyGo 0.32.0 to test matrix, updates `wasm-tools` to latest, along with the following changes:

### Added
- `Tuple9`...`Tuple16` types in package `cm` to align with [component-model#373](https://github.com/WebAssembly/component-model/issues/373). Tuples with 9 to 16 types will no longer generate inline `struct` types.
- Documentation for Canonical ABI lift and lower helper functions in package `cm`.

### Changed
- Removed outdated documentation in [design](./design/README.md).