### PR TITLE
chore: add Go 1.23 and TinyGo 0.33.0 to test matrix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -71,8 +71,8 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        tinygo-version: ["0.31.2", "0.32.0", "0.33.0"]
         go-version: ["1.22"]
+        tinygo-version: ["0.31.2", "0.32.0", "0.33.0"]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -107,9 +107,9 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        wasmtime-version: ["21.0.1"]
-        tinygo-version: ["0.31.2", "0.32.0", "0.33.0"]
         go-version: ["1.22"] # WASI Preview 1 only available in Go 1.21 or later
+        tinygo-version: ["0.31.2", "0.32.0", "0.33.0"]
+        wasmtime-version: ["24.0.0"]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         go-version: ["1.22", "1.23"]
-        wasm-tools-version: ["v1.215.0"]
+        wasm-tools-version: ["v1.214.0"]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -74,7 +74,7 @@ jobs:
       matrix:
         go-version: ["1.22", "1.23"]
         tinygo-version: ["0.31.2", "0.32.0", "0.33.0"]
-        wasm-tools-version: ["v1.215.0"]
+        wasm-tools-version: ["v1.214.0"]
         exclude:
           - go-version: "1.23"
             tinygo-version: "0.31.2"
@@ -116,7 +116,7 @@ jobs:
       matrix:
         go-version: ["1.22", "1.23"]
         tinygo-version: ["0.31.2", "0.32.0", "0.33.0"]
-        wasm-tools-version: ["v1.215.0"]
+        wasm-tools-version: ["v1.214.0"]
         wasmtime-version: ["24.0.0"]
         exclude:
           - go-version: "1.23"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         go-version: ["1.22", "1.23"]
-        wasm-tools-version: ["v1.214.0"]
+        wasm-tools-version: ["1.214.0"]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -74,7 +74,7 @@ jobs:
       matrix:
         go-version: ["1.22", "1.23"]
         tinygo-version: ["0.32.0", "0.33.0"]
-        wasm-tools-version: ["v1.214.0"]
+        wasm-tools-version: ["1.214.0"]
         exclude:
           - go-version: "1.23"
             tinygo-version: "0.31.2"
@@ -116,7 +116,7 @@ jobs:
       matrix:
         go-version: ["1.22", "1.23"]
         tinygo-version: ["0.32.0", "0.33.0"]
-        wasm-tools-version: ["v1.214.0"]
+        wasm-tools-version: ["1.214.0"]
         wasmtime-version: ["24.0.0"]
         exclude:
           - go-version: "1.23"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -76,9 +76,9 @@ jobs:
         tinygo-version: ["0.31.2", "0.32.0", "0.33.0"]
         wasm-tools-version: ["v1.215.0"]
         exclude:
-          - go-version: "1.22"
+          - go-version: "1.23"
             tinygo-version: "0.31.2"
-          - go-version: "1.22"
+          - go-version: "1.23"
             tinygo-version: "0.32.0"
     steps:
       - name: Checkout repo
@@ -119,9 +119,9 @@ jobs:
         wasm-tools-version: ["v1.215.0"]
         wasmtime-version: ["24.0.0"]
         exclude:
-          - go-version: "1.22"
+          - go-version: "1.23"
             tinygo-version: "0.31.2"
-          - go-version: "1.22"
+          - go-version: "1.23"
             tinygo-version: "0.32.0"
     steps:
       - name: Checkout repo

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -73,7 +73,7 @@ jobs:
     strategy:
       matrix:
         go-version: ["1.22", "1.23"]
-        tinygo-version: ["0.31.2", "0.32.0", "0.33.0"]
+        tinygo-version: ["0.32.0", "0.33.0"]
         wasm-tools-version: ["v1.214.0"]
         exclude:
           - go-version: "1.23"
@@ -102,7 +102,7 @@ jobs:
           version: ${{ matrix.wasm-tools-version }}
 
       - name: Test with TinyGo
-        run: tinygo test -stack-size=64KB -v ./...
+        run: tinygo test -v ./...
 
       - name: Verify repo is unchanged
         run: git diff --exit-code HEAD
@@ -115,7 +115,7 @@ jobs:
     strategy:
       matrix:
         go-version: ["1.22", "1.23"]
-        tinygo-version: ["0.31.2", "0.32.0", "0.33.0"]
+        tinygo-version: ["0.32.0", "0.33.0"]
         wasm-tools-version: ["v1.214.0"]
         wasmtime-version: ["24.0.0"]
         exclude:
@@ -152,17 +152,23 @@ jobs:
       - name: Add Go wasm exec to $PATH
         run: echo "$(go env GOROOT)/misc/wasm" >> $GITHUB_PATH
 
-      - name: Test WebAssembly with Go + Wasmtime
+      - name: Test wasm/wasip1 with Go
         env:
-          GOOS: wasip1
           GOARCH: wasm
+          GOOS: wasip1
         run: go test -v ./...
 
-      - name: Test WebAssembly with TinyGo + Wasmtime
-        env:
-          GOOS: wasip1
-          GOARCH: wasm
-        run: tinygo test -stack-size=64KB -v ./...
+      - name: Test wasm/wasip1 with TinyGo 0.32.0
+        if: ${{ matrix.tinygo-version == '0.32.0' }}
+        run: tinygo test -v -target=wasi ./...
+
+      - name: Test wasm/wasip1 with TinyGo >= 0.33.0
+        if: ${{ matrix.tinygo-version != '0.32.0' }}
+        run: tinygo test -v -target=wasip1 ./...
+
+      - name: Test wasm/wasip2 with TinyGo >= 0.33.0
+        if: ${{ matrix.tinygo-version != '0.32.0' }}
+        run: tinygo test -v -target=wasip2 ./...
 
       - name: Verify repo is unchanged
         run: git diff --exit-code HEAD

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -71,7 +71,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        tinygo-version: ["0.31.2", "0.32.0"]
+        tinygo-version: ["0.31.2", "0.32.0", "0.33.0"]
         go-version: ["1.22"]
     steps:
       - name: Checkout repo
@@ -108,7 +108,7 @@ jobs:
     strategy:
       matrix:
         wasmtime-version: ["21.0.1"]
-        tinygo-version: ["0.31.2", "0.32.0"]
+        tinygo-version: ["0.31.2", "0.32.0", "0.33.0"]
         go-version: ["1.22"] # WASI Preview 1 only available in Go 1.21 or later
     steps:
       - name: Checkout repo

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,7 +33,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        go-version: ["1.22"]
+        go-version: ["1.22", "1.23"]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -71,8 +71,13 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        go-version: ["1.22"]
+        go-version: ["1.22", "1.23"]
         tinygo-version: ["0.31.2", "0.32.0", "0.33.0"]
+        exclude:
+          - go-version: "1.22"
+            tinygo-version: "0.31.2"
+          - go-version: "1.22"
+            tinygo-version: "0.32.0"
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -107,9 +112,14 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        go-version: ["1.22"] # WASI Preview 1 only available in Go 1.21 or later
+        go-version: ["1.22", "1.23"]
         tinygo-version: ["0.31.2", "0.32.0", "0.33.0"]
         wasmtime-version: ["24.0.0"]
+        exclude:
+          - go-version: "1.22"
+            tinygo-version: "0.31.2"
+          - go-version: "1.22"
+            tinygo-version: "0.32.0"
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,21 +34,22 @@ jobs:
     strategy:
       matrix:
         go-version: ["1.22", "1.23"]
+        wasm-tools-version: ["v1.215.0"]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      - name: Set up wasm-tools
-        uses: bytecodealliance/actions/wasm-tools/setup@v1
-        with:
-          version: v1.215.0
-
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
+
+      - name: Set up wasm-tools
+        uses: bytecodealliance/actions/wasm-tools/setup@v1
+        with:
+          version: ${{ matrix.wasm-tools-version }}
 
       - name: Run Go tests
         run: go test -v ./...
@@ -73,6 +74,7 @@ jobs:
       matrix:
         go-version: ["1.22", "1.23"]
         tinygo-version: ["0.31.2", "0.32.0", "0.33.0"]
+        wasm-tools-version: ["v1.215.0"]
         exclude:
           - go-version: "1.22"
             tinygo-version: "0.31.2"
@@ -84,11 +86,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Set up wasm-tools
-        uses: bytecodealliance/actions/wasm-tools/setup@v1
-        with:
-          version: v1.215.0
-
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -98,6 +95,11 @@ jobs:
         uses: acifani/setup-tinygo@v2
         with:
           tinygo-version: ${{ matrix.tinygo-version }}
+
+      - name: Set up wasm-tools
+        uses: bytecodealliance/actions/wasm-tools/setup@v1
+        with:
+          version: ${{ matrix.wasm-tools-version }}
 
       - name: Test with TinyGo
         run: tinygo test -stack-size=64KB -v ./...
@@ -114,6 +116,7 @@ jobs:
       matrix:
         go-version: ["1.22", "1.23"]
         tinygo-version: ["0.31.2", "0.32.0", "0.33.0"]
+        wasm-tools-version: ["v1.215.0"]
         wasmtime-version: ["24.0.0"]
         exclude:
           - go-version: "1.22"
@@ -126,16 +129,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Set up wasm-tools
-        uses: bytecodealliance/actions/wasm-tools/setup@v1
-        with:
-          version: v1.215.0
-
-      - name: Set up Wasmtime
-        uses: bytecodealliance/actions/wasmtime/setup@v1
-        with:
-          version: ${{ matrix.wasmtime-version }}
-
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -145,6 +138,16 @@ jobs:
         uses: acifani/setup-tinygo@v2
         with:
           tinygo-version: ${{ matrix.tinygo-version }}
+
+      - name: Set up wasm-tools
+        uses: bytecodealliance/actions/wasm-tools/setup@v1
+        with:
+          version: ${{ matrix.wasm-tools-version }}
+
+      - name: Set up Wasmtime
+        uses: bytecodealliance/actions/wasmtime/setup@v1
+        with:
+          version: ${{ matrix.wasmtime-version }}
 
       - name: Add Go wasm exec to $PATH
         run: echo "$(go env GOROOT)/misc/wasm" >> $GITHUB_PATH

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up wasm-tools
         uses: bytecodealliance/actions/wasm-tools/setup@v1
         with:
-          version: v1.213.0
+          version: v1.215.0
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -82,7 +82,7 @@ jobs:
       - name: Set up wasm-tools
         uses: bytecodealliance/actions/wasm-tools/setup@v1
         with:
-          version: v1.213.0
+          version: v1.215.0
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -119,7 +119,7 @@ jobs:
       - name: Set up wasm-tools
         uses: bytecodealliance/actions/wasm-tools/setup@v1
         with:
-          version: v1.213.0
+          version: v1.215.0
 
       - name: Set up Wasmtime
         uses: bytecodealliance/actions/wasmtime/setup@v1

--- a/cabi/realloc.go
+++ b/cabi/realloc.go
@@ -5,10 +5,7 @@ import "unsafe"
 // realloc allocates or reallocates memory for Component Model calls across
 // the host-guest boundary.
 //
-// Note: the use of uintptr assumes 32-bit pointers when compiled for WebAssembly.
-//
-//go:export cabi_realloc
-//go:wasmexport cabi_realloc
+// Note: the use of uintptr assumes 32-bit pointers when compiled for wasm or wasm32.
 func realloc(ptr unsafe.Pointer, size, align, newsize uintptr) unsafe.Pointer {
 	if newsize <= size {
 		return unsafe.Add(ptr, offset(uintptr(ptr), align))

--- a/internal/relpath/getwd_other.go
+++ b/internal/relpath/getwd_other.go
@@ -1,0 +1,11 @@
+//go:build !wasip1
+
+package relpath
+
+import "os"
+
+// Getwd returns best-effort path to the current working directory, even on WebAssembly.
+// The path may be absolute, or it may be relative, prefixed with one or more ".." segments.
+func Getwd() (string, error) {
+	return os.Getwd()
+}

--- a/internal/relpath/getwd_wasip1.go
+++ b/internal/relpath/getwd_wasip1.go
@@ -1,0 +1,59 @@
+//go:build wasip1
+
+package relpath
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// Getwd returns best-effort path to the current working directory, even on WebAssembly.
+// The path may be absolute, or it may be relative, prefixed with one or more ".." segments.
+func Getwd() (string, error) {
+	var path string
+	var target string
+	parent := "."
+outer:
+	for {
+		target = parent
+		// println("statting target:", target)
+		dirInfo, err := os.Stat(target)
+		if err != nil {
+			return path, err
+		}
+		parent = filepath.Join("..", target)
+
+		dir, err := os.Open(parent)
+		if err != nil {
+			return filepath.Clean(filepath.Join(target, path)), nil
+		}
+		names, err := dir.Readdirnames(-1)
+		dir.Close()
+		if err != nil {
+			return filepath.Clean(filepath.Join(target, path)), nil
+		}
+		// println("NAMES: ", strings.Join(names, " "))
+		for _, name := range names {
+			info, err := os.Stat(filepath.Join(parent, name))
+			if err != nil {
+				continue
+			}
+			if info.IsDir() && sameFile(dirInfo, info) {
+				path = filepath.Join(name, path)
+				continue outer
+			}
+		}
+		break
+	}
+	return filepath.Clean(filepath.Join("/", path)), nil
+}
+
+func sameFile(a, b fs.FileInfo) bool {
+	// fmt.Printf("A: %s %d %v %v %t\n", a.Name(), a.Size(), a.Mode(), a.ModTime(), a.IsDir())
+	// fmt.Printf("B: %s %d %v %v %t\n", b.Name(), b.Size(), b.Mode(), b.ModTime(), b.IsDir())
+	return a.Size() == b.Size() &&
+		a.Mode() == b.Mode() &&
+		a.ModTime().Equal(b.ModTime()) &&
+		a.IsDir() == b.IsDir()
+}

--- a/internal/relpath/getwd_wasip1.go
+++ b/internal/relpath/getwd_wasip1.go
@@ -39,7 +39,7 @@ outer:
 			if err != nil {
 				continue
 			}
-			if info.IsDir() && sameFile(dirInfo, info) {
+			if info.IsDir() && os.SameFile(dirInfo, info) {
 				path = filepath.Join(name, path)
 				continue outer
 			}

--- a/internal/relpath/relpath.go
+++ b/internal/relpath/relpath.go
@@ -2,7 +2,6 @@ package relpath
 
 import (
 	"io/fs"
-	"os"
 	"path/filepath"
 	"runtime"
 )
@@ -46,47 +45,6 @@ func CallerRel(path string) string {
 	}
 	dir := filepath.Dir(file)
 	return filepath.Join(dir, path)
-}
-
-// Getwd returns best-effort path to the current working directory, even on WebAssembly.
-// The path may be absolute, or it may be relative, prefixed with one or more ".." segments.
-func Getwd() (string, error) {
-	var path string
-	var target string
-	parent := "."
-outer:
-	for {
-		target = parent
-		// println("statting target:", target)
-		dirInfo, err := os.Stat(target)
-		if err != nil {
-			return path, err
-		}
-		parent = filepath.Join("..", target)
-
-		dir, err := os.Open(parent)
-		if err != nil {
-			return filepath.Clean(filepath.Join(target, path)), nil
-		}
-		names, err := dir.Readdirnames(-1)
-		dir.Close()
-		if err != nil {
-			return filepath.Clean(filepath.Join(target, path)), nil
-		}
-		// println("NAMES: ", strings.Join(names, " "))
-		for _, name := range names {
-			info, err := os.Stat(filepath.Join(parent, name))
-			if err != nil {
-				continue
-			}
-			if os.SameFile(dirInfo, info) {
-				path = filepath.Join(name, path)
-				continue outer
-			}
-		}
-		break
-	}
-	return filepath.Clean(filepath.Join("/", path)), nil
 }
 
 // Walk walks the files in directory dir, passing them to func f.


### PR DESCRIPTION
This PR adds Go 1.23 and TinyGo 0.33 to the test matrix, with necessary workarounds to make it work.