### PR TITLE
cmd/wit-bindgen-go: add --version flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+- `wit-bindgen-go --version` now reports the module version and git revision of the `wit-bindgen-go` command.
+
 ### Changed
 - Omit the default `//go:build !wasip1` build tags from generated Go files. This enables `wit-bindgen-go` to target `GOOS=wasip1` (fixes [#147](https://github.com/ydnar/wasm-tools-go/issues/147)).
 

--- a/cmd/wit-bindgen-go/main.go
+++ b/cmd/wit-bindgen-go/main.go
@@ -4,12 +4,32 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"runtime/debug"
 
 	"github.com/urfave/cli/v3"
 
 	"github.com/ydnar/wasm-tools-go/cmd/wit-bindgen-go/cmd/generate"
 	"github.com/ydnar/wasm-tools-go/cmd/wit-bindgen-go/cmd/wit"
 )
+
+var (
+	version  = ""
+	revision = ""
+)
+
+func init() {
+	build, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	version = build.Main.Version
+	for _, s := range build.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			revision = s.Value
+		}
+	}
+}
 
 func main() {
 	cmd := &cli.Command{
@@ -25,6 +45,7 @@ func main() {
 				Usage: "force loading WIT via wasm-tools",
 			},
 		},
+		Version: fmt.Sprintf("%v (%v)", version, revision),
 	}
 
 	err := cmd.Run(context.Background(), os.Args)


### PR DESCRIPTION
The version and git revision are pulled from the debug.BuildMode struct.

Variation of #143.
