### PR TITLE
build tag option wasip1

### DIFF
--- a/cmd/wit-bindgen-go/cmd/generate/generate.go
+++ b/cmd/wit-bindgen-go/cmd/generate/generate.go
@@ -60,6 +60,14 @@ var Command = &cli.Command{
 			Name:  "dry-run",
 			Usage: "do not write files; print to stdout",
 		},
+		&cli.StringFlag{
+			Name:     "target",
+			Aliases:  []string{"t"},
+			Value:    "wasip2",
+			OnlyOnce: true,
+			Config:   cli.StringConfig{TrimSpace: true},
+			Usage:    "sets the Go build tag for the generated WIT bindings",
+		},
 	},
 	Action: action,
 }
@@ -98,6 +106,7 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		bindgen.PackageRoot(pkgRoot),
 		bindgen.Versioned(cmd.Bool("versioned")),
 		bindgen.CMPackage(cmd.String("cm")),
+		bindgen.Target(cmd.String("target")),
 	)
 	if err != nil {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -7,10 +7,10 @@ require (
 	github.com/sergi/go-diff v1.3.1
 	github.com/urfave/cli/v3 v3.0.0-alpha9
 	golang.org/x/mod v0.20.0
-	golang.org/x/tools v0.23.0
+	golang.org/x/tools v0.24.0
 )
 
 require (
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
-	golang.org/x/sync v0.7.0 // indirect
+	golang.org/x/sync v0.8.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -20,10 +20,10 @@ github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRT
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 golang.org/x/mod v0.20.0 h1:utOm6MM3R3dnawAiJgn0y+xvuYRsm1RKM/4giyfDgV0=
 golang.org/x/mod v0.20.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
-golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
-golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
-golang.org/x/tools v0.23.0 h1:SGsXPZ+2l4JsgaCKkx+FQ9YZ5XEtA1GZYuoDjenLjvg=
-golang.org/x/tools v0.23.0/go.mod h1:pnu6ufv6vQkll6szChhK3C3L/ruaIv5eBeztNG8wtsI=
+golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
+golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/tools v0.24.0 h1:J1shsA93PJUEVaUSaay7UXAyE8aimq3GW0pjlolpa24=
+golang.org/x/tools v0.24.0/go.mod h1:YhNqVBIfWHdzvTLs0d8LCuMhkKUgSUKldakyV7W/WDQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -172,6 +172,11 @@ func newGenerator(res *wit.Resolve, opts ...Option) (*generator, error) {
 	if g.opts.cmPackage == "" {
 		g.opts.cmPackage = cmPackage
 	}
+
+	if g.opts.target == "" {
+		g.opts.target = BuildDefault
+	}
+
 	g.res = res
 	return g, nil
 }
@@ -2110,7 +2115,7 @@ func (g *generator) ensureEmptyAsm(pkg *gen.Package) error {
 func (g *generator) abiFile(pkg *gen.Package) *gen.File {
 	file := pkg.File("abi.go")
 	file.GeneratedBy = g.opts.generatedBy
-	file.Build = BuildDefault
+	file.Build = g.opts.target
 	return file
 }
 
@@ -2118,7 +2123,7 @@ func (g *generator) fileFor(id wit.Ident) *gen.File {
 	pkg := g.packageFor(id)
 	file := pkg.File(id.Extension + ".wit.go")
 	file.GeneratedBy = g.opts.generatedBy
-	file.Build = BuildDefault
+	file.Build = g.opts.target
 	return file
 }
 
@@ -2126,7 +2131,7 @@ func (g *generator) exportsFileFor(id wit.Ident) *gen.File {
 	pkg := g.packageFor(id)
 	file := pkg.File(id.Extension + ".exports.go")
 	file.GeneratedBy = g.opts.generatedBy
-	file.Build = BuildDefault
+	file.Build = g.opts.target
 	if len(file.Header) == 0 {
 		exports := file.GetName("Exports")
 		var b strings.Builder

--- a/wit/bindgen/options.go
+++ b/wit/bindgen/options.go
@@ -95,9 +95,9 @@ func Versioned(versioned bool) Option {
 // the target suppilied.
 func Target(target string) Option {
 	return optionFunc(func(opts *options) error {
-		switch strings.ToLower(target) {
+		target = strings.ToLower(target)
+		switch target {
 		case "wasip1":
-			fmt.Println("setting target")
 			opts.target = target
 		case "wasip2":
 			opts.target = BuildDefault

--- a/wit/bindgen/options.go
+++ b/wit/bindgen/options.go
@@ -1,5 +1,10 @@
 package bindgen
 
+import (
+	"fmt"
+	"strings"
+)
+
 // Option represents a single configuration option for this package.
 type Option interface {
 	applyOption(*options) error
@@ -28,6 +33,9 @@ type options struct {
 
 	// versioned determines if Go packages are generated with version numbers.
 	versioned bool
+
+	// target determines the golang build tags that should be added to the generated wit bindings
+	target string
 }
 
 func (opts *options) apply(o ...Option) error {
@@ -79,6 +87,23 @@ func CMPackage(path string) Option {
 func Versioned(versioned bool) Option {
 	return optionFunc(func(opts *options) error {
 		opts.versioned = versioned
+		return nil
+	})
+}
+
+// Target returns an [Option] that specifices that all generated bindings include a build tag allowing
+// the target suppilied.
+func Target(target string) Option {
+	return optionFunc(func(opts *options) error {
+		switch strings.ToLower(target) {
+		case "wasip1":
+			fmt.Println("setting target")
+			opts.target = target
+		case "wasip2":
+			opts.target = BuildDefault
+		default:
+			return fmt.Errorf("target: %s not supported", target)
+		}
 		return nil
 	})
 }


### PR DESCRIPTION
This adds an option for setting the build tag for generated code. Currently, wasip1 and wasip2 are supported. 

This repo provides a wit definition, generated code, and sample code for creating a module targeting wasip1 and a component targeting wasip2 https://github.com/elewis787/wasip1-wasip2. 

