### PR TITLE
wit: generate multi-package WIT files with an un-nested root package

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         go-version: ["1.22", "1.23"]
-        wasm-tools-version: ["1.214.0"]
+        wasm-tools-version: ["1.216.0"]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -74,7 +74,7 @@ jobs:
       matrix:
         go-version: ["1.22", "1.23"]
         tinygo-version: ["0.32.0", "0.33.0"]
-        wasm-tools-version: ["1.214.0"]
+        wasm-tools-version: ["1.216.0"]
         exclude:
           - go-version: "1.23"
             tinygo-version: "0.31.2"
@@ -116,7 +116,7 @@ jobs:
       matrix:
         go-version: ["1.22", "1.23"]
         tinygo-version: ["0.32.0", "0.33.0"]
-        wasm-tools-version: ["1.214.0"]
+        wasm-tools-version: ["1.216.0"]
         wasmtime-version: ["24.0.0"]
         exclude:
           - go-version: "1.23"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 - Omit the default `//go:build !wasip1` build tags from generated Go files. This enables `wit-bindgen-go` to target `GOOS=wasip1` (fixes [#147](https://github.com/ydnar/wasm-tools-go/issues/147)).
+- Package `wit` now serializes multi-package WIT files with an un-nested “root” package. See [WebAssembly/component-model#380](https://github.com/WebAssembly/component-model/pull/380) and [bytecodealliance/wasm-tools#1700](https://github.com/bytecodealliance/wasm-tools/pull/1700).
 
 ## [v0.1.4] — 2024-07-16
 

--- a/testdata/wasi/cli.wit.json.golden.wit
+++ b/testdata/wasi/cli.wit.json.golden.wit
@@ -1,159 +1,160 @@
-package wasi:cli@0.2.0 {
-	interface environment {
-		/// Get the POSIX-style environment variables.
-		///
-		/// Each environment variable is provided as a pair of string variable names
-		/// and string value.
-		///
-		/// Morally, these are a value import, but until value imports are available
-		/// in the component model, this import function should return the same
-		/// values each time it is called.
-		get-environment: func() -> list<tuple<string, string>>;
+package wasi:cli@0.2.0;
 
-		/// Get the POSIX-style arguments to the program.
-		get-arguments: func() -> list<string>;
-
-		/// Return a path that programs should use as their initial current working
-		/// directory, interpreting `.` as shorthand for this.
-		initial-cwd: func() -> option<string>;
-	}
-
-	interface exit {
-		/// Exit the current instance and any linked instances.
-		exit: func(status: result);
-	}
-
-	interface run {
-		/// Run the program.
-		run: func() -> result;
-	}
-
-	interface stdin {
-		use wasi:io/streams@0.2.0.{input-stream};
-		get-stdin: func() -> input-stream;
-	}
-
-	interface stdout {
-		use wasi:io/streams@0.2.0.{output-stream};
-		get-stdout: func() -> output-stream;
-	}
-
-	interface stderr {
-		use wasi:io/streams@0.2.0.{output-stream};
-		get-stderr: func() -> output-stream;
-	}
-
-	/// Terminal input.
+interface environment {
+	/// Get the POSIX-style environment variables.
 	///
-	/// In the future, this may include functions for disabling echoing,
-	/// disabling input buffering so that keyboard events are sent through
-	/// immediately, querying supported features, and so on.
-	interface terminal-input {
-		/// The input side of a terminal.
-		resource terminal-input;
-	}
-
-	/// Terminal output.
+	/// Each environment variable is provided as a pair of string variable names
+	/// and string value.
 	///
-	/// In the future, this may include functions for querying the terminal
-	/// size, being notified of terminal size changes, querying supported
-	/// features, and so on.
-	interface terminal-output {
-		/// The output side of a terminal.
-		resource terminal-output;
-	}
+	/// Morally, these are a value import, but until value imports are available
+	/// in the component model, this import function should return the same
+	/// values each time it is called.
+	get-environment: func() -> list<tuple<string, string>>;
 
-	/// An interface providing an optional `terminal-input` for stdin as a
-	/// link-time authority.
-	interface terminal-stdin {
-		use terminal-input.{terminal-input};
+	/// Get the POSIX-style arguments to the program.
+	get-arguments: func() -> list<string>;
 
-		/// If stdin is connected to a terminal, return a `terminal-input` handle
-		/// allowing further interaction with it.
-		get-terminal-stdin: func() -> option<terminal-input>;
-	}
-
-	/// An interface providing an optional `terminal-output` for stdout as a
-	/// link-time authority.
-	interface terminal-stdout {
-		use terminal-output.{terminal-output};
-
-		/// If stdout is connected to a terminal, return a `terminal-output` handle
-		/// allowing further interaction with it.
-		get-terminal-stdout: func() -> option<terminal-output>;
-	}
-
-	/// An interface providing an optional `terminal-output` for stderr as a
-	/// link-time authority.
-	interface terminal-stderr {
-		use terminal-output.{terminal-output};
-
-		/// If stderr is connected to a terminal, return a `terminal-output` handle
-		/// allowing further interaction with it.
-		get-terminal-stderr: func() -> option<terminal-output>;
-	}
-
-	world imports {
-		import environment;
-		import exit;
-		import wasi:io/error@0.2.0;
-		import wasi:io/poll@0.2.0;
-		import wasi:io/streams@0.2.0;
-		import stdin;
-		import stdout;
-		import stderr;
-		import terminal-input;
-		import terminal-output;
-		import terminal-stdin;
-		import terminal-stdout;
-		import terminal-stderr;
-		import wasi:clocks/monotonic-clock@0.2.0;
-		import wasi:clocks/wall-clock@0.2.0;
-		import wasi:filesystem/types@0.2.0;
-		import wasi:filesystem/preopens@0.2.0;
-		import wasi:sockets/network@0.2.0;
-		import wasi:sockets/instance-network@0.2.0;
-		import wasi:sockets/udp@0.2.0;
-		import wasi:sockets/udp-create-socket@0.2.0;
-		import wasi:sockets/tcp@0.2.0;
-		import wasi:sockets/tcp-create-socket@0.2.0;
-		import wasi:sockets/ip-name-lookup@0.2.0;
-		import wasi:random/random@0.2.0;
-		import wasi:random/insecure@0.2.0;
-		import wasi:random/insecure-seed@0.2.0;
-	}
-
-	world command {
-		import environment;
-		import exit;
-		import wasi:io/error@0.2.0;
-		import wasi:io/poll@0.2.0;
-		import wasi:io/streams@0.2.0;
-		import stdin;
-		import stdout;
-		import stderr;
-		import terminal-input;
-		import terminal-output;
-		import terminal-stdin;
-		import terminal-stdout;
-		import terminal-stderr;
-		import wasi:clocks/monotonic-clock@0.2.0;
-		import wasi:clocks/wall-clock@0.2.0;
-		import wasi:filesystem/types@0.2.0;
-		import wasi:filesystem/preopens@0.2.0;
-		import wasi:sockets/network@0.2.0;
-		import wasi:sockets/instance-network@0.2.0;
-		import wasi:sockets/udp@0.2.0;
-		import wasi:sockets/udp-create-socket@0.2.0;
-		import wasi:sockets/tcp@0.2.0;
-		import wasi:sockets/tcp-create-socket@0.2.0;
-		import wasi:sockets/ip-name-lookup@0.2.0;
-		import wasi:random/random@0.2.0;
-		import wasi:random/insecure@0.2.0;
-		import wasi:random/insecure-seed@0.2.0;
-		export run;
-	}
+	/// Return a path that programs should use as their initial current working
+	/// directory, interpreting `.` as shorthand for this.
+	initial-cwd: func() -> option<string>;
 }
+
+interface exit {
+	/// Exit the current instance and any linked instances.
+	exit: func(status: result);
+}
+
+interface run {
+	/// Run the program.
+	run: func() -> result;
+}
+
+interface stdin {
+	use wasi:io/streams@0.2.0.{input-stream};
+	get-stdin: func() -> input-stream;
+}
+
+interface stdout {
+	use wasi:io/streams@0.2.0.{output-stream};
+	get-stdout: func() -> output-stream;
+}
+
+interface stderr {
+	use wasi:io/streams@0.2.0.{output-stream};
+	get-stderr: func() -> output-stream;
+}
+
+/// Terminal input.
+///
+/// In the future, this may include functions for disabling echoing,
+/// disabling input buffering so that keyboard events are sent through
+/// immediately, querying supported features, and so on.
+interface terminal-input {
+	/// The input side of a terminal.
+	resource terminal-input;
+}
+
+/// Terminal output.
+///
+/// In the future, this may include functions for querying the terminal
+/// size, being notified of terminal size changes, querying supported
+/// features, and so on.
+interface terminal-output {
+	/// The output side of a terminal.
+	resource terminal-output;
+}
+
+/// An interface providing an optional `terminal-input` for stdin as a
+/// link-time authority.
+interface terminal-stdin {
+	use terminal-input.{terminal-input};
+
+	/// If stdin is connected to a terminal, return a `terminal-input` handle
+	/// allowing further interaction with it.
+	get-terminal-stdin: func() -> option<terminal-input>;
+}
+
+/// An interface providing an optional `terminal-output` for stdout as a
+/// link-time authority.
+interface terminal-stdout {
+	use terminal-output.{terminal-output};
+
+	/// If stdout is connected to a terminal, return a `terminal-output` handle
+	/// allowing further interaction with it.
+	get-terminal-stdout: func() -> option<terminal-output>;
+}
+
+/// An interface providing an optional `terminal-output` for stderr as a
+/// link-time authority.
+interface terminal-stderr {
+	use terminal-output.{terminal-output};
+
+	/// If stderr is connected to a terminal, return a `terminal-output` handle
+	/// allowing further interaction with it.
+	get-terminal-stderr: func() -> option<terminal-output>;
+}
+
+world imports {
+	import environment;
+	import exit;
+	import wasi:io/error@0.2.0;
+	import wasi:io/poll@0.2.0;
+	import wasi:io/streams@0.2.0;
+	import stdin;
+	import stdout;
+	import stderr;
+	import terminal-input;
+	import terminal-output;
+	import terminal-stdin;
+	import terminal-stdout;
+	import terminal-stderr;
+	import wasi:clocks/monotonic-clock@0.2.0;
+	import wasi:clocks/wall-clock@0.2.0;
+	import wasi:filesystem/types@0.2.0;
+	import wasi:filesystem/preopens@0.2.0;
+	import wasi:sockets/network@0.2.0;
+	import wasi:sockets/instance-network@0.2.0;
+	import wasi:sockets/udp@0.2.0;
+	import wasi:sockets/udp-create-socket@0.2.0;
+	import wasi:sockets/tcp@0.2.0;
+	import wasi:sockets/tcp-create-socket@0.2.0;
+	import wasi:sockets/ip-name-lookup@0.2.0;
+	import wasi:random/random@0.2.0;
+	import wasi:random/insecure@0.2.0;
+	import wasi:random/insecure-seed@0.2.0;
+}
+
+world command {
+	import environment;
+	import exit;
+	import wasi:io/error@0.2.0;
+	import wasi:io/poll@0.2.0;
+	import wasi:io/streams@0.2.0;
+	import stdin;
+	import stdout;
+	import stderr;
+	import terminal-input;
+	import terminal-output;
+	import terminal-stdin;
+	import terminal-stdout;
+	import terminal-stderr;
+	import wasi:clocks/monotonic-clock@0.2.0;
+	import wasi:clocks/wall-clock@0.2.0;
+	import wasi:filesystem/types@0.2.0;
+	import wasi:filesystem/preopens@0.2.0;
+	import wasi:sockets/network@0.2.0;
+	import wasi:sockets/instance-network@0.2.0;
+	import wasi:sockets/udp@0.2.0;
+	import wasi:sockets/udp-create-socket@0.2.0;
+	import wasi:sockets/tcp@0.2.0;
+	import wasi:sockets/tcp-create-socket@0.2.0;
+	import wasi:sockets/ip-name-lookup@0.2.0;
+	import wasi:random/random@0.2.0;
+	import wasi:random/insecure@0.2.0;
+	import wasi:random/insecure-seed@0.2.0;
+	export run;
+}
+
 
 package wasi:clocks@0.2.0 {
 	/// WASI Monotonic Clock is a clock API intended to let users measure elapsed

--- a/testdata/wasi/http.wit.json.golden.wit
+++ b/testdata/wasi/http.wit.json.golden.wit
@@ -1,159 +1,160 @@
-package wasi:cli@0.2.0 {
-	interface environment {
-		/// Get the POSIX-style environment variables.
-		///
-		/// Each environment variable is provided as a pair of string variable names
-		/// and string value.
-		///
-		/// Morally, these are a value import, but until value imports are available
-		/// in the component model, this import function should return the same
-		/// values each time it is called.
-		get-environment: func() -> list<tuple<string, string>>;
+package wasi:cli@0.2.0;
 
-		/// Get the POSIX-style arguments to the program.
-		get-arguments: func() -> list<string>;
-
-		/// Return a path that programs should use as their initial current working
-		/// directory, interpreting `.` as shorthand for this.
-		initial-cwd: func() -> option<string>;
-	}
-
-	interface exit {
-		/// Exit the current instance and any linked instances.
-		exit: func(status: result);
-	}
-
-	interface run {
-		/// Run the program.
-		run: func() -> result;
-	}
-
-	interface stdin {
-		use wasi:io/streams@0.2.0.{input-stream};
-		get-stdin: func() -> input-stream;
-	}
-
-	interface stdout {
-		use wasi:io/streams@0.2.0.{output-stream};
-		get-stdout: func() -> output-stream;
-	}
-
-	interface stderr {
-		use wasi:io/streams@0.2.0.{output-stream};
-		get-stderr: func() -> output-stream;
-	}
-
-	/// Terminal input.
+interface environment {
+	/// Get the POSIX-style environment variables.
 	///
-	/// In the future, this may include functions for disabling echoing,
-	/// disabling input buffering so that keyboard events are sent through
-	/// immediately, querying supported features, and so on.
-	interface terminal-input {
-		/// The input side of a terminal.
-		resource terminal-input;
-	}
-
-	/// Terminal output.
+	/// Each environment variable is provided as a pair of string variable names
+	/// and string value.
 	///
-	/// In the future, this may include functions for querying the terminal
-	/// size, being notified of terminal size changes, querying supported
-	/// features, and so on.
-	interface terminal-output {
-		/// The output side of a terminal.
-		resource terminal-output;
-	}
+	/// Morally, these are a value import, but until value imports are available
+	/// in the component model, this import function should return the same
+	/// values each time it is called.
+	get-environment: func() -> list<tuple<string, string>>;
 
-	/// An interface providing an optional `terminal-input` for stdin as a
-	/// link-time authority.
-	interface terminal-stdin {
-		use terminal-input.{terminal-input};
+	/// Get the POSIX-style arguments to the program.
+	get-arguments: func() -> list<string>;
 
-		/// If stdin is connected to a terminal, return a `terminal-input` handle
-		/// allowing further interaction with it.
-		get-terminal-stdin: func() -> option<terminal-input>;
-	}
-
-	/// An interface providing an optional `terminal-output` for stdout as a
-	/// link-time authority.
-	interface terminal-stdout {
-		use terminal-output.{terminal-output};
-
-		/// If stdout is connected to a terminal, return a `terminal-output` handle
-		/// allowing further interaction with it.
-		get-terminal-stdout: func() -> option<terminal-output>;
-	}
-
-	/// An interface providing an optional `terminal-output` for stderr as a
-	/// link-time authority.
-	interface terminal-stderr {
-		use terminal-output.{terminal-output};
-
-		/// If stderr is connected to a terminal, return a `terminal-output` handle
-		/// allowing further interaction with it.
-		get-terminal-stderr: func() -> option<terminal-output>;
-	}
-
-	world imports {
-		import environment;
-		import exit;
-		import wasi:io/error@0.2.0;
-		import wasi:io/poll@0.2.0;
-		import wasi:io/streams@0.2.0;
-		import stdin;
-		import stdout;
-		import stderr;
-		import terminal-input;
-		import terminal-output;
-		import terminal-stdin;
-		import terminal-stdout;
-		import terminal-stderr;
-		import wasi:clocks/monotonic-clock@0.2.0;
-		import wasi:clocks/wall-clock@0.2.0;
-		import wasi:filesystem/types@0.2.0;
-		import wasi:filesystem/preopens@0.2.0;
-		import wasi:sockets/network@0.2.0;
-		import wasi:sockets/instance-network@0.2.0;
-		import wasi:sockets/udp@0.2.0;
-		import wasi:sockets/udp-create-socket@0.2.0;
-		import wasi:sockets/tcp@0.2.0;
-		import wasi:sockets/tcp-create-socket@0.2.0;
-		import wasi:sockets/ip-name-lookup@0.2.0;
-		import wasi:random/random@0.2.0;
-		import wasi:random/insecure@0.2.0;
-		import wasi:random/insecure-seed@0.2.0;
-	}
-
-	world command {
-		import environment;
-		import exit;
-		import wasi:io/error@0.2.0;
-		import wasi:io/poll@0.2.0;
-		import wasi:io/streams@0.2.0;
-		import stdin;
-		import stdout;
-		import stderr;
-		import terminal-input;
-		import terminal-output;
-		import terminal-stdin;
-		import terminal-stdout;
-		import terminal-stderr;
-		import wasi:clocks/monotonic-clock@0.2.0;
-		import wasi:clocks/wall-clock@0.2.0;
-		import wasi:filesystem/types@0.2.0;
-		import wasi:filesystem/preopens@0.2.0;
-		import wasi:sockets/network@0.2.0;
-		import wasi:sockets/instance-network@0.2.0;
-		import wasi:sockets/udp@0.2.0;
-		import wasi:sockets/udp-create-socket@0.2.0;
-		import wasi:sockets/tcp@0.2.0;
-		import wasi:sockets/tcp-create-socket@0.2.0;
-		import wasi:sockets/ip-name-lookup@0.2.0;
-		import wasi:random/random@0.2.0;
-		import wasi:random/insecure@0.2.0;
-		import wasi:random/insecure-seed@0.2.0;
-		export run;
-	}
+	/// Return a path that programs should use as their initial current working
+	/// directory, interpreting `.` as shorthand for this.
+	initial-cwd: func() -> option<string>;
 }
+
+interface exit {
+	/// Exit the current instance and any linked instances.
+	exit: func(status: result);
+}
+
+interface run {
+	/// Run the program.
+	run: func() -> result;
+}
+
+interface stdin {
+	use wasi:io/streams@0.2.0.{input-stream};
+	get-stdin: func() -> input-stream;
+}
+
+interface stdout {
+	use wasi:io/streams@0.2.0.{output-stream};
+	get-stdout: func() -> output-stream;
+}
+
+interface stderr {
+	use wasi:io/streams@0.2.0.{output-stream};
+	get-stderr: func() -> output-stream;
+}
+
+/// Terminal input.
+///
+/// In the future, this may include functions for disabling echoing,
+/// disabling input buffering so that keyboard events are sent through
+/// immediately, querying supported features, and so on.
+interface terminal-input {
+	/// The input side of a terminal.
+	resource terminal-input;
+}
+
+/// Terminal output.
+///
+/// In the future, this may include functions for querying the terminal
+/// size, being notified of terminal size changes, querying supported
+/// features, and so on.
+interface terminal-output {
+	/// The output side of a terminal.
+	resource terminal-output;
+}
+
+/// An interface providing an optional `terminal-input` for stdin as a
+/// link-time authority.
+interface terminal-stdin {
+	use terminal-input.{terminal-input};
+
+	/// If stdin is connected to a terminal, return a `terminal-input` handle
+	/// allowing further interaction with it.
+	get-terminal-stdin: func() -> option<terminal-input>;
+}
+
+/// An interface providing an optional `terminal-output` for stdout as a
+/// link-time authority.
+interface terminal-stdout {
+	use terminal-output.{terminal-output};
+
+	/// If stdout is connected to a terminal, return a `terminal-output` handle
+	/// allowing further interaction with it.
+	get-terminal-stdout: func() -> option<terminal-output>;
+}
+
+/// An interface providing an optional `terminal-output` for stderr as a
+/// link-time authority.
+interface terminal-stderr {
+	use terminal-output.{terminal-output};
+
+	/// If stderr is connected to a terminal, return a `terminal-output` handle
+	/// allowing further interaction with it.
+	get-terminal-stderr: func() -> option<terminal-output>;
+}
+
+world imports {
+	import environment;
+	import exit;
+	import wasi:io/error@0.2.0;
+	import wasi:io/poll@0.2.0;
+	import wasi:io/streams@0.2.0;
+	import stdin;
+	import stdout;
+	import stderr;
+	import terminal-input;
+	import terminal-output;
+	import terminal-stdin;
+	import terminal-stdout;
+	import terminal-stderr;
+	import wasi:clocks/monotonic-clock@0.2.0;
+	import wasi:clocks/wall-clock@0.2.0;
+	import wasi:filesystem/types@0.2.0;
+	import wasi:filesystem/preopens@0.2.0;
+	import wasi:sockets/network@0.2.0;
+	import wasi:sockets/instance-network@0.2.0;
+	import wasi:sockets/udp@0.2.0;
+	import wasi:sockets/udp-create-socket@0.2.0;
+	import wasi:sockets/tcp@0.2.0;
+	import wasi:sockets/tcp-create-socket@0.2.0;
+	import wasi:sockets/ip-name-lookup@0.2.0;
+	import wasi:random/random@0.2.0;
+	import wasi:random/insecure@0.2.0;
+	import wasi:random/insecure-seed@0.2.0;
+}
+
+world command {
+	import environment;
+	import exit;
+	import wasi:io/error@0.2.0;
+	import wasi:io/poll@0.2.0;
+	import wasi:io/streams@0.2.0;
+	import stdin;
+	import stdout;
+	import stderr;
+	import terminal-input;
+	import terminal-output;
+	import terminal-stdin;
+	import terminal-stdout;
+	import terminal-stderr;
+	import wasi:clocks/monotonic-clock@0.2.0;
+	import wasi:clocks/wall-clock@0.2.0;
+	import wasi:filesystem/types@0.2.0;
+	import wasi:filesystem/preopens@0.2.0;
+	import wasi:sockets/network@0.2.0;
+	import wasi:sockets/instance-network@0.2.0;
+	import wasi:sockets/udp@0.2.0;
+	import wasi:sockets/udp-create-socket@0.2.0;
+	import wasi:sockets/tcp@0.2.0;
+	import wasi:sockets/tcp-create-socket@0.2.0;
+	import wasi:sockets/ip-name-lookup@0.2.0;
+	import wasi:random/random@0.2.0;
+	import wasi:random/insecure@0.2.0;
+	import wasi:random/insecure-seed@0.2.0;
+	export run;
+}
+
 
 package wasi:clocks@0.2.0 {
 	/// WASI Monotonic Clock is a clock API intended to let users measure elapsed

--- a/testdata/wit-parser/complex-include.wit.json.golden.wit
+++ b/testdata/wit-parser/complex-include.wit.json.golden.wit
@@ -1,13 +1,14 @@
-package foo:bar {
-	interface a {}
+package foo:bar;
 
-	interface b {}
+interface a {}
 
-	world bar-a {
-		import a;
-		import b;
-	}
+interface b {}
+
+world bar-a {
+	import a;
+	import b;
 }
+
 
 package foo:baz {
 	interface a {}

--- a/testdata/wit-parser/cross-package-resource.wit.json.golden.wit
+++ b/testdata/wit-parser/cross-package-resource.wit.json.golden.wit
@@ -1,9 +1,10 @@
-package foo:bar {
-	interface foo {
-		use some:dep/foo.{r};
-		type t = own<r>;
-	}
+package foo:bar;
+
+interface foo {
+	use some:dep/foo.{r};
+	type t = own<r>;
 }
+
 
 package some:dep {
 	interface foo {

--- a/testdata/wit-parser/diamond1.wit.json.golden.wit
+++ b/testdata/wit-parser/diamond1.wit.json.golden.wit
@@ -1,6 +1,7 @@
-package foo:dep1 {
-	interface types {}
-}
+package foo:dep1;
+
+interface types {}
+
 
 package foo:dep2 {
 	interface types {}

--- a/testdata/wit-parser/foreign-deps-union.wit.json.golden.wit
+++ b/testdata/wit-parser/foreign-deps-union.wit.json.golden.wit
@@ -1,6 +1,7 @@
-package foo:another-pkg {
-	interface other-interface {}
-}
+package foo:another-pkg;
+
+interface other-interface {}
+
 
 package foo:corp {
 	interface saas {}

--- a/testdata/wit-parser/foreign-deps.wit.json.golden.wit
+++ b/testdata/wit-parser/foreign-deps.wit.json.golden.wit
@@ -1,6 +1,7 @@
-package foo:another-pkg {
-	interface other-interface {}
-}
+package foo:another-pkg;
+
+interface other-interface {}
+
 
 package foo:corp {
 	interface saas {}

--- a/testdata/wit-parser/ignore-files-deps.wit.json.golden.wit
+++ b/testdata/wit-parser/ignore-files-deps.wit.json.golden.wit
@@ -1,6 +1,7 @@
-package foo:bar {
-	interface types {}
-}
+package foo:bar;
+
+interface types {}
+
 
 package foo:foo {
 	world foo {

--- a/testdata/wit-parser/kinds-of-deps.wit.json.golden.wit
+++ b/testdata/wit-parser/kinds-of-deps.wit.json.golden.wit
@@ -1,11 +1,12 @@
-package a:a {
-	world a {
-		import b:b/b;
-		import c:c/c;
-		import d:d/d;
-		import e:e/e;
-	}
+package a:a;
+
+world a {
+	import b:b/b;
+	import c:c/c;
+	import d:d/d;
+	import e:e/e;
 }
+
 
 package b:b {
 	interface b {}

--- a/testdata/wit-parser/multi-file-multi-package.wit.json.golden.wit
+++ b/testdata/wit-parser/multi-file-multi-package.wit.json.golden.wit
@@ -1,15 +1,16 @@
-package bar:name {
-	interface i2 {
-		type b = u32;
-	}
+package bar:name;
 
-	world w2 {
-		import i2;
-		import imp2: interface {
-			use i2.{b};
-		}
+interface i2 {
+	type b = u32;
+}
+
+world w2 {
+	import i2;
+	import imp2: interface {
+		use i2.{b};
 	}
 }
+
 
 package baz:name {
 	interface i3 {

--- a/testdata/wit-parser/multi-package-shared-deps.wit.json.golden.wit
+++ b/testdata/wit-parser/multi-package-shared-deps.wit.json.golden.wit
@@ -1,9 +1,10 @@
-package foo:bar {
-	world w-bar {
-		import foo:dep1/types;
-		import foo:dep2/types;
-	}
+package foo:bar;
+
+world w-bar {
+	import foo:dep1/types;
+	import foo:dep2/types;
 }
+
 
 package foo:dep1 {
 	interface types {}

--- a/testdata/wit-parser/multi-package-transitive-deps.wit.json.golden.wit
+++ b/testdata/wit-parser/multi-package-transitive-deps.wit.json.golden.wit
@@ -1,9 +1,10 @@
-package foo:bar {
-	world w-bar {
-		import foo:dep2/types;
-		import foo:dep1/types;
-	}
+package foo:bar;
+
+world w-bar {
+	import foo:dep2/types;
+	import foo:dep1/types;
 }
+
 
 package foo:dep1 {
 	interface types {

--- a/testdata/wit-parser/name-both-resource-and-type.wit.json.golden.wit
+++ b/testdata/wit-parser/name-both-resource-and-type.wit.json.golden.wit
@@ -1,11 +1,12 @@
-package foo:bar {
-	interface foo {
-		use some:dep/foo.{a};
-		type t1 = a;
-		type t2 = borrow<a>;
-		type t3 = borrow<t1>;
-	}
+package foo:bar;
+
+interface foo {
+	use some:dep/foo.{a};
+	type t1 = a;
+	type t2 = borrow<a>;
+	type t3 = borrow<t1>;
 }
+
 
 package some:dep {
 	interface foo {

--- a/testdata/wit-parser/packages-explicit-colliding-decl-names.wit.json.golden.wit
+++ b/testdata/wit-parser/packages-explicit-colliding-decl-names.wit.json.golden.wit
@@ -1,15 +1,16 @@
-package bar:name {
-	interface i {
-		type a = u32;
-	}
+package bar:name;
 
-	world w {
-		import i;
-		import imp: interface {
-			use i.{a};
-		}
+interface i {
+	type a = u32;
+}
+
+world w {
+	import i;
+	import imp: interface {
+		use i.{a};
 	}
 }
+
 
 package foo:name {
 	interface i {

--- a/testdata/wit-parser/packages-explicit-internal-references.wit.json.golden.wit
+++ b/testdata/wit-parser/packages-explicit-internal-references.wit.json.golden.wit
@@ -1,12 +1,13 @@
-package bar:name {
-	world w1 {
-		import foo:name/i1;
-		import imp1: interface {
-			use foo:name/i1.{a};
-			fn: func(a: a);
-		}
+package bar:name;
+
+world w1 {
+	import foo:name/i1;
+	import imp1: interface {
+		use foo:name/i1.{a};
+		fn: func(a: a);
 	}
 }
+
 
 package foo:name {
 	interface i1 {

--- a/testdata/wit-parser/packages-explicit-with-semver.wit.json.golden.wit
+++ b/testdata/wit-parser/packages-explicit-with-semver.wit.json.golden.wit
@@ -1,15 +1,16 @@
-package foo:name@1.0.0 {
-	interface i1 {
-		type a = u32;
-	}
+package foo:name@1.0.0;
 
-	world w1 {
-		import i1;
-		import imp1: interface {
-			use i1.{a};
-		}
+interface i1 {
+	type a = u32;
+}
+
+world w1 {
+	import i1;
+	import imp1: interface {
+		use i1.{a};
 	}
 }
+
 
 package foo:name@1.0.1 {
 	interface i1 {

--- a/testdata/wit-parser/packages-multiple-explicit.wit.json.golden.wit
+++ b/testdata/wit-parser/packages-multiple-explicit.wit.json.golden.wit
@@ -1,15 +1,16 @@
-package bar:name {
-	interface i2 {
-		type b = u32;
-	}
+package bar:name;
 
-	world w2 {
-		import i2;
-		import imp2: interface {
-			use i2.{b};
-		}
+interface i2 {
+	type b = u32;
+}
+
+world w2 {
+	import i2;
+	import imp2: interface {
+		use i2.{b};
 	}
 }
+
 
 package foo:name {
 	interface i1 {

--- a/testdata/wit-parser/versions.wit.json.golden.wit
+++ b/testdata/wit-parser/versions.wit.json.golden.wit
@@ -1,8 +1,9 @@
-package a:a@1.0.0 {
-	interface foo {
-		type t = u32;
-	}
+package a:a@1.0.0;
+
+interface foo {
+	type t = u32;
 }
+
 
 package a:a@2.0.0 {
 	interface foo {

--- a/wit/wit.go
+++ b/wit/wit.go
@@ -58,20 +58,20 @@ func (r *Resolve) WIT(_ Node, _ string) string {
 	slices.SortFunc(packages, func(a, b *Package) int {
 		return strings.Compare(a.Name.String(), b.Name.String())
 	})
-	// Special case if only single package.
-	if len(packages) == 1 {
-		return packages[0].WIT(nil, "")
-	}
-	// Use single-file, multi-package style:
-	// https://github.com/WebAssembly/component-model/pull/340
-	// https://github.com/bytecodealliance/wasm-tools/pull/1577
 	var b strings.Builder
 	for i, p := range packages {
-		if i > 0 {
+		if i == 0 {
+			// Context == nil means write non-nested form of package
+			// https://github.com/bytecodealliance/wasm-tools/pull/1700
+			b.WriteString(p.WIT(nil, ""))
+		} else {
 			b.WriteRune('\n')
 			b.WriteRune('\n')
+			// Context == *Resolve means write single-file, multi-package style:
+			// https://github.com/WebAssembly/component-model/pull/340
+			// https://github.com/bytecodealliance/wasm-tools/pull/1577
+			b.WriteString(p.WIT(r, ""))
 		}
-		b.WriteString(p.WIT(r, ""))
 	}
 	return b.String()
 }


### PR DESCRIPTION
- **wit: emit multi-package, single-file WIT with a top-level un-nested root package**
- **testdata: regenerate WIT with un-nested root package**
- **.github/workflows: update to wasm-tools@1.216.0**
- **CHANGELOG: update for multi-package, single-file WIT serialization**
