### PR TITLE
feat(cmd): add version flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
+VERSION ?= 0.1.5
+REVISION ?= $(shell git rev-parse --short HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo .m; fi)
+PKG=github.com/ydnar/wasm-tools-go
+
+GO_LDFLAGS=-ldflags '-X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision=$(REVISION)'
+
 wit_files = $(sort $(shell find testdata -name '*.wit' ! -name '*.golden.*'))
 
 .PHONY: json
@@ -6,3 +12,7 @@ json: $(wit_files)
 .PHONY: $(wit_files)
 $(wit_files):
 	wasm-tools component wit -j --all-features $@ > $@.json
+
+.PHONY: build
+build:
+	go build $(GO_LDFLAGS) ./cmd/wit-bindgen-go

--- a/cmd/wit-bindgen-go/main.go
+++ b/cmd/wit-bindgen-go/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ydnar/wasm-tools-go/cmd/wit-bindgen-go/cmd/generate"
 	"github.com/ydnar/wasm-tools-go/cmd/wit-bindgen-go/cmd/wit"
+	"github.com/ydnar/wasm-tools-go/version"
 )
 
 func main() {
@@ -25,6 +26,7 @@ func main() {
 				Usage: "force loading WIT via wasm-tools",
 			},
 		},
+		Version: fmt.Sprintf("%v (%v)", version.Version, version.Revision),
 	}
 
 	err := cmd.Run(context.Background(), os.Args)

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,9 @@
+package version
+
+var (
+	// Version is filled with the version number at linking time.
+	Version = ""
+
+	// Revision is filled with the git commit at linking time.
+	Revision = ""
+)


### PR DESCRIPTION
This commit adds a `--version` flag to `wit-bindgen-go` cmd. It includes the version number, the git revision, and an indicator of dirty commit. 